### PR TITLE
Add multi-arch support

### DIFF
--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -14,7 +14,7 @@
   <% end %>
 
   <os>
-    <type arch='x86_64'>hvm</type>
+    <type>hvm</type>
     <boot dev='hd'/>
     <kernel><%= @kernel %></kernel>
     <initrd><%= @initrd %></initrd>


### PR DESCRIPTION
Currently the domain template as defined in domain.xml.erb hard-codes the arch
attribute under OS tag to x86_64. This is really not required since the
'arch' attribute is automatically populated by libvirt

`<type arch='x86_64'>hvm</type>`

This prevents using this plugin to manage non-x86_64 architecture like
Power(ppc64) and Arm.

This patch removes the 'arch' attribute from the domain template
