### PR TITLE
Allow override of 9p mount params

### DIFF
--- a/lib/vagrant-libvirt/cap/mount_p9.rb
+++ b/lib/vagrant-libvirt/cap/mount_p9.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
       class MountP9
         extend Vagrant::Util::Retryable
 
-        def self.mount_p9_shared_folder(machine, folders, options)
+        def self.mount_p9_shared_folder(machine, folders)
           folders.each do |name, opts|
             # Expand the guest path so we can handle things like "~/vagrant"
             expanded_guest_path = machine.guest.capability(
@@ -19,9 +19,9 @@ module VagrantPlugins
             mount_tag = name.dup
 
             mount_opts="-o trans=virtio"
-            mount_opts += ",access=#{options[:owner]}" if options[:owner]
-            mount_opts += ",version=#{options[:version]}" if options[:version]
-            mount_opts += ",#{opts[:mount_options]}" if opts[:mount_options]
+            mount_opts += ",access=#{opts[:owner]}" if opts[:owner]
+            mount_opts += ",version=#{opts[:version]}" if opts[:version]
+            mount_opts += ",#{opts[:mount_opts]}" if opts[:mount_opts]
 
             mount_command = "mount -t 9p #{mount_opts} '#{mount_tag}' #{expanded_guest_path}"
             retryable(:on => Vagrant::Errors::LinuxMountFailed,

--- a/lib/vagrant-libvirt/cap/synced_folder.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder.rb
@@ -67,13 +67,12 @@ module VagrantPlugins
         mount_folders = {}
         folders.each do |id, opts|
           mount_folders[id] = opts.dup if opts[:guestpath]
+          # merge common options if not given
+          mount_folders[id].merge!(:version => '9p2000.L') { |_k, ov, _nv| ov }
         end
-        common_opts = {
-          :version => '9p2000.L',
-        }
         # Mount the actual folder
         machine.guest.capability(
-            :mount_p9_shared_folder, mount_folders, common_opts)
+            :mount_p9_shared_folder, mount_folders)
       end
 
       def cleanup(machine, _opts)


### PR DESCRIPTION
"accessmode" and "readonly" were not overridable.
