### PR TITLE
allow newer ruby-libvirt (#158)

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec-mocks", "~> 2.12.1"
 
   gem.add_runtime_dependency 'fog', '~> 1.15'
-  gem.add_runtime_dependency 'ruby-libvirt', '~> 0.4.0'
+  gem.add_runtime_dependency 'ruby-libvirt', '~> 0.4'
   gem.add_runtime_dependency 'nokogiri', '~> 1.6.0'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
As per #158, vagrant-libvirt depends on ruby-libvirt transitively through fog.  Since fog/fog#2706 was resolved, fog now requires `ruby-libvirt ~> 0.5.0`, therefore vagrant-libvirt should allow both 0.4.x and 0.5.x.  Furthermore, according to semantic versioning, we currently have no good reason to reject anything newer below 1.x.  If such a restriction is required in the future (e.g. `< 0.7.0`) then it is likely that fog's `.gemspec` will take care of that on our behalf anyway.

Closes #158.
