### PR TITLE
add trustGuestRxFilters attribute to public interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,9 @@ virtual network.
 * `:portgroup` - Name of libvirt portgroup to connect to.
 * `:ovs` - Support to connect to an Open vSwitch bridge device. Default is
   'false'.
+* `:trust_guest_rx_filters` - Support trustGuestRxFilters attribute. Details
+  are listed [here](http://www.libvirt.org/formatdomain.html#elementsNICSDirect).
+  Default is 'false'.
 
 ### Management Network
 

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -82,6 +82,7 @@ module VagrantPlugins
               template_name = 'public_interface'
               @logger.info("Setting up public interface using device #{@device} in mode #{@mode}")
               @ovs = iface_configuration.fetch(:ovs, false)
+              @trust_guest_rx_filters = iface_configuration.fetch(:trust_guest_rx_filters, false)
             # configuration for udp or tcp tunnel interfaces (p2p conn btwn guest OSes)
             elsif iface_configuration.fetch(:tunnel_type, nil)
               @type = iface_configuration.fetch(:tunnel_type)

--- a/lib/vagrant-libvirt/templates/public_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/public_interface.xml.erb
@@ -1,4 +1,4 @@
-<interface type='<%= @type %>'>
+<interface type='<%= @type %>'<% if @trust_guest_rx_filters %> trustGuestRxFilters='yes'<% end %>>
   <% if @mac %>
   <mac address='<%= @mac %>'/>
   <% end %>


### PR DESCRIPTION
set :trust_guest_rx_filters => true in the network definition to enable
trustGuestRxFilters for the public interface.

Details from http://www.libvirt.org/formatdomain.html#elementsNICSDirect:
"If the model type is set to virtio and interface's trustGuestRxFilters
attribute is set to yes, changes made to the interface mac address,
unicast/multicast receive filters, and vlan settings in the guest will
be monitored and propagated to the associated macvtap device on the host
(Since 1.2.10). If trustGuestRxFilters is not set, or is not supported
for the device model in use, an attempted change to the mac address
originating from the guest side will result in a non-working network
connection."

closes #650