### PR TITLE
Autostart of libvirt networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,8 @@ starts with `libvirt__` string. Here is a list of those options:
 * `:model_type` - parameter specifies the model of the network adapter when you
   create a domain value by default virtio KVM believe possible values, see the
   documentation for libvirt
+* `:autostart` - Automatic startup of network by the libvirt daemon.
+  If not specified the default is 'false'.
 
 When the option `:libvirt__dhcp_enabled` is to to 'false' it shouldn't matter
 whether the virtual network contains a DHCP server or not and vagrant-libvirt
@@ -629,6 +631,8 @@ used by this network are configurable at the provider level.
   [here](https://libvirt.org/formatnetwork.html#examplesPrivate6), and
   [here](http://libvirt.org/git/?p=libvirt.git;a=commitdiff;h=705e67d40b09a905cd6a4b8b418d5cb94eaa95a8)
   for for more information.
+* `management_network_autostart` - Automatic startup of mgmt network, if not
+  specified the default is 'false'.
 
 You may wonder how vagrant-libvirt knows the IP address a VM received.  Libvirt
 doesn't provide a standard way to find out the IP address of a running domain.

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -60,7 +60,7 @@ module VagrantPlugins
                 ipv6_prefix:      options[:ipv6_prefix] || nil,
                 created:          false,
                 active:           false,
-                autostart:        false,
+                autostart:        options[:autostart] || false,
                 guest_ipv6:       @options[:guest_ipv6] || 'yes',
                 libvirt_network:  nil
               }

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -50,6 +50,7 @@ module VagrantPlugins
       attr_accessor :management_network_mode
       attr_accessor :management_network_mac
       attr_accessor :management_network_guest_ipv6
+      attr_accessor :management_network_autostart
 
       # Default host prefix (alternative to use project folder name)
       attr_accessor :default_prefix
@@ -146,6 +147,7 @@ module VagrantPlugins
         @management_network_mode = UNSET_VALUE
         @management_network_mac  = UNSET_VALUE
         @management_network_guest_ipv6 = UNSET_VALUE
+        @management_network_autostart = UNSET_VALUE
 
         # Domain specific settings.
         @uuid              = UNSET_VALUE
@@ -496,6 +498,7 @@ module VagrantPlugins
         @management_network_mode = 'nat' if @management_network_mode == UNSET_VALUE
         @management_network_mac = nil if @management_network_mac == UNSET_VALUE
         @management_network_guest_ipv6 = 'yes' if @management_network_guest_ipv6 == UNSET_VALUE
+        @management_network_autostart = false if @management_network_autostart == UNSET_VALUE
 
         # generate a URI if none is supplied
         @uri = _generate_uri if @uri == UNSET_VALUE

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -13,6 +13,7 @@ module VagrantPlugins
           management_network_mode = env[:machine].provider_config.management_network_mode
           management_network_mac = env[:machine].provider_config.management_network_mac
           management_network_guest_ipv6 = env[:machine].provider_config.management_network_guest_ipv6
+          management_network_autostart = env[:machine].provider_config.management_network_autostart
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -37,7 +38,8 @@ module VagrantPlugins
             netmask: Regexp.last_match(2),
             dhcp_enabled: true,
             forward_mode: management_network_mode,
-            guest_ipv6: management_network_guest_ipv6
+            guest_ipv6: management_network_guest_ipv6,
+            autostart: management_network_autostart
           }
 
           unless management_network_mac.nil?


### PR DESCRIPTION
Add option for defining autostart behaviour for mgmt network.
Take into account 'autostart' value for private networks.
Fixes #615