### PR TITLE
Handle forward slash in box name

### DIFF
--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
           # Get config options
           config   = env[:machine].provider_config
           box_image_file = env[:machine].box.directory.join('box.img').to_s
-          env[:box_volume_name] = env[:machine].box.name.to_s.dup
+          env[:box_volume_name] = env[:machine].box.name.to_s.dup.gsub("/", "-VAGRANTSLASH-")
           env[:box_volume_name] << '_vagrant_box_image.img'
 
           # Don't continue if image already exists in storage pool.


### PR DESCRIPTION
With the release of Vagrant Cloud, boxes can now have a forward slash in the name. When creating paths  based on the box name, we need to handle that slash. Vagrant  transforms it to _-VAGRANTSLASH-_, so I thought we could do the same.

This PR adjusts the only code I've found so far that need adjusting. In my testing it fixes #196
