### PR TITLE
Support AMD and Intel processors with nested vm's

### DIFF
--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -4,9 +4,10 @@
   <vcpu><%= @cpus %></vcpu>
 
   <% if @nested %>
-    <cpu match='exact'>
-      <model>core2duo</model>
-      <feature policy='require' name='vmx'/>
+    <cpu mode='host-passthrough'>
+      <model fallback='allow'>qemu64</model>
+      <feature policy='optional' name='vmx'/>
+      <feature policy='optional' name='svm'/>
     </cpu>
   <% end %>
 


### PR DESCRIPTION
Use a more generic cpu model and optional vmx or svm feature. This has been tested on multiple Intel and AMD processors.
