### PR TITLE
make gem dependencies reasonably optimistic again (fixes #253)

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ['Lukas Stanek','Dima Vasilets','Brian Pitts']
   gem.email         = ['ls@elostech.cz','pronix.service@gmail.com','brian@polibyte.com']
   gem.license       = 'MIT'
-  gem.description   = %q{Vagrant provider for libvirt. support a lot options}
+  gem.description   = %q{Vagrant provider for libvirt.}
   gem.summary       = %q{Vagrant provider for libvirt.}
   gem.homepage      = 'https://github.com/pradels/vagrant-libvirt'
 
@@ -16,14 +16,14 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = VagrantPlugins::ProviderLibvirt::VERSION
 
-  gem.add_development_dependency 'rspec-core', '2.12.2'
-  gem.add_development_dependency 'rspec-expectations', '2.12.1'
-  gem.add_development_dependency 'rspec-mocks', '2.12.1'
+  gem.add_development_dependency "rspec-core", "~> 2.12.2"
+  gem.add_development_dependency "rspec-expectations", "~> 2.12.1"
+  gem.add_development_dependency "rspec-mocks", "~> 2.12.1"
 
-  gem.add_runtime_dependency 'fog', '1.15'
-  gem.add_runtime_dependency 'ruby-libvirt', '0.4.0'
+  gem.add_runtime_dependency 'fog', '~> 1.15'
+  gem.add_runtime_dependency 'ruby-libvirt', '~> 0.4.0'
   gem.add_runtime_dependency 'nokogiri', '~> 1.6.0'
 
-  gem.add_development_dependency 'rake', '10.1.0'
+  gem.add_development_dependency 'rake'
 end
 


### PR DESCRIPTION
This reverts the vagrant-libvirt.gemspec changes in commit 19cd8be193fdeb0a8e1b004705ef3d4465c02812.
