### PR TITLE
set initial value of uri config attribute

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -62,6 +62,7 @@ module VagrantPlugins
       attr_accessor :disks
 
       def initialize
+        @uri               = UNSET_VALUE
         @driver            = UNSET_VALUE
         @host              = UNSET_VALUE
         @connect_via_ssh   = UNSET_VALUE


### PR DESCRIPTION
New `uri` attribute needs to be initialized as UNSET_VALUE in order to evaluate correctly in `finalize!` method.
