### PR TITLE
[Docs] add important notes to GPU passthrough section

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ end
 * `keymap` - Set keymap for vm. default: en-us
 * `kvm_hidden` - [Hide the hypervisor from the
   guest](https://libvirt.org/formatdomain.html#elementsFeatures). Useful for
-  GPU passthrough on stubborn drivers. Default is false.
+  [GPU passthrough](#pci-device-passthrough) on stubborn drivers. Default is false.
 * `video_type` - Sets the graphics card type exposed to the guest.  Defaults to
   "cirrus".  [Possible
   values](http://libvirt.org/formatdomain.html#elementsVideo) are "vga",
@@ -729,6 +729,10 @@ Vagrant.configure("2") do |config|
   end
 end
 ```
+
+Note! Above options affect configuration only at domain creation. It won't change VM behaviour on `vagrant reload` after domain was created.
+
+Don't forget to [set](#domain-specific-options) `kvm_hidden` option to `true` especially if you are passthroughing NVIDIA GPUs. Otherwise GPU is visible from VM but cannot be operated.
 
 ## Random number generator passthrough
 


### PR DESCRIPTION
There are some difficulties with pass through of GPU devices like NVIDIA cards which are not obvious at first glance.

For example it isn't obvious that changing `libvirt.pci` won't change actual domain configuration and won't change actual list of passthroughed devices. You should recreate (`vagrant destroy` and `vagrant up`) domain in order to change that behaviour.

Also quite unobvious option is `kvm_hidden`. If you are passthroughing AMD device it is quite probable that everything is ok, but if are passthroughing NVIDIA GPU you probably face some strange behaviour like visibility of that GPUs to VM but impossibility to operate (run CUDA programs, get access to GPU and etc).