### PR TITLE
Add support for RNG passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ can help a lot :-)
 - [CDROMs](#cdroms)
 - [Input](#input)
 - [PCI device passthrough](#pci-device-passthrough)
+- [Random number generator passthrough](#random-number-generator-passthrough)
 - [CPU Features](#cpu-features)
 - [No box and PXE boot](#no-box-and-pxe-boot)
 - [SSH Access To VM](#ssh-access-to-vm)
@@ -700,6 +701,21 @@ Vagrant.configure("2") do |config|
   end
 end
 ```
+
+## Random number generator passthrough
+
+You can pass through `/dev/random` to your VM by configuring the domain like this:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    # Pass through /dev/random from the host to the VM
+    libvirt.random :model => 'random'
+  end
+end
+```
+
+At the moment only the `random` backend is supported.
 
 ## CPU features
 

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -89,6 +89,9 @@ module VagrantPlugins
           # USB device passthrough
           @usbs = config.usbs
 
+          # RNG device passthrough
+          @rng =config.rng
+
           config = env[:machine].provider_config
           @domain_type = config.driver
 
@@ -217,6 +220,10 @@ module VagrantPlugins
 
           @pcis.each do |pci|
             env[:ui].info(" -- PCI passthrough:   #{pci[:bus]}:#{pci[:slot]}.#{pci[:function]}")
+          end
+
+          if !@rng[:model].nil?
+            env[:ui].info(" -- RNG device model:  #{@rng[:model]}")
           end
 
           @usbs.each do |usb|

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -111,6 +111,9 @@ module VagrantPlugins
       # PCI device passthrough
       attr_accessor :pcis
 
+      # Random number device passthrough
+      attr_accessor :rng
+
       # USB device passthrough
       attr_accessor :usbs
 
@@ -188,6 +191,9 @@ module VagrantPlugins
 
         # PCI device passthrough
         @pcis              = UNSET_VALUE
+
+        # Random number device passthrough
+        @rng              = UNSET_VALUE
 
         # USB device passthrough
         @usbs              = UNSET_VALUE
@@ -315,6 +321,18 @@ module VagrantPlugins
           target_port: options[:target_port],
           target_type: options[:target_type]
         })
+      end
+
+      def random(options={})
+        if !options[:model].nil? && options[:model] != "random"
+          raise 'The only supported rng backend is "random".'
+        end
+
+        if @rng == UNSET_VALUE
+          @rng = {}
+        end
+
+        @rng[:model] = options[:model]
       end
 
       def pci(options={})
@@ -534,6 +552,9 @@ module VagrantPlugins
 
         # PCI device passthrough
         @pcis = [] if @pcis == UNSET_VALUE
+
+        # Random number generator passthrough
+        @rng = {} if @rng == UNSET_VALUE
 
         # USB device passthrough
         @usbs = [] if @usbs == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -140,6 +140,11 @@
       </video>
       <%#End Video -%>
     <% end %>
+    <% if @rng[:model] == "random"%>
+      <rng model='virtio'>
+        <backend model='random'>/dev/random</backend>
+      </rng>
+    <% end %>
     <% @pcis.each do |pci| %>
       <hostdev mode='subsystem' type='pci' managed='yes'>
         <source>


### PR DESCRIPTION
Allow passing through /dev/random from the host to the VM. This speeds
up pretty much everything which needs entropy inside the VM.