### PR TITLE
Make mgmt network detachable from no box VMs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ end
   for use by the [qemu guest
   agent](http://wiki.libvirt.org/page/Qemu_guest_agent) and the Spice/QXL
   graphics type.
+* `mgmt_attach` - Decide if VM has interface in mgmt network. If set to 'false'
+  it is not possible to communicate with VM through `vagrant ssh` or run
+  provisioning. Setting to 'false' is only possible when VM doesn't use box.
+  Defaults set to 'true'.
 
 Specific domain settings can be set for each domain separately in multi-VM
 environment. Example below shows a part of Vagrantfile, where specific options
@@ -608,9 +612,9 @@ virtual network.
 
 vagrant-libvirt uses a private network to perform some management operations on
 VMs. All VMs will have an interface connected to this network and an IP address
-dynamically assigned by libvirt. This is in addition to any networks you
-configure. The name and address used by this network are configurable at the
-provider level.
+dynamically assigned by libvirt unless you set `:mgmt_attach` to 'false'.
+This is in addition to any networks you configure. The name and address
+used by this network are configurable at the provider level.
 
 * `management_network_name` - Name of libvirt network to which all VMs will be
   connected. If not specified the default is 'vagrant-libvirt'.

--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -105,7 +105,7 @@ module VagrantPlugins
                 b3.use ForwardPorts
                 b3.use PrepareNFSSettings
                 b3.use ShareFolders
-             end
+              end
             end
           end
         end

--- a/lib/vagrant-libvirt/action/set_boot_order.rb
+++ b/lib/vagrant-libvirt/action/set_boot_order.rb
@@ -86,7 +86,7 @@ module VagrantPlugins
 
         def search_network(nets, xml)
           str = '/domain/devices/interface'
-          str += "[(@type='network' or @type='udp')"
+          str += "[(@type='network' or @type='udp' or @type='bridge')"
           unless nets.empty?
             str += " and source[@network='#{nets.first['network']}']"
           end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -128,6 +128,9 @@ module VagrantPlugins
       # Autostart
       attr_accessor :autostart
 
+      # Attach mgmt network
+      attr_accessor :mgmt_attach
+
       def initialize
         @uri               = UNSET_VALUE
         @driver            = UNSET_VALUE
@@ -212,6 +215,9 @@ module VagrantPlugins
 
         # Autostart
         @autostart         = UNSET_VALUE
+
+        # Attach mgmt network
+        @mgmt_attach       = UNSET_VALUE
       end
 
       def boot(device)
@@ -577,6 +583,9 @@ module VagrantPlugins
 
         # Autostart
         @autostart = false if @autostart == UNSET_VALUE
+
+        # Attach mgmt network
+        @mgmt_attach = true if @mgmt_attach == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -108,6 +108,10 @@ module VagrantPlugins
         error_key(:tunnel_port_not_defined)
       end
 
+      class ManagementNetworkRequired < VagrantLibvirtError
+        error_key(:management_network_required)
+      end
+
       # Other exceptions
       class InterfaceSlotNotAvailable < VagrantLibvirtError
         error_key(:interface_slot_not_available)

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -44,8 +44,18 @@ module VagrantPlugins
             management_network_options[:mac] = management_network_mac
           end
 
+          if (env[:machine].config.vm.box &&
+              !env[:machine].provider_config.mgmt_attach)
+            raise Errors::ManagementNetworkRequired
+          end
+
           # add management network to list of networks to check
-          networks = [management_network_options]
+          # unless mgmt_attach set to false
+          networks = if env[:machine].provider_config.mgmt_attach
+                       [management_network_options]
+                     else
+                       []
+                     end
 
           env[:machine].config.vm.networks.each do |type, original_options|
             logger.debug "In config found network type #{type} options #{original_options}"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -137,6 +137,9 @@ en:
         Error while deleting snapshot: %{error_message}.
       tunnel_port_not_defined: |-
          tunnel UDP or TCP port not defined.
+      management_network_required: |-
+        Management network can't be disabled when VM use box.
+        Please fix your configuration and run vagrant again.
 
     states:
       paused: |-


### PR DESCRIPTION
Pxe nodes are not provisioned, mgmt network is not required for them.
Also take into account bridge interfaces when set boot order, to support
scenario when we would like to use vagrant VM to pxe boot physical nodes
in existing network.