### PR TITLE
set cpu model only for custom cpu mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ end
   mode](https://libvirt.org/formatdomain.html#elementsCPU). Defaults to
   'host-model' if not set. Allowed values: host-model, host-passthrough,
   custom.
-* `cpu_model` - CPU Model. Defaults to 'qemu64' if not set. This can really
-  only be used when setting `cpu_mode` to `custom`.
+* `cpu_model` - CPU Model. Defaults to 'qemu64' if not set and `cpu_mode` is
+  `custom` and to '' otherwise. This can really only be used when setting
+  `cpu_mode` to `custom`.
 * `cpu_fallback` - Whether to allow libvirt to fall back to a CPU model close
   to the specified model if features in the guest CPU are not supported on the
   host. Defaults to 'allow' if not set. Allowed values: `allow`, `forbid`.

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -502,7 +502,8 @@ module VagrantPlugins
         @memory = 512 if @memory == UNSET_VALUE
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
-        @cpu_model = 'qemu64' if @cpu_model == UNSET_VALUE
+        @cpu_model = 'qemu64' if (@cpu_model == UNSET_VALUE and @cpu_mode == 'custom')
+        @cpu_model = '' if (@cpu_mode != 'custom')
         @cpu_fallback = 'allow' if @cpu_fallback == UNSET_VALUE
         @cpu_features = [] if @cpu_features == UNSET_VALUE
         @numa_nodes = @numa_nodes == UNSET_VALUE ? nil : _generate_numa()

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -502,8 +502,11 @@ module VagrantPlugins
         @memory = 512 if @memory == UNSET_VALUE
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
-        @cpu_model = 'qemu64' if (@cpu_model == UNSET_VALUE and @cpu_mode == 'custom')
-        @cpu_model = '' if (@cpu_mode != 'custom')
+        @cpu_model = if (@cpu_model == UNSET_VALUE and @cpu_mode == 'custom')
+            'qemu64'
+          elsif (@cpu_mode != 'custom')
+            ''
+          end
         @cpu_fallback = 'allow' if @cpu_fallback == UNSET_VALUE
         @cpu_features = [] if @cpu_features == UNSET_VALUE
         @numa_nodes = @numa_nodes == UNSET_VALUE ? nil : _generate_numa()

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -7,7 +7,7 @@
 
   <cpu mode='<%= @cpu_mode %>'>
     <% if @cpu_mode != 'host-passthrough' %>
-      <model fallback='<%= @cpu_fallback %>'><%= @cpu_model %></model>
+      <model fallback='<%= @cpu_fallback %>'><% if @cpu_mode == 'custom' %><%= @cpu_model %><% end %></model>
       <% if @nested %>
         <feature policy='optional' name='vmx'/>
         <feature policy='optional' name='svm'/>


### PR DESCRIPTION
according to https://libvirt.org/formatdomain.html#elementsCPU setting the model is not supported when using "host-model" and with recent libvirt this actually results in errors like this:

```
There was an error talking to Libvirt. The error message is shown
below:

Call to virDomainCreateWithFlags failed: the CPU is incompatible with host CPU: Host CPU does not provide required features: svm
```