### PR TITLE
Fixed message about required Vagrant version

### DIFF
--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -7,7 +7,7 @@ end
 # This is a sanity check to make sure no one is attempting to install
 # this into an early Vagrant version.
 if Vagrant::VERSION < '1.5.0'
-  raise 'The Vagrant Libvirt plugin is only compatible with Vagrant 1.4+'
+  raise 'The Vagrant Libvirt plugin is only compatible with Vagrant 1.5+'
 end
 
 module VagrantPlugins


### PR DESCRIPTION
Small fix for informing users that Vagrant 1.5+ is needed with current sources.
