### PR TITLE
Accept any version of Nokogiri 1.6

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fog', '1.15'
   gem.add_runtime_dependency 'ruby-libvirt', '0.4.0'
-  gem.add_runtime_dependency 'nokogiri', '1.6'
+  gem.add_runtime_dependency 'nokogiri', '~> 1.6.0'
 
   gem.add_development_dependency 'rake', '10.1.0'
 end


### PR DESCRIPTION
This fixes #240 and makes vagrant-libvirt installable in vagrant 1.6.5.
