### PR TITLE
Fix port forwarding ssh process cleanup

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -83,7 +83,8 @@ module VagrantPlugins
                           gateway_ports)
           ssh_info = machine.ssh_info
           params = %W(
-            "-L #{host_ip}:#{host_port}:#{guest_ip}:#{guest_port}"
+            -L
+            #{host_ip}:#{host_port}:#{guest_ip}:#{guest_port}
             -N
             #{ssh_info[:host]}
           ).join(' ')


### PR DESCRIPTION
The presence of quotes in the command to spawn caused ruby to run it via
a shell instead of running it directly. This broke our code for
killing the ssh processes when the VM is halted.

Closes #265
