### PR TITLE
condition for setting default value was wrong

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -209,7 +209,7 @@ module VagrantPlugins
         @random_hostname = false if @random_hostname == UNSET_VALUE
         @management_network_name = 'vagrant-libvirt' if @management_network_name == UNSET_VALUE
         @management_network_address = '192.168.121.0/24' if @management_network_address == UNSET_VALUE
-        @management_network_mode = 'nat' if @management_network_address == UNSET_VALUE
+        @management_network_mode = 'nat' if @management_network_mode == UNSET_VALUE
 
         # generate a URI if none is supplied
         @uri = _generate_uri() if @uri == UNSET_VALUE


### PR DESCRIPTION
This caused an error:

```
Error occured while creating new network: Call to virNetworkDefineXML failed: (network_definition):5: Unescaped '<' not allowed in attributes values
  <forward mode="#<Object:0x000000020bb1a0>" />
```
