### PR TITLE
Validator for network MAC configuration options.

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -524,7 +524,7 @@ module VagrantPlugins
         end
 
         machine.config.vm.networks.each do |_type, opts|
-          if opts[:mac] && !(opts[:mac] =~ /\A([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})\z/)
+          if opts[:mac] && opts[:mac].downcase! && !(opts[:mac] =~ /\A([0-9a-f]{2}:){5}([0-9a-f]{2})\z/)
             errors << "Configured NIC MAC '#{opts[:mac]}' is not in 'xx:xx:xx:xx:xx:xx' format"
           end
         end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -523,6 +523,12 @@ module VagrantPlugins
           end
         end
 
+        machine.config.vm.networks.each do |_type, opts|
+          if opts[:mac] && !(opts[:mac] =~ /\A([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})\z/)
+            errors << "Configured NIC MAC '#{opts[:mac]}' is not in 'xx:xx:xx:xx:xx:xx' format"
+          end
+        end
+
          { "Libvirt Provider" => errors }
       end
 


### PR DESCRIPTION
Implements #638 feature.
Validates network interface mac address if it is configured.
MAC should be in canonical form 'xx:xx:xx:xx:xx:xx', otherwise vagrant throws configuration error.