### PR TITLE
Update connect_libvirt.rb

### DIFF
--- a/lib/vagrant-libvirt/action/connect_libvirt.rb
+++ b/lib/vagrant-libvirt/action/connect_libvirt.rb
@@ -57,7 +57,7 @@ module VagrantPlugins
           if config.id_ssh_key_file
             # set ssh key for access to libvirt host
             home_dir = `echo ${HOME}`.chomp
-            uri << "&keyfile=#{home_dir}/.ssh/"+config.id_ssh_key_file
+            uri << "\&keyfile=#{home_dir}/.ssh/"+config.id_ssh_key_file
           end
 
           conn_attr = {}


### PR DESCRIPTION
Added an escape character to the connect string - since it was not escaped the connection URI was cut off after "?noverify=1"
