### PR TITLE
Delete files from destination to avoid confusions

### DIFF
--- a/lib/vagrant-libvirt/action/sync_folders.rb
+++ b/lib/vagrant-libvirt/action/sync_folders.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
 
             # Rsync over to the guest path using the SSH info
             command = [
-              "rsync", "--verbose", "--archive", "-z",
+              "rsync", "--del", "--verbose", "--archive", "-z",
               "--exclude", ".vagrant/",
               "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no -i '#{ssh_info[:private_key_path]}'",
               hostpath,


### PR DESCRIPTION
This is introduced after rsync 3.0 imporved version of --delete-during.
So currently sync will be 1:1 everytime.
