### PR TITLE
Spec test for domain template to verify rendering

### DIFF
--- a/spec/support/libvirt_context.rb
+++ b/spec/support/libvirt_context.rb
@@ -24,5 +24,7 @@ shared_context "libvirt" do
 
     # return some information for domain when needed
     allow(domain).to receive(:mac).and_return("9C:D5:53:F1:5A:E7")
+
+    machine.stub(:id => id)
   end
 end

--- a/spec/support/sharedcontext.rb
+++ b/spec/support/sharedcontext.rb
@@ -29,7 +29,6 @@ shared_context "unit" do
   before (:each) do
     machine.stub(:guest => guest)
     machine.stub(:communicator => communicator)
-    machine.stub(:id => id)
   end
 
 end

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -1,0 +1,125 @@
+<domain type='kvm'>
+  <name></name>
+  <uuid></uuid>
+  <memory></memory>
+  <vcpu>1</vcpu>
+
+
+  <cpu mode='custom'>
+      <model fallback='allow'>qemu64</model>
+        <feature name='AAA' policy='required'/>
+  </cpu>
+
+
+  <os>
+        <type arch='x86_64' machine='pc-compatible'>hvm</type>
+      <loader readonly='yes' type='rom'>/efi/loader</loader>
+      <bootmenu enable='yes'/>
+    <kernel></kernel>
+    <initrd></initrd>
+    <cmdline></cmdline>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'/>
+  <devices>
+    <emulator>/usr/bin/kvm-spice</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test.qcow2'/>
+      <target dev='vda' bus='ide'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='default'/>
+      <source file='/var/lib/libvirt/images/test-disk1.qcow2'/>
+      <target dev='vdb' bus='virtio'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='default'/>
+      <source file='/var/lib/libvirt/images/test-disk2.qcow2'/>
+      <target dev='vdc' bus='virtio'/>
+    </disk>
+
+    <disk type='file' device='cdrom'>
+      <source file=''/>
+      <target dev='hda' bus='ide'/>
+      <readonly/>
+    </disk>
+    <disk type='file' device='cdrom'>
+      <source file=''/>
+      <target dev='hdb' bus='ide'/>
+      <readonly/>
+    </disk>
+
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+
+  <channel type='unix' >
+      <source mode=''
+      />
+      <target type='virtio'
+               name="org.qemu.guest_agent.0"
+      />
+  </channel>
+  <channel type='unix' >
+      <source mode=''
+               path="/tmp/foo"
+      />
+      <target type='guestfwd'
+               address="192.0.2.42"
+               port="4242"
+      />
+  </channel>
+
+    <input type='mouse' bus='ps2'/>
+
+      <graphics type='vnc' port='5900' autoport='yes' listen='127.0.0.1' keymap='en-us'  />
+      <video>
+        <model type='cirrus' vram='9216' heads='1'/>
+      </video>
+      <rng model='virtio'>
+        <backend model='random'>/dev/random</backend>
+      </rng>
+      <hostdev mode='subsystem' type='pci' managed='yes'>
+        <source>
+          <address domain='0x0000'
+            bus='0x06'
+            slot='0x12'
+            function='0x5'/>
+        </source>
+      </hostdev>
+      <hostdev mode='subsystem' type='pci' managed='yes'>
+        <source>
+          <address domain='0x0000'
+            bus='0x03'
+            slot='0x00'
+            function='0x0'/>
+        </source>
+      </hostdev>
+      <hostdev mode='subsystem' type='usb'>
+        <source startupPolicy='mandatory'>
+          <vendor id='0x1234'/>
+          <product id='0xabcd'/>
+          <address bus='1' device='2'/>
+        </source>
+      </hostdev>
+        <redirdev bus='usb' type='tcp'>
+        </redirdev>
+        <redirfilter>
+          <usbdev class='0x0b' vendor='0x0b' product='0x0b' version='0x0b' allow='yes'/>
+        </redirfilter>
+
+    <tpm model='tpm-tis'>
+      <backend type='passthrough'>
+        <device path='/dev/tpm0'/>
+      </backend>
+    </tpm>
+  </devices>
+</domain>

