### PR TITLE
Skip delete cdrom

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -35,8 +35,10 @@ module VagrantPlugins
 
           domain = env[:machine].provider.driver.connection.servers.get(env[:machine].id.to_s)
 
-          if env[:machine].provider_config.disks.empty?
-            # if using default configuration of disks
+          if env[:machine].provider_config.disks.empty? and
+              env[:machine].provider_config.cdroms.empty?
+            # if using default configuration of disks and cdroms
+            # cdroms are consider volumes, but cannot be destroyed
             domain.destroy(destroy_volumes: true)
           else
             domain.destroy(destroy_volumes: false)

--- a/spec/support/sharedcontext.rb
+++ b/spec/support/sharedcontext.rb
@@ -3,12 +3,13 @@ require 'spec_helper'
 shared_context "unit" do
   include_context 'vagrant-unit'
 
-  let(:test_env) do
-    vagrantfile ||= <<-EOF
+  let(:vagrantfile) do <<-EOF
     Vagrant.configure('2') do |config|
       config.vm.define :test
     end
     EOF
+  end
+  let(:test_env) do
     test_env = isolated_environment
     test_env.vagrantfile vagrantfile
     test_env

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+require "support/sharedcontext"
+require "support/libvirt_context"
+
+require "vagrant-libvirt/action/destroy_domain"
+
+describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
+
+  subject { described_class.new(app, env) }
+
+  include_context "unit"
+  include_context "libvirt"
+
+  let(:libvirt_domain) { double("libvirt_domain") }
+  let(:libvirt_client) { double("libvirt_client") }
+  let(:servers) { double("servers") }
+
+  describe "#call" do
+    before do
+      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver).
+        to receive(:connection).and_return(connection)
+      allow(connection).to receive(:client).and_return(libvirt_client)
+      allow(libvirt_client).to receive(:lookup_domain_by_uuid).
+        and_return(libvirt_domain)
+      allow(connection).to receive(:servers).and_return(servers)
+      allow(servers).to receive(:get).and_return(domain)
+      # always see this at the start of #call
+      expect(ui).to receive(:info).with("Removing domain...")
+    end
+
+    context "when no snapshots" do
+      let(:root_disk) { double("libvirt_root_disk") }
+
+      before do
+        allow(libvirt_domain).to receive(:list_snapshots).and_return([])
+        allow(libvirt_domain).to receive(:has_managed_save?).and_return(nil)
+        root_disk.stub(:name => "test.img")
+      end
+
+      context "when only has root disk" do
+        it "calls fog to destroy volumes" do
+          expect(domain).to receive(:destroy).with(:destroy_volumes => true)
+          expect(subject.call(env)).to be_nil
+        end
+      end
+
+      context "when has additional disks" do
+        let(:vagrantfile) { <<-EOF
+          Vagrant.configure('2') do |config|
+            config.vm.define :test
+            config.vm.provider :libvirt do |libvirt|
+              libvirt.storage :file
+            end
+          end
+          EOF
+        }
+
+        let(:extra_disk) { double("libvirt_extra_disk") }
+        before do
+          extra_disk.stub(:name => "test-vdb.qcow2")
+        end
+
+        it "destroys disks individually" do
+          allow(libvirt_domain).to receive(:name).and_return("test")
+          allow(domain).to receive(:volumes).and_return([extra_disk], [root_disk])
+
+          expect(domain).to receive(:destroy).with(:destroy_volumes => false)
+          expect(extra_disk).to receive(:destroy)  # extra disk remove
+          expect(root_disk).to receive(:destroy)  # root disk remove
+          expect(subject.call(env)).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -70,6 +70,27 @@ describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
           expect(subject.call(env)).to be_nil
         end
       end
+
+      context "when has CDROMs attached" do
+        let(:vagrantfile) { <<-EOF
+          Vagrant.configure('2') do |config|
+            config.vm.define :test
+            config.vm.provider :libvirt do |libvirt|
+              libvirt.storage :file, :device => :cdrom
+            end
+          end
+          EOF
+        }
+
+        it "uses explicit removal of disks" do
+          allow(libvirt_domain).to receive(:name).and_return("test")
+          allow(domain).to receive(:volumes).and_return([root_disk])
+
+          expect(domain).to_not receive(:destroy).with(:destroy_volumes => true)
+          expect(root_disk).to receive(:destroy)  # root disk remove
+          expect(subject.call(env)).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add rudimentary tests for destroy domain and ensure that when cdroms are present that disks are iterated explicitly to avoid attempting to delete iso files as they are also recognized as volumes.