### PR TITLE
Corrected a wrongly spelled key and added domain_name to the error outpu...

### DIFF
--- a/lib/vagrant-libvirt/action/set_name_of_domain.rb
+++ b/lib/vagrant-libvirt/action/set_name_of_domain.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
       # Setup name for domain and domain volumes.
       class SetNameOfDomain
         def initialize(app, env)
+          @logger     = Log4r::Logger.new("vagrant_libvirt::action::set_name_of_domain")
           @app = app
         end
 
@@ -14,12 +15,16 @@ module VagrantPlugins
           env[:domain_name].gsub!(/[^-a-z0-9_]/i, '')
           env[:domain_name] << '_'
           env[:domain_name] << env[:machine].name.to_s
-
+          
+          @logger.info("Looking for domain #{env[:domain_name]} through list #{env[:libvirt_compute].servers.all}")
           # Check if the domain name is not already taken
           domain = ProviderLibvirt::Util::Collection.find_matching(
             env[:libvirt_compute].servers.all, env[:domain_name])
+
+          @logger.info("Looking for domain #{env[:domain_name]}")
+
           if domain != nil
-            raise Vagrant::Errors::DomainNameExists,
+            raise ProviderLibvirt::Errors::DomainNameExists,
               :domain_name => env[:domain_name]
           end
 

--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -103,7 +103,7 @@ module VagrantPlugins
       end
 
       class DomainNameExists < VagrantLibvirtError
-        error_key(:domain_name_exists_error)
+        error_key(:domain_name_exists)
       end
 
       class NoDomainError < VagrantLibvirtError

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -89,7 +89,7 @@ en:
       fog_create_server_error: |-
         Error while creating domain: %{error_message}
       domain_name_exists: |-
-        Name of domain about to create is already taken. Please try to run
+        Name `%{domain_name}` of domain about to create is already taken. Please try to run
         `vagrant up` command again.
       creating_storage_pool_error: |-
         There was error while creating libvirt storage pool: %{error_message}


### PR DESCRIPTION
I had an error (stacktrace) with vagrant 1.4.1 because the translation key could not be found in locales ( when a volume already existed in libvirt). I corrected it and added the domain name to the output
