### PR TITLE
Retry mac to ip search when libvirt throws an error

### DIFF
--- a/lib/vagrant-libvirt/action/wait_till_up.rb
+++ b/lib/vagrant-libvirt/action/wait_till_up.rb
@@ -41,8 +41,14 @@ module VagrantPlugins
 
               # Wait for domain to obtain an ip address
               domain.wait_for(2) {
-                addresses.each_pair do |type, ip|
-                  env[:ip_address] = ip[0] if ip[0] != nil
+                begin
+                  addresses.each_pair do |type, ip|
+                    env[:ip_address] = ip[0] if ip[0] != nil
+                  end
+                # Workaround for fog-libvirt terminating when mac is not found
+                rescue Libvirt::Error
+                  sleep(2)
+                  retry
                 end
                 env[:ip_address] != nil
               }

--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -81,10 +81,16 @@ module VagrantPlugins
         ip_address = nil
         begin
           domain.wait_for(2) do
-            addresses.each_pair do |type, ip|
-              # Multiple leases are separated with a newline, return only
-              # the most recent address
-              ip_address = ip[0].split("\n").first if ip[0] != nil
+            begin
+              addresses.each_pair do |type, ip|
+                # Multiple leases are separated with a newline, return only
+                # the most recent address
+                ip_address = ip[0].split("\n").first if ip[0] != nil
+              end
+            # Workaround for fog-libvirt terminating when mac is not found
+            rescue Libvirt::Error
+              sleep(2)
+              retry
             end
             ip_address != nil
           end


### PR DESCRIPTION
Libvirt will return 'Call to virNetworkGetDHCPLeases failed: internal
error: no lease with matching MAC address' when a mac is not found.
fog-libvirt behaviour changed in 0.2.0 but since we immediately start to
poll for an IP, we need to retry despite the libvirt error.

Workaround fix for #668