### PR TITLE
adding the nfs share on start

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -59,6 +59,10 @@ module VagrantPlugins
               # VM is not running or suspended. Start it.. Machine should gain
               # IP address when comming up, so wait for dhcp lease and store IP
               # into machines data_dir.
+              b2.use NFS
+              b2.use PrepareNFSSettings
+              b2.use ShareFolders
+
               b3.use StartDomain
               b3.use WaitTillUp
             end


### PR DESCRIPTION
the nfs shares were missing when starting a container back up after it was halted.

addessing #93 
