### PR TITLE
Use /sbin/ip when there is no 'ip' command in any of the default PATHs

### DIFF
--- a/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
@@ -59,7 +59,7 @@ module VagrantPlugins
           return ssh_host if ping(ssh_host)
 
           # check other ips
-          command = "ip addr show | grep -i 'inet ' | grep -v '127.0.0.1' | tr -s ' ' | cut -d' ' -f3 | cut -d'/' -f 1"
+          command = "ip=$(which ip); ${ip:-/sbin/ip} addr show | grep -i 'inet ' | grep -v '127.0.0.1' | tr -s ' ' | cut -d' ' -f3 | cut -d'/' -f 1"
           result  = ""
           machine.communicate.execute(command) do |type, data|
             result << data if type == :stdout


### PR DESCRIPTION
While configuring NFS an attempt is done to find out all guest IP addresses using the 'ip' tool.
This tool is located in /sbin folder which is not always in the default PATH. This can result in errors like:

```
 INFO warden: Calling OUT action: #<VagrantPlugins::ProviderLibvirt::Action::ShareFolders:0x007fc8689b14b8>
DEBUG host: Searching for cap: nfs_installed
DEBUG host: Checking in: redhat
DEBUG host: Checking in: linux
DEBUG host: Found cap: nfs_installed in linux
 INFO host: Execute capability: nfs_installed [#<Vagrant::Environment: /var/lib/jenkins/workspace/pipeline-test_wip-TG6O6HU2IAULWKZINVXPWYUIU4APVEDUCV4TIOMW3LHGUVGFESPQ>] (redhat)
 INFO nfs: Using NFS, preparing NFS settings by reading host IP and machine IP
DEBUG ssh: Checking key permissions: /var/lib/jenkins/.vagrant.d/insecure_private_key
DEBUG ssh: Re-using SSH connection.
 INFO ssh: Execute: ip addr show | grep -i 'inet ' | grep -v '127.0.0.1' | tr -s ' ' | cut -d' ' -f3 | cut -d'/' -f 1 (sudo=false)
DEBUG ssh: stderr: bash: line 2: ip: command not found

DEBUG ssh: Exit status: 0
 INFO nfs: guest IPs:
 INFO nfs: host IP: 127.0.0.1 machine IP: []
 INFO warden: Calling OUT action: #<VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings:0x007fc868974b80>
 INFO warden: Calling OUT action: #<VagrantPlugins::ProviderLibvirt::Action::ForwardPorts:0x007fc868948b70>
 INFO warden: Calling OUT action: #<VagrantPlugins::ProviderLibvirt::Action::WaitTillUp:0x007fc868916120>
 INFO warden: Calling OUT action: #<VagrantPlugins::ProviderLibvirt::Action::StartDomain:0x0055a7c389c608>
```

and later on a fatal error occurs due to the wrong IP address being used:

```
 INFO guest: Execute capability: mount_nfs_folder [#<Vagrant::Machine: dev01 (VagrantPlugins::ProviderLibvirt::Provider)>, "127.0.0.1", {"/vagrant"=>{:type=>:"", :guestpath=>"/vagrant", :hostpath=>"/var/lib/jenkins/workspace/pipeline-test_rhsm_wip-TG6O6HU2IAULWKZINVXPWYUIU4APVEDUCV4TIOMW3LHGUVGFESPQ", :disabled=>false, :__vagrantfile=>true, :map_uid=>981, :map_gid=>980, :nfs_udp=>true, :nfs_version=>3, :uuid=>"519459908", :linux__nfs_options=>["rw", "no_subtree_check", "all_squash", "anonuid=981", "anongid=980", "fsid=519459908"]}, "/software"=>{:guestpath=>"/software", :hostpath=>"/home/shared/software", :disabled=>false, :__vagrantfile=>true, :map_uid=>1000, :map_gid=>1000, :nfs_udp=>true, :nfs_version=>3, :uuid=>"258980992", :linux__nfs_options=>["rw", "no_subtree_check", "all_squash", "anonuid=1000", "anongid=1000", "fsid=258980992"]}, "/yum_repos"=>{:guestpath=>"/yum_repos", :hostpath=>"/home/shared/yum_repos", :disabled=>false, :__vagrantfile=>true, :map_uid=>1000, :map_gid=>1000, :nfs_udp=>true, :nfs_version=>3, :uuid=>"1600717094", :linux__nfs_options=>["rw", "no_subtree_check", "all_squash", "anonuid=1000", "anongid=1000", "fsid=1600717094"]}}] (redhat)
DEBUG ssh: Re-using SSH connection.
 INFO ssh: Execute: set -e
mkdir -p /vagrant
mount -o vers=3,udp 127.0.0.1:/var/lib/jenkins/workspace/pipeline-test_wip-TG6O6HU2IAULWKZINVXPWYUIU4APVEDUCV4TIOMW3LHGUVGFESPQ /vagrant
if command -v /sbin/init && /sbin/init --version | grep upstart; then
  /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=/vagrant
fi
 (sudo=true)
DEBUG ssh: Re-using SSH connection.
 INFO ssh: Execute: echo; printf $SSH_AUTH_SOCK (sudo=false)
DEBUG ssh: Exit status: 0
DEBUG ssh: stdout:
/tmp/ssh-IQUlPd2203/agent.2203
 INFO ssh: Setting SSH_AUTH_SOCK remotely: /tmp/ssh-IQUlPd2203/agent.2203
DEBUG ssh: stderr: mount.nfs: requested NFS version or transport protocol is not supported

DEBUG ssh: Exit status: 32
 INFO retryable: Retryable exception raised: #<Vagrant::Errors::NFSMountFailed: The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!
```

By using /sbin/ip instead of just 'ip' the IP address detection works more reliable and prevents errors like above