### PR TITLE
Allow network gateway attr

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -153,6 +153,7 @@ module VagrantPlugins
               @logger.debug "Configuring interface slot_number #{slot_number} options #{options}"
 
               network = {
+                :gateway                         => nil || options[:gateway],
                 :interface                       => slot_number,
                 :use_dhcp_assigned_default_route => options[:use_dhcp_assigned_default_route],
                 :mac_address => options[:mac],


### PR DESCRIPTION
Template of the network interface in vagrat can be set the value of the gateway , but you can not even want to set because CreateNetworkInterfaces class in "vagrant-libvirt" is wrapping the value .
Therefore allow network gateway attribute.

https://github.com/mitchellh/vagrant/blob/master/templates/guests/fedora/network_static.erb#L9-L11