### PR TITLE
[WIP] Virtio scsi

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -99,6 +99,7 @@ module VagrantPlugins
       attr_accessor :machine_virtual_size
       attr_accessor :disk_bus
       attr_accessor :disk_device
+      attr_accessor :disk_controller_model
       attr_accessor :disk_driver_opts
       attr_accessor :nic_model_type
       attr_accessor :nested
@@ -256,6 +257,7 @@ module VagrantPlugins
         @machine_virtual_size = UNSET_VALUE
         @disk_bus          = UNSET_VALUE
         @disk_device       = UNSET_VALUE
+        @disk_controller_model = UNSET_VALUE
         @disk_driver_opts  = {}
         @nic_model_type    = UNSET_VALUE
         @nested            = UNSET_VALUE
@@ -871,8 +873,15 @@ module VagrantPlugins
         @machine_type = nil if @machine_type == UNSET_VALUE
         @machine_arch = nil if @machine_arch == UNSET_VALUE
         @machine_virtual_size = nil if @machine_virtual_size == UNSET_VALUE
-        @disk_bus = 'virtio' if @disk_bus == UNSET_VALUE
-        @disk_device = 'vda' if @disk_device == UNSET_VALUE
+        @disk_device = @disk_bus == 'scsi' ? 'sda' : 'vda' if @disk_device == UNSET_VALUE
+        @disk_bus = @disk_device.start_with?('sd') ? 'scsi' : 'virtio' if @disk_bus == UNSET_VALUE
+        if @disk_controller_model == UNSET_VALUE
+          if @disk_bus == 'scsi' or @disk_device.start_with?('sd') == 'sd'
+            @disk_controller_model = 'virtio-scsi'
+          else
+            @disk_controller_model = nil
+          end
+        end
         @disk_driver_opts = {} if @disk_driver_opts == UNSET_VALUE
         @nic_model_type = nil if @nic_model_type == UNSET_VALUE
         @nested = false if @nested == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -122,6 +122,11 @@
       <target dev='<%= volume[:device] %>' bus='<%= volume[:bus] %>'/>
     </disk>
 <%- end -%>
+<%- if @disk_bus == "scsi" and @disk_controller_model != nil %>
+  <%- for idx in 0..(@domain_volumes.length / 7) do %>
+    <controller type='scsi' model='<%= @disk_controller_model %>' index='<%= idx -%>'/>
+  <%- end -%>
+<%- end -%>
 <%# additional disks -%>
 <%- @disks.each_with_index do |d, index| -%>
     <disk type='file' device='disk'>

--- a/spec/unit/templates/domain_scsi_bus_storage.xml
+++ b/spec/unit/templates/domain_scsi_bus_storage.xml
@@ -1,0 +1,44 @@
+<domain type='' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name></name>
+  <title></title>
+  <description></description>
+  <uuid></uuid>
+  <memory></memory>
+  <vcpu>1</vcpu>
+  <cpu mode='host-model'>
+    <model fallback='allow'></model>
+  </cpu>
+  <os>
+    <type>hvm</type>
+    <kernel></kernel>
+    <initrd></initrd>
+    <cmdline></cmdline>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'>
+  </clock>
+  <devices>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-0'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test.qcow2'/>
+      <target dev='vda' bus='scsi'/>
+    </disk>
+    <controller type='scsi' model='virtio-scsi' index='0'/>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <video>
+      <model type='cirrus' vram='16384' heads='1'/>
+    </video>
+  </devices>
+</domain>

--- a/spec/unit/templates/domain_scsi_device_storage.xml
+++ b/spec/unit/templates/domain_scsi_device_storage.xml
@@ -1,0 +1,44 @@
+<domain type='' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name></name>
+  <title></title>
+  <description></description>
+  <uuid></uuid>
+  <memory></memory>
+  <vcpu>1</vcpu>
+  <cpu mode='host-model'>
+    <model fallback='allow'></model>
+  </cpu>
+  <os>
+    <type>hvm</type>
+    <kernel></kernel>
+    <initrd></initrd>
+    <cmdline></cmdline>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'>
+  </clock>
+  <devices>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-0'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test.qcow2'/>
+      <target dev='sda' bus='scsi'/>
+    </disk>
+    <controller type='scsi' model='virtio-scsi' index='0'/>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <video>
+      <model type='cirrus' vram='16384' heads='1'/>
+    </video>
+  </devices>
+</domain>

--- a/spec/unit/templates/domain_scsi_multiple_controllers_storage.xml
+++ b/spec/unit/templates/domain_scsi_multiple_controllers_storage.xml
@@ -1,0 +1,130 @@
+<domain type='' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name></name>
+  <title></title>
+  <description></description>
+  <uuid></uuid>
+  <memory></memory>
+  <vcpu>1</vcpu>
+  <cpu mode='host-model'>
+    <model fallback='allow'></model>
+  </cpu>
+  <os>
+    <type>hvm</type>
+    <kernel></kernel>
+    <initrd></initrd>
+    <cmdline></cmdline>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'>
+  </clock>
+  <devices>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-0'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-1.img'/>
+      <target dev='sda' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-1'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-2.img'/>
+      <target dev='sdb' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-2'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-3.img'/>
+      <target dev='sdc' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-3'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-4.img'/>
+      <target dev='sdd' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-4'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-5.img'/>
+      <target dev='sde' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-5'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-6.img'/>
+      <target dev='sdf' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-6'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-7.img'/>
+      <target dev='sdg' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-7'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-8.img'/>
+      <target dev='sdh' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-8'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-9.img'/>
+      <target dev='sdi' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-9'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-10.img'/>
+      <target dev='sdj' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-10'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-11.img'/>
+      <target dev='sdk' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-11'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-12.img'/>
+      <target dev='sdl' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-12'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-13.img'/>
+      <target dev='sdm' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-13'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-14.img'/>
+      <target dev='sdn' bus='scsi'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <alias name='ua-box-volume-14'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
+      <source file='/var/lib/libvirt/images/test-15.img'/>
+      <target dev='sdo' bus='scsi'/>
+    </disk>
+    <controller type='scsi' model='virtio-scsi' index='0'/>
+    <controller type='scsi' model='virtio-scsi' index='1'/>
+    <controller type='scsi' model='virtio-scsi' index='2'/>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <video>
+      <model type='cirrus' vram='16384' heads='1'/>
+    </video>
+  </devices>
+</domain>


### PR DESCRIPTION
Allows enabling of virtio-scsi for better performance when using a scsi disk.

Rather than control this via disks, need to look at being able to add controllers and be able to assign disks to specific controllers. Virt-manager limits each scsi controller to 4 devices, though the naming indicates that there could be up to 8 devices allowed (c1: sda, .., sdd, c2: sdh, .., sdk, c3: sdo, ...).
Additional the scsi controller controller supports multiple models http://libvirt.org/formatdomain.html#elementsControllers.
Note that device names for scsi disks are also supposed to be 'sdX' rather than 'vdX', which is apparently used as a hint for libvirt to indicate the correct controller.
CDROM devices using scsi may also be attached to the same controller
Scsi controllers using virtio-scsi may be assigned a dedicated IOThread through config settings, where all disks attached to the same controller will use the same thread (different to standard disk controller), and to have separate threads per SCSI disk a separate controller for each disk must be created.

It may be worth first refactoring some code before attempting to fix all of this behaviour, in which case this can serve as a suggested temporary patch users can apply to their environment until someone has a chance to implement better disk and controller config/handling.