### PR TITLE
Add en locale for long_shutoff message

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -130,6 +130,8 @@ en:
         pause
       short_shutoff: |-
         shutoff
+      long_shutoff: |-
+        The Libvirt domain is not running. Run `vagrant up` to start it.
       short_not_created: |-
         not created
       long_not_created: |-


### PR DESCRIPTION
Running a vagrant status mentions long_shutoff is missing:

```
jenkins@rts50:~/foo$ vagrant status
Current machine states:

slave1                    shutoff (libvirt)

translation missing: en.vagrant_libvirt.states.long_shutoff
jenkins@rts50:~/foo$ vagrant plugin list
vagrant-libvirt (0.0.19)
  - Version Constraint: 0.0.19
vagrant-login (1.0.1, system)
vagrant-mutate (0.3.0)
vagrant-share (1.1.0, system)
```
