### PR TITLE
Minimum support for xen

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ end
   _target_](http://libvirt.org/formatdomain.html#elementsDisks). NOTE: this
   option applies only to disks associated with a box image. To set the bus type
   on additional disks, see the [Additional Disks](#additional-disks) section.
+* `disk_device` - The disk device to emulate. Defaults to vda if not
+  set, which should be fine for paravirtualized guests, but some fully
+  virtualized guests may require hda. NOTE: this option also applies only to
+  disks associated with a box image.
 * `nic_model_type` - parameter specifies the model of the network adapter when
   you create a domain value by default virtio KVM believe possible values, see
   the [documentation for

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -42,6 +42,7 @@ module VagrantPlugins
           @machine_type = config.machine_type
           @machine_arch = config.machine_arch
           @disk_bus = config.disk_bus
+          @disk_device = config.disk_device
           @nested = config.nested
           @memory_size = config.memory.to_i * 1024
           @management_network_mac = config.management_network_mac

--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -20,13 +20,19 @@ module VagrantPlugins
           libvirt_domain = env[:machine].provider.driver.connection.client.lookup_domain_by_uuid(
             env[:machine].id
           )
-          libvirt_domain.list_snapshots.each do |name|
-            @logger.info("Deleting snapshot '#{name}'")
-            begin
-              libvirt_domain.lookup_snapshot_by_name(name).delete
-            rescue => e
-              raise Errors::DeleteSnapshotError, error_message: e.message
+          begin
+            libvirt_domain.list_snapshots.each do |name|
+              @logger.info("Deleting snapshot '#{name}'")
+              begin
+                libvirt_domain.lookup_snapshot_by_name(name).delete
+              rescue => e
+                raise Errors::DeleteSnapshotError, error_message: e.message
+              end
             end
+          rescue
+            # Some drivers (xen) don't support getting list of snapshots,
+            # not much can be done here about it
+            @logger.warn("Failed to get list of snapshots")
           end
 
           # must remove managed saves

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -71,6 +71,7 @@ module VagrantPlugins
       attr_accessor :machine_arch
       attr_accessor :machine_virtual_size
       attr_accessor :disk_bus
+      attr_accessor :disk_device
       attr_accessor :nic_model_type
       attr_accessor :nested
       attr_accessor :volume_cache
@@ -170,6 +171,7 @@ module VagrantPlugins
         @machine_arch      = UNSET_VALUE
         @machine_virtual_size = UNSET_VALUE
         @disk_bus          = UNSET_VALUE
+        @disk_device       = UNSET_VALUE
         @nic_model_type    = UNSET_VALUE
         @nested            = UNSET_VALUE
         @volume_cache      = UNSET_VALUE
@@ -569,6 +571,7 @@ module VagrantPlugins
         @machine_arch = nil if @machine_arch == UNSET_VALUE
         @machine_virtual_size = nil if @machine_virtual_size == UNSET_VALUE
         @disk_bus = 'virtio' if @disk_bus == UNSET_VALUE
+        @disk_device = 'vda' if @disk_device == UNSET_VALUE
         @nic_model_type = 'virtio' if @nic_model_type == UNSET_VALUE
         @nested = false if @nested == UNSET_VALUE
         @volume_cache = 'default' if @volume_cache == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -74,7 +74,7 @@
       <driver name='qemu' type='qcow2' cache='<%= @domain_volume_cache %>'/>
       <source file='<%= @domain_volume_path %>'/>
       <%# we need to ensure a unique target dev -%>
-      <target dev='vda' bus='<%= @disk_bus %>'/>
+      <target dev='<%= @disk_device %>' bus='<%= @disk_bus %>'/>
     </disk>
     <% end %>
 <%# additional disks -%>

--- a/spec/support/environment_helper.rb
+++ b/spec/support/environment_helper.rb
@@ -18,7 +18,7 @@ class EnvironmentHelper
     1024
   end
 
-  %w(cpus cpu_mode loader boot_order machine_type disk_bus nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms driver).each do |name|
+  %w(cpus cpu_mode loader boot_order machine_type disk_bus disk_device nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms driver).each do |name|
     define_method(name.to_sym) do
       nil
     end

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -36,6 +36,7 @@ describe 'templates/domain' do
       domain.instance_variable_set('@domain_volume_path', '/var/lib/libvirt/images/test.qcow2')
       domain.instance_variable_set('@domain_volume_cache', 'unsafe')
       domain.disk_bus = 'ide'
+      domain.disk_device = 'vda'
       domain.storage(:file, path: 'test-disk1.qcow2')
       domain.storage(:file, path: 'test-disk2.qcow2')
       domain.disks.each do |disk|


### PR DESCRIPTION
When trying to get vagrant-libvirt to work with xen I got across 2 showstoppers which should be fixed in this PR:
1. Disk device had to be named hda, while it was hardcoded to vda. This makes it possible to change this in Vagrantfile
2. Xen driver for libvirt does not support snapshots. My change will just log a warning if it was impossible to get a list of snapshots, but keep the old functionality if there are snapshots found but can't be removed.