### PR TITLE
Accept other MAC address formats.

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -81,6 +81,7 @@ module VagrantPlugins
             message = "Creating network interface eth#{@iface_number}"
             message << " connected to network #{@network_name}."
             if @mac
+              @mac = mac.scan(/(\h{2})/).join(':')
               message << " Using MAC address: #{@mac}"
             end
             @logger.info(message)


### PR DESCRIPTION
This will accept formats like 00006C2830d5 which other backends accept, as well as any other variant that  contains hex digits, such as Cisco's 0000.6C28.30d5.

Bug: #208
