### PR TITLE
Don't run pacman -Sy, simply install with -S instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ yum install qemu libvirt libvirt-devel ruby-devel gcc qemu-kvm
 dnf -y install qemu libvirt libvirt-devel ruby-devel gcc
 ```
 
-* Arch linux: look at tips and solutions from Arch wiki.
+* Arch linux: please read the related [ArchWiki](https://wiki.archlinux.org/index.php/Vagrant#vagrant-libvirt) page.
 ```shell
-pacman -Sy vagrant
+pacman -S vagrant
 ```
 
 Now you're ready to install vagrant-libvirt using standard [Vagrant


### PR DESCRIPTION
See https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported for details.

TL;DR is that Arch only supports the latest version of packages. If you install or upgrade a single package with -Sy, it may update dependencies that other packages also make use of that may break because of it.