### PR TITLE
Do not include features/model when cpu_mode = host-passthrough

### DIFF
--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -5,9 +5,11 @@
 
   <% if @nested %>
     <cpu mode='<%= @cpu_mode %>'>
+      <% unless @cpu_mode == 'host-passthrough' %>
       <model fallback='allow'>qemu64</model>
       <feature policy='optional' name='vmx'/>
       <feature policy='optional' name='svm'/>
+      <% end %>
     </cpu>
   <% end %>
 


### PR DESCRIPTION
Features/model should not be specified when using host-passthrough
