### PR TITLE
Allow network gateway attr (fix)

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -163,6 +163,7 @@ module VagrantPlugins
                   :type    => :static,
                   :ip      => options[:ip],
                   :netmask => options[:netmask],
+                  :gateway => options[:gateway],
                 }.merge(network)
               else
                 network[:type] = :dhcp


### PR DESCRIPTION
Template of the network interface in vagrat can be set the gateway attribute, but you can not even want to set because CreateNetworkInterfaces class in "vagrant-libvirt" is filtering the attributes.
Therefore allow network gateway attribute.

https://github.com/mitchellh/vagrant/blob/master/templates/guests/fedora/network_static.erb#L9-L11