### PR TITLE
Fixing parameters of run_provisioner

### DIFF
--- a/lib/vagrant-libvirt/action/timed_provision.rb
+++ b/lib/vagrant-libvirt/action/timed_provision.rb
@@ -6,17 +6,14 @@ module VagrantPlugins
       # This is the same as the builtin provision except it times the
       # provisioner runs.
       class TimedProvision < Vagrant::Action::Builtin::Provision
-        def run_provisioner(env, name, p)
-          env[:ui].info(I18n.t("vagrant.actions.vm.provision.beginning",
-                               :provisioner => name))
-
+        def run_provisioner(env)
           timer = Util::Timer.time do
             super
           end
 
           env[:metrics] ||= {}
           env[:metrics]["provisioner_times"] ||= []
-          env[:metrics]["provisioner_times"] << [p.class.to_s, timer]
+          env[:metrics]["provisioner_times"] << [env[:provisioner].class.to_s, timer]
         end
       end
     end


### PR DESCRIPTION
- Removed logging since that was moved one method up in the Vagrant code

This is in response to https://github.com/pradels/vagrant-libvirt/issues/141
