### PR TITLE
Fixed port forwarding when using remote libvirt (use a ProxyCommand)

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -97,6 +97,8 @@ module VagrantPlugins
               "IdentityFile=#{pk}"
             end).map { |s| s.prepend('-o ') }.join(' ')
 
+          options += " -o ProxyCommand=\"#{ssh_info[:proxy_command]}\"" if machine.provider_config.connect_via_ssh
+
           # TODO: instead of this, try and lock and get the stdin from spawn...
           ssh_cmd = ''
           if host_port <= 1024


### PR DESCRIPTION
Hi,

It seems like port forwarding doesn't work when using libvirt on a remote server. This patch fixes the problem, but i'm not sure if this is the best way to fix this.

I didn't test features like multiple networks and things like that, but it should not break anything since we only ask SSH to connect to the remote libvirt server before doing the port forward.
