### PR TITLE
Only rsync if the type is set to rsync

### DIFF
--- a/lib/vagrant-libvirt/action/sync_folders.rb
+++ b/lib/vagrant-libvirt/action/sync_folders.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
           ssh_info = env[:machine].ssh_info
 
           env[:machine].config.vm.synced_folders.each do |id, data|
-            next if data[:type] == :nfs
+            next unless data[:type] == :rsync
             proxycommand = "-o ProxyCommand='#{ssh_info[:proxy_command]}'" if ssh_info[:proxy_command]
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             guestpath = data[:guestpath]


### PR DESCRIPTION
Since the default of vagrant-libvirt is now NFS even in case the type is 
empty, rsync should only be called if the type is explicitly set to rsync.
