### PR TITLE
Fix default_prefix behavior

### DIFF
--- a/lib/vagrant-libvirt/action/set_name_of_domain.rb
+++ b/lib/vagrant-libvirt/action/set_name_of_domain.rb
@@ -51,7 +51,7 @@ module VagrantPlugins
               # don't have any prefix, not even "_"
               ""
             else
-              config.default_prefix.to_s.concat("_")
+              config.default_prefix.to_s.dup.concat("_")
             end
           domain_name << env[:machine].name.to_s
           domain_name.gsub!(/[^-a-z0-9_\.]/i, '')


### PR DESCRIPTION
Call `dup` on default prefix before amending it via `concat` and
`<<`. Previously when default_prefix was used, it was amended in place,
so it was changing with every VM definition and kept getting longer,
leading to wrong domain names.