### PR TITLE
Fix destroy in vagrant 1.5.1+

### DIFF
--- a/lib/vagrant-libvirt/action/prune_nfs_exports.rb
+++ b/lib/vagrant-libvirt/action/prune_nfs_exports.rb
@@ -15,7 +15,8 @@ module VagrantPlugins
             uuids = env[:libvirt_compute].servers.all.map(&:id)
             # not exiisted in array will removed from nfs
             uuids.delete(uuid)
-            env[:host].nfs_prune(uuids)
+            env[:host].capability(
+              :nfs_prune, env[:machine].ui, uuids)
           end
 
           @app.call(env)


### PR DESCRIPTION
Addresses issue pradels/vagrant-libvirt#166

I'm not completely sure this is the proper way to fix this as I'm new to vagrant plugins.  I've tested this in my environment and does seem to prune the nfs exports that were added by my vagrant box.  Let me know how it goes!
