### PR TITLE
added options for SET values ​​Vagrantfile type of network adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ end
 ### Domain Specific Options
 
 * `disk_bus` - The type of disk device to emulate. Defaults to virtio if not set. Possible values are documented in libvirt's [description for _target_](http://libvirt.org/formatdomain.html#elementsDisks).
+* `nic_model_type` - parameter specifies the model of the network adapter when you create a domain value by default virtio KVM believe possible values, see the documentation for libvirt
 * `memory` - Amount of memory in MBytes. Defaults to 512 if not set.
 * `cpus` - Number of virtual cpus. Defaults to 1 if not set.
 * `nested` - [Enable nested virtualization](https://github.com/torvalds/linux/blob/master/Documentation/virtual/kvm/nested-vmx.txt). Default is false.
@@ -237,6 +238,7 @@ starts with 'libvirt__' string. Here is a list of those options:
   be forwarded (NATed or routed). Used only when creating new network. By
   default, all physical interfaces are used.
 * `:mac` - MAC address for the interface.
+* `model_type` - parameter specifies the model of the network adapter when you create a domain value by default virtio KVM believe possible values, see the documentation for libvirt
 
 ### Public Network Options
 * `:dev` - Physical device that the public interface should use. Default is 'eth0'.

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -17,6 +17,8 @@ module VagrantPlugins
         def initialize(app, env)
           @logger = Log4r::Logger.new('vagrant_libvirt::action::create_network_interfaces')
           @management_network_name = env[:machine].provider_config.management_network_name
+	  config = env[:machine].provider_config
+	  @nic_model_type = config.nic_model_type
           @app = app
         end
 
@@ -66,6 +68,7 @@ module VagrantPlugins
             @iface_number = slot_number
             @network_name = iface_configuration[:network_name]
             @mac = iface_configuration.fetch(:mac, false)
+            @model_type = iface_configuration.fetch(:model_type, @nic_model_type)
             template_name = 'interface'
 
             # Configuration for public interfaces which use the macvtap driver
@@ -73,7 +76,7 @@ module VagrantPlugins
               @device = iface_configuration.fetch(:dev, 'eth0')
               @type = iface_configuration.fetch(:type, 'direct')
               @mode = iface_configuration.fetch(:mode, 'bridge')
-              @model_type = iface_configuration.fetch(:model_type, 'e1000')
+              @model_type = iface_configuration.fetch(:model_type, @nic_model_type)
               template_name = 'public_interface'
               @logger.info("Setting up public interface using device #{@device} in mode #{@mode}")
             end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -52,6 +52,7 @@ module VagrantPlugins
       attr_accessor :cpus
       attr_accessor :cpu_mode
       attr_accessor :disk_bus
+      attr_accessor :nic_model_type
       attr_accessor :nested
       attr_accessor :volume_cache
       attr_accessor :kernel
@@ -78,6 +79,7 @@ module VagrantPlugins
         @cpus              = UNSET_VALUE
         @cpu_mode          = UNSET_VALUE
         @disk_bus          = UNSET_VALUE
+        @nic_model_type    = UNSET_VALUE
         @nested            = UNSET_VALUE
         @volume_cache      = UNSET_VALUE
         @kernel            = UNSET_VALUE
@@ -193,6 +195,7 @@ module VagrantPlugins
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
         @disk_bus = 'virtio' if @disk_bus == UNSET_VALUE
+        @nic_model_type = 'virtio' if @nic_model_type == UNSET_VALUE
         @nested = false if @nested == UNSET_VALUE
         @volume_cache = 'default' if @volume_cache == UNSET_VALUE
         @kernel = nil if @kernel == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/interface.xml.erb
@@ -5,6 +5,6 @@
 	<% end %>
   <target dev='vnet<%= @iface_number %>'/>
   <alias name='net<%= @iface_number %>'/>
-  <model type='virtio'/>
+  <model type='<%=@model_type%>'/>
 </interface>
 


### PR DESCRIPTION
Added options for SET values ​​Vagrantfile type of network adapters when you create a domain KVM
nic_model_tipe and model_type

Maybe it's someone realties need. 
Sorry for my english
