### PR TITLE
Requre Nokogiri 1.5

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fog', '1.15.0'
   gem.add_runtime_dependency 'ruby-libvirt', '~> 0.4.0'
-  gem.add_runtime_dependency 'nokogiri', '~> 1.5.0'
+  gem.add_runtime_dependency 'nokogiri', '1.5.10'
 
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
If a version isn't specified in the gemspec, 'vagrant plugin install' for vagrant-libvirt will try to install nokogiri 1.6.0. This version of Nokogiri fails to build for me on RHEL6 with the error 

```
./.libs/libxml2.so: undefined reference to `gzopen64'
```

I think this is because Nokogiri 1.6.0 is bundling a version of libxml2 that requires a newer version of zlib then RHEL6 includes.

This pull request works around the issue by requiring an older Nokogiri which does not bundle libxml2.