--- a/spec/unit/templates/domain_defaults.xml
+++ b/spec/unit/templates/domain_defaults.xml
@@ -1,0 +1,44 @@
+<domain type=''>
+  <name></name>
+  <uuid></uuid>
+  <memory></memory>
+  <vcpu>1</vcpu>
+
+
+  <cpu mode='host-model'>
+      <model fallback='allow'></model>
+  </cpu>
+
+
+  <os>
+        <type>hvm</type>
+    <kernel></kernel>
+    <initrd></initrd>
+    <cmdline></cmdline>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'/>
+  <devices>
+
+
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+
+
+    <input type='mouse' bus='ps2'/>
+
+      <graphics type='vnc' port='5900' autoport='yes' listen='127.0.0.1' keymap='en-us'  />
+      <video>
+        <model type='cirrus' vram='9216' heads='1'/>
+      </video>
+
+  </devices>
+</domain>

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -1,0 +1,70 @@
+require "support/sharedcontext"
+
+require "vagrant-libvirt/config"
+require "vagrant-libvirt/util/erb_template"
+
+describe "templates/domain" do
+
+  include_context "unit"
+
+  class DomainTemplateHelper < VagrantPlugins::ProviderLibvirt::Config
+    include VagrantPlugins::ProviderLibvirt::Util::ErbTemplate
+  end
+
+  let(:domain) { DomainTemplateHelper.new }
+  let(:xml_expected) { File.read(File.join(File.dirname(__FILE__), test_file)) }
+
+  context "when only defaults used" do
+    let(:test_file) { 'domain_defaults.xml' }
+    it "renders template" do
+      domain.finalize!
+      expect(domain.to_xml('domain')).to eq xml_expected
+    end
+  end
+
+  context "when all settings enabled" do
+    before do
+      domain.instance_variable_set('@domain_type', 'kvm')
+      domain.cpu_mode = 'custom'
+      domain.cpu_feature({:name => 'AAA', :policy => 'required'})
+      domain.machine_type = 'pc-compatible'
+      domain.machine_arch = 'x86_64'
+      domain.loader = '/efi/loader'
+      domain.boot('network')
+      domain.boot('cdrom')
+      domain.boot('hd')
+      domain.emulator_path = '/usr/bin/kvm-spice'
+      domain.instance_variable_set('@domain_volume_path', '/var/lib/libvirt/images/test.qcow2')
+      domain.instance_variable_set('@domain_volume_cache', 'unsafe')
+      domain.disk_bus = 'ide'
+      domain.storage(:file, {:path => 'test-disk1.qcow2'})
+      domain.storage(:file, {:path => 'test-disk2.qcow2'})
+      domain.disks.each do |disk|
+        disk[:absolute_path] = '/var/lib/libvirt/images/' + disk[:path]
+      end
+      domain.storage(:file, {:device => :cdrom})
+      domain.storage(:file, {:device => :cdrom})
+      domain.channel(:type => 'unix',
+                     :target_name => 'org.qemu.guest_agent.0',
+                     :target_type => 'virtio')
+      domain.channel(:type => 'unix',
+                     :target_type => 'guestfwd',
+                     :target_address => '192.0.2.42',
+                     :target_port => '4242',
+                     :source_path => '/tmp/foo')
+      domain.random(:model => 'random')
+      domain.pci(:bus => '0x06', :slot => '0x12', :function => '0x5')
+      domain.pci(:bus => '0x03', :slot => '0x00', :function => '0x0')
+      domain.usb(:bus => '1', :device => '2', :vendor => '0x1234', :product => '0xabcd')
+      domain.redirdev(:type => 'tcp', :host => 'localhost', :port => '4000')
+      domain.redirfilter(:class => '0x0b', :vendor => '0x08e6',
+                         :product => '0x3437', :version => '2.00', :allow => 'yes')
+      domain.tpm_path = '/dev/tpm0'
+    end
+    let(:test_file) { 'domain_all_settings.xml' }
+    it "renders template" do
+      domain.finalize!
+      expect(domain.to_xml('domain')).to eq xml_expected
+    end
+  end
+end


### PR DESCRIPTION
Add basic spec tests for the domain template to test rendering through
simple wrapping of a config object to provide values for class instance
variables used by the template as it mostly mirrors those required.