### PR TITLE
Add model_type to public networks of type direct

### DIFF
--- a/lib/vagrant-libvirt/templates/public_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/public_interface.xml.erb
@@ -4,6 +4,7 @@
   <% end %>
   <%if @type == 'direct'%>
   <source dev='<%= @device %>' mode='<%= @mode %>'/>
+  <model type='<%=@model_type%>'/>
   <% else %>
   <source bridge='<%=@device%>'/>
   <model type='<%=@model_type%>'/>


### PR DESCRIPTION
Add the ability to set the model_type of the NIC
for public networks of the (default) type direct.
