### PR TITLE
don't monkey-patch #default_provider

### DIFF
--- a/lib/vagrant-libvirt.rb
+++ b/lib/vagrant-libvirt.rb
@@ -27,13 +27,3 @@ module VagrantPlugins
     end
   end
 end
-
-# set provider by bash env
-# export VAGRANT_DEFAULT_PROVIDER=libvirt
-Vagrant::Environment.class_eval do
-  def default_provider
-    (ENV['VAGRANT_DEFAULT_PROVIDER'] || :virtualbox).to_sym
-  end
-end
-
-


### PR DESCRIPTION
This monkey-patching of `Vagrant::Environment#default_provider` breaks with Vagrant git `master` (1.7.0-dev), since [the method's signature changed](https://github.com/mitchellh/vagrant/commit/a9dfb6b3bdd7).  In any case Vagrant should do the right thing without "help" from vagrant-libvirt.
