### PR TITLE
Introduce qemu:commandline (for osx quirks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,20 @@ Vagrant.configure(2) do |config|
 end
 ```
 
+## Custom command line arguments
+You can also specify multiple qemuargs arguments for qemu-system
+
+* `value` - Value
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.qemuargs :value => "-device"
+    libvirt.qemuargs :value => "intel-iommu"
+  end
+end
+```
+
 ## Box Format
 
 You can view an example box in the

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -88,9 +88,9 @@ module VagrantPlugins
 
           # PCI device passthrough
           @pcis = config.pcis
-          
+
           # Watchdog device
-          @watchdog_dev = config.watchdog_dev          
+          @watchdog_dev = config.watchdog_dev
 
           # USB device passthrough
           @usbs = config.usbs
@@ -101,6 +101,9 @@ module VagrantPlugins
 
           # smartcard device
           @smartcard_dev = config.smartcard_dev
+
+          # qemuargs
+          @qemuargs = config.qemuargs
 
           # RNG device passthrough
           @rng = config.rng
@@ -278,6 +281,14 @@ module VagrantPlugins
 
           if not @smartcard_dev.empty?
             env[:ui].info(" -- smartcard device:  mode=#{@smartcard_dev[:mode]}, type=#{@smartcard_dev[:type]}")
+          end
+
+          unless @qemuargs.empty?
+            env[:ui].info(' -- Command line args: ')
+            @qemuargs.each do |arg|
+              msg = "    -> value=#{arg[:value]}, "
+              env[:ui].info(msg)
+            end
           end
 
           env[:ui].info(" -- Command line : #{@cmd_line}")

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -141,6 +141,9 @@ module VagrantPlugins
       # Attach mgmt network
       attr_accessor :mgmt_attach
 
+      # Additional qemuargs arguments
+      attr_accessor :qemuargs
+
       def initialize
         @uri               = UNSET_VALUE
         @driver            = UNSET_VALUE
@@ -238,6 +241,8 @@ module VagrantPlugins
 
         # Attach mgmt network
         @mgmt_attach       = UNSET_VALUE
+
+        @qemuargs  = UNSET_VALUE
       end
 
       def boot(device)
@@ -489,6 +494,11 @@ module VagrantPlugins
         @disks << disk # append
       end
 
+      def qemuargs(options = {})
+        @qemuargs = [] if @qemuargs == UNSET_VALUE
+        @qemuargs.push(value: options[:value])
+      end
+
       # code to generate URI from a config moved out of the connect action
       def _generate_uri
         # builds the libvirt connection URI from the given driver config
@@ -651,6 +661,8 @@ module VagrantPlugins
 
         # Attach mgmt network
         @mgmt_attach = true if @mgmt_attach == UNSET_VALUE
+
+        @qemuargs = [] if @qemuargs == UNSET_VALUE
       end
 
       def validate(machine)
@@ -676,9 +688,14 @@ module VagrantPlugins
           c = disks.dup
           c += other.disks
           result.disks = c
+
           c = cdroms.dup
           c += other.cdroms
           result.cdroms = c
+
+          c = qemuargs.dup
+          c += other.qemuargs
+          result.qemuargs = c
         end
       end
     end

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -1,4 +1,4 @@
-<domain type='<%= @domain_type %>'>
+<domain type='<%= @domain_type %>' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name><%= @name %></name>
   <uuid><%= @uuid %></uuid>
   <memory><%= @memory_size %></memory>
@@ -218,4 +218,12 @@
     </tpm>
     <% end -%>
   </devices>
+
+  <% unless @qemuargs.empty? %>
+  <qemu:commandline>
+    <% @qemuargs.each do |arg| %>
+    <qemu:arg value='<%= arg[:value] %>'/>
+    <% end %>
+  </qemu:commandline>
+  <% end %>
 </domain>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -1,4 +1,4 @@
-<domain type='kvm'>
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name></name>
   <uuid></uuid>
   <memory></memory>
@@ -125,4 +125,9 @@
       </backend>
     </tpm>
   </devices>
+
+  <qemu:commandline>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='dummy-device'/>
+  </qemu:commandline>
 </domain>

--- a/spec/unit/templates/domain_defaults.xml
+++ b/spec/unit/templates/domain_defaults.xml
@@ -1,4 +1,4 @@
-<domain type=''>
+<domain type='' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name></name>
   <uuid></uuid>
   <memory></memory>
@@ -42,4 +42,5 @@
 
 
   </devices>
+
 </domain>

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -62,6 +62,9 @@ describe 'templates/domain' do
       domain.watchdog(model: 'i6300esb', action: 'reset')
       domain.smartcard(mode: 'passthrough')
       domain.tpm_path = '/dev/tpm0'
+
+      domain.qemuargs(value: '-device')
+      domain.qemuargs(value: 'dummy-device')
     end
     let(:test_file) { 'domain_all_settings.xml' }
     it 'renders template' do


### PR DESCRIPTION
Hello everyone,

It will be great to have support for creating configs like this:
```
<qemu:commandline>
    <qemu:arg value='-device'/>
    <qemu:arg value='isa-applesmc,osk=secret-here'/>
    <qemu:arg value='-smbios'/>
    <qemu:arg value='type=2'/>
    <qemu:arg value='-cpu'/>
    <qemu:arg value='Penryn,vendor=GenuineIntel'/>
</qemu:commandline>
```

For now it is not possible to pass `-device` and `-smbios` at least, and I'm not sure about `-cpu` (at least `vendor` for it).

And here is my proposal, though I guess it is ugly (since I don't write in `ruby`)

Thanks,
Azat.