### PR TITLE
Add provider specific default_prefix option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `id_ssh_key_file` - The id ssh key file name to access Libvirt (eg: id_dsa or id_rsa or ... in the user .ssh directory)
 * `storage_pool_name` - Libvirt storage pool name, where box image and instance snapshots will be stored.
 * `default_network` - Libvirt default network name. If not specified default network name is 'default'.
+* `default_prefix` - Set a prefix for the machines that's different than the project dir name.
 
 ### Domain Specific Options
 

--- a/example_box/Vagrantfile
+++ b/example_box/Vagrantfile
@@ -52,6 +52,9 @@ Vagrant.configure("2") do |config|
     # Libvirt storage pool name, where box image and instance snapshots will
     # be stored.
     libvirt.storage_pool_name = "default"
+
+    # Set a prefix for the machines that's different than the project dir name.
+    #libvirt.default_prefix = ''
   end
 end
 

--- a/lib/vagrant-libvirt/action/set_name_of_domain.rb
+++ b/lib/vagrant-libvirt/action/set_name_of_domain.rb
@@ -11,7 +11,12 @@ module VagrantPlugins
 
         def call(env)
           require 'securerandom'
-          env[:domain_name] = env[:root_path].basename.to_s.dup
+          config = env[:machine].provider_config
+          if config.default_prefix.nil?
+            env[:domain_name] = env[:root_path].basename.to_s.dup
+          else
+            env[:domain_name] = config.default_prefix.to_s
+          end
           env[:domain_name].gsub!(/[^-a-z0-9_]/i, '')
           env[:domain_name] << '_'
           env[:domain_name] << env[:machine].name.to_s

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -28,6 +28,9 @@ module VagrantPlugins
       # Libvirt default network
       attr_accessor :default_network
 
+      # Default host prefix (alternative to use project folder name)
+      attr_accessor :default_prefix
+
       # Domain specific settings used while creating new domain.
       attr_accessor :memory
       attr_accessor :cpus
@@ -45,6 +48,7 @@ module VagrantPlugins
         @id_ssh_key_file   = UNSET_VALUE
         @storage_pool_name = UNSET_VALUE
         @default_network   = UNSET_VALUE
+        @default_prefix    = UNSET_VALUE
 
         # Domain specific settings.
         @memory            = UNSET_VALUE
@@ -64,6 +68,7 @@ module VagrantPlugins
         @id_ssh_key_file = 'id_rsa' if @id_ssh_key_file == UNSET_VALUE
         @storage_pool_name = 'default' if @storage_pool_name == UNSET_VALUE
         @default_network = 'default' if @default_network == UNSET_VALUE
+        @default_prefix = nil if @default_prefix == UNSET_VALUE
 
         # Domain specific settings.
         @memory = 512 if @memory == UNSET_VALUE


### PR DESCRIPTION
This patch adds support for a provider specific default_prefix option.
When set, this value is used instead of the project's dir name as the
prefix for the machines being created.
