### PR TITLE
drop version number from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ control and provision machines via Libvirt toolkit.
 **Note:** Actual version (0.0.15) is still a development one. Feedback is
 welcome and can help a lot :-)
 
-## Features (Version 0.0.13)
+## Features
 
 * Controll local Libvirt hypervisors.
 * Vagrant `up`, `destroy`, `suspend`, `resume`, `halt`, `ssh`, `reload` and `provision` commands.


### PR DESCRIPTION
As it is valid assumption that readme reflex real situation - there is no need to explicitly state plugin number
