### PR TITLE
Add provisioner shared folders after first boot.

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -74,6 +74,8 @@ module VagrantPlugins
 
               # VM is not running or suspended.
 
+              b3.use Provision
+
               # Ensure networks are created and active
               b3.use CreateNetworks
 


### PR DESCRIPTION
Without this change, the shared folders for provisioners like Puppet will not be created on the second and subsequent boots.
