### PR TITLE
Honor the auto_config configuration option

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -105,6 +105,7 @@ module VagrantPlugins
             # It's used for provisioning and it has to be available during provisioning,
             # ifdown command is not acceptable here.
             next if slot_number == 0
+            next if options[:auto_config] === false
             @logger.debug "Configuring interface slot_number #{slot_number} options #{options}"
 
             network = {


### PR DESCRIPTION
Honor the auto_config configuration option to allow vagrant to skip configuring network interfaces per https://docs.vagrantup.com/v2/networking/private_network.html
