### PR TITLE
Add libvirt portgroup support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ virtual network.
   Default mode is 'bridge'.
 * `:type` - is type of interface.(`<interface type="#{@type}">`)
 * `:mac` - MAC address for the interface.
+* `:network_name` - Name of libvirt network to connect to.
+* `:portgroup` - Name of libvirt portgroup to connect to.
 * `:ovs` - Support to connect to an open vSwitch bridge device. Default is 'false'.
 
 ### Management Network

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -77,6 +77,8 @@ module VagrantPlugins
               @mode = iface_configuration.fetch(:mode, 'bridge')
               @type = iface_configuration.fetch(:type, 'direct')
               @model_type = iface_configuration.fetch(:model_type, @nic_model_type)
+              @portgroup = iface_configuration.fetch(:portgroup, nil)
+              @network_name = iface_configuration.fetch(:network_name, @network_name)
               template_name = 'public_interface'
               @logger.info("Setting up public interface using device #{@device} in mode #{@mode}")
               @ovs = iface_configuration.fetch(:ovs, false)
@@ -125,6 +127,8 @@ module VagrantPlugins
               if iface_configuration[:iface_type] == :public_network
                 if @type == 'direct'
                   @mac = xml.xpath("/domain/devices/interface[source[@dev='#{@device}']]/mac/@address")
+                elsif !@portgroup.nil?
+                  @mac = xml.xpath("/domain/devices/interface[source[@network='#{@network_name}']]/mac/@address")
                 else
                   @mac = xml.xpath("/domain/devices/interface[source[@bridge='#{@device}']]/mac/@address")
                 end

--- a/lib/vagrant-libvirt/templates/public_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/public_interface.xml.erb
@@ -4,6 +4,8 @@
   <% end %>
   <%if @type == 'direct'%>
   <source dev='<%= @device %>' mode='<%= @mode %>'/>
+  <% elsif !@portgroup.nil? %>
+  <source network='<%=@network_name%>' portgroup='<%=@portgroup%>'/>
   <% else %>
   <source bridge='<%=@device%>'/>
   <% end %>


### PR DESCRIPTION
This PR enables support for the networking feature `portgroup` in `vagrant-libvirt`.

For libvirt details see: `https://libvirt.org/formatdomain.html#elementsNICSVirtual`

To verify the functionality you can use the following basic Vagrantfile:
```
Vagrant.configure("2") do |config|

  config.vm.box = "centos/7"

  config.vm.network :public_network,
      :type => 'network',
      :portgroup => 'admin',
      :network_name => 'ovs-net'
end
```

The command `virsh edit vagrant-libvirt_default` will show the portgroup and network:
```
...
    <interface type='network'>
      <mac address='52:54:00:39:a7:9b'/>
      <source network='ovs-net' portgroup='admin'/>
      <model type='virtio'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
    </interface>
...
```

Inside the VM:
```
[vagrant@localhost ~]$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 52:54:00:76:7b:c7 brd ff:ff:ff:ff:ff:ff
    inet 192.168.121.14/24 brd 192.168.121.255 scope global dynamic eth0
       valid_lft 3499sec preferred_lft 3499sec
    inet6 fe80::5054:ff:fe76:7bc7/64 scope link
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 52:54:00:a7:a8:21 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::5054:ff:fea7:a821/64 scope link
       valid_lft forever preferred_lft forever
```
