### PR TITLE
Update README to note libvirt-dev requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ libraries libxslt and libxml2.
 
 In Ubuntu, Debian, ...
 ```
-$ sudo apt-get install libxslt-dev libxml2-dev
+$ sudo apt-get install libxslt-dev libxml2-dev libvirt-dev
 ```
 
 In RedHat, Centos, Fedora, ...
 ```
-# yum install libxslt-devel libxml2-devel
+# yum install libxslt-devel libxml2-devel libvirt-devel
 ```
 
 ## Vagrant Project Preparation


### PR DESCRIPTION
The libxml-devel note was helpful, but I needed libvirt-devel too
