### PR TITLE
Don't force username to root, rely on config.ssh.username

### DIFF
--- a/lib/vagrant-libvirt/action/read_ssh_info.rb
+++ b/lib/vagrant-libvirt/action/read_ssh_info.rb
@@ -45,7 +45,6 @@ module VagrantPlugins
           return {
             :host          => ip_address,
             :port          => 22,
-            :username      => 'root',
             :forward_agent => true,
             :forward_x11   => true,
           }


### PR DESCRIPTION
The plugin's currently forcing the username to root, which is unusual since vagrant boxes normally use the "vagrant" user.

By leaving this out, users can instead override this in the Vagrantfile with:

```
config.ssh.username = "root"
```

I'd suggest you do this in the Vagrantfile for your example CentOS box, or change it to have a vagrant user instead.
