### PR TITLE
Handle invalid NUMA nodes-memory combinations

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -239,6 +239,10 @@ module VagrantPlugins
           raise 'NUMA nodes must be a factor of CPUs'
         end
 
+        if @memory % @numa_nodes != 0
+          raise 'NUMA nodes must be a factor of memory'
+        end
+
         numa = []
 
         (1..@numa_nodes).each do |node|


### PR DESCRIPTION
Raise an exception if the user specifies a memory allowance that cannot
be divided cleanly between available NUMA nodes.