### PR TITLE
Add support for libvirt channels:

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -79,6 +79,9 @@ module VagrantPlugins
           # Input
           @inputs = config.inputs
 
+          # Channels
+          @channels = config.channels
+
           # PCI device passthrough
           @pcis = config.pcis
 
@@ -203,6 +206,11 @@ module VagrantPlugins
 
           @inputs.each do |input|
             env[:ui].info(" -- INPUT:             type=#{input[:type]}, bus=#{input[:bus]}")
+          end
+
+          @channels.each do |channel|
+            env[:ui].info(" -- CHANNEL:             type=#{channel[:type]}, mode=#{channel[:source_mode]}")
+            env[:ui].info(" -- CHANNEL:             target_type=#{channel[:target_type]}, target_name=#{channel[:target_name]}")
           end
 
           @pcis.each do |pci|

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -56,6 +56,7 @@ module VagrantPlugins
       # Domain specific settings used while creating new domain.
       attr_accessor :uuid
       attr_accessor :memory
+      attr_accessor :channel
       attr_accessor :cpus
       attr_accessor :cpu_mode
       attr_accessor :cpu_model

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -103,6 +103,9 @@ module VagrantPlugins
       # Inputs
       attr_accessor :inputs
 
+      # Channels
+      attr_accessor :channels
+
       # PCI device passthrough
       attr_accessor :pcis
 
@@ -176,6 +179,9 @@ module VagrantPlugins
 
         # Inputs
         @inputs            = UNSET_VALUE
+
+        # Channels
+        @channels          = UNSET_VALUE
 
         # PCI device passthrough
         @pcis              = UNSET_VALUE
@@ -252,6 +258,32 @@ module VagrantPlugins
         @inputs.push({
           type: options[:type],
           bus:  options[:bus]
+        })
+      end
+
+      def channel(options={})
+        if options[:type].nil?
+            raise "Channel type must be specified."
+        elsif options[:type] == 'unix' && options[:target_type] == 'guestfwd'
+            # Guest forwarding requires a target (ip address) and a port
+            if options[:target_address].nil? || options[:target_port].nil? ||
+               options[:source_path].nil?
+              raise 'guestfwd requires target_address, target_port and source_path'
+            end
+        end
+
+        if @channels == UNSET_VALUE
+          @channels = []
+        end
+
+        @channels.push({
+          type: options[:type],
+          source_mode: options[:source_mode],
+          source_path: options[:source_path],
+          target_address: options[:target_address],
+          target_name: options[:target_name],
+          target_port: options[:target_port],
+          target_type: options[:target_type]
         })
       end
 
@@ -464,6 +496,9 @@ module VagrantPlugins
 
         # Inputs
         @inputs = [{:type => "mouse", :bus => "ps2"}] if @inputs == UNSET_VALUE
+
+        # Channels
+        @channels = [{:target => "unix", :source_mode => "bind"}] if @channels == UNSET_VALUE
 
         # PCI device passthrough
         @pcis = [] if @pcis == UNSET_VALUE

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -498,7 +498,7 @@ module VagrantPlugins
         @inputs = [{:type => "mouse", :bus => "ps2"}] if @inputs == UNSET_VALUE
 
         # Channels
-        @channels = [{:target => "unix", :source_mode => "bind"}] if @channels == UNSET_VALUE
+        @channels = [ ] if @channels == UNSET_VALUE
 
         # PCI device passthrough
         @pcis = [] if @pcis == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -96,6 +96,27 @@
       <target port='0'/>
     </console>
 
+<% @channels.each do |channel| %>
+  <channel type='<%= channel[:type] %>' >
+      <source mode='<%= channel[:source_mode] %>'
+          <% if channel[:source_path] %>
+               path="<%= channel[:source_path] %>"
+          <% end %>
+      />
+      <target type='<%= channel[:target_type] %>'
+          <% if channel[:target_name] %>
+               name="<%= channel[:target_name] %>"
+          <% end %>
+          <% if channel[:target_address] %>
+               address="<%= channel[:target_address] %>"
+          <% end %>
+          <% if channel[:target_port] %>
+               port="<%= channel[:target_port] %>"
+          <% end %>
+      />
+  </channel>
+<% end %>
+
 <% @inputs.each do |input| %>
     <input type='<%= input[:type] %>' bus='<%= input[:bus] %>'/>
 <% end %>


### PR DESCRIPTION
 Allow for the creation of libvirt host- to-guest communication channels.

Vagrantfile  example:

    config.vm.provider :libvirt do |libvirt|
        # Create a virtio channel for use by the qemu-guest agent (time sync, snapshotting, etc)
        libvirt.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'

        # Forward traffic to 1.2.3.4 from the guest, to the specified socket on the host
        libvirt.channel :type => 'unix', :target_type => 'guestfwd', :target_address => '1.2.3.4', :target_port => '9999',
                        :source_path => '/tmp/foo'
    end

- https://libvirt.org/formatdomain.html#elementCharChannel
- http://wiki.libvirt.org/page/Qemu_guest_agent