### PR TITLE
remove ruby-libvirt dependency

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.version       = VagrantPlugins::ProviderLibvirt::VERSION
 
   gem.add_runtime_dependency 'fog', '1.15.0'
-  gem.add_runtime_dependency 'ruby-libvirt', '~> 0.4.0'
   gem.add_runtime_dependency 'nokogiri', '1.5.10'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
it have not already  depended on ruby-libvirt library.

Signed-off-by: Hiroshi Miura miurahr@linux.com
