### PR TITLE
Added an option to set the path to the libvirt socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `username` - Username and password to access Libvirt.
 * `password` - Password to access Libvirt.
 * `id_ssh_key_file` - The id ssh key file name to access Libvirt (eg: id_dsa or id_rsa or ... in the user .ssh directory)
+* `socket` - Path to the libvirt unix socket (eg: /var/run/libvirt/libvirt-sock)
 * `storage_pool_name` - Libvirt storage pool name, where box image and instance snapshots will be stored.
 
 ### Domain Specific Options

--- a/lib/vagrant-libvirt/action/connect_libvirt.rb
+++ b/lib/vagrant-libvirt/action/connect_libvirt.rb
@@ -59,6 +59,8 @@ module VagrantPlugins
             home_dir = `echo ${HOME}`.chomp
             uri << "\&keyfile=#{home_dir}/.ssh/"+config.id_ssh_key_file
           end
+          # set path to libvirt socket
+          uri << "\&socket="+config.socket if config.socket
 
           conn_attr = {}
           conn_attr[:provider] = 'libvirt'

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -12,6 +12,9 @@ module VagrantPlugins
       # If use ssh tunnel to connect to Libvirt.
       attr_accessor :connect_via_ssh
 
+      # Path towards the libvirt socket
+      attr_accessor :socket
+
       # The username to access Libvirt.
       attr_accessor :username
 


### PR DESCRIPTION
I sometimes hack libvirt and sets an alternate path for the socket file. This allows me to do so via adding a config.socket option. Maybe it would be more generic to provide an "uri" option since anyway a poweruser would know how to do ?

Anyway here is a patch with an updated readme
