### PR TITLE
Always call provisioners logic for booted machines

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -67,8 +67,11 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
           b.use Call, IsRunning do |env, b2|
-            # If the VM is running, then our work here is done, exit
-            next if env[:result]
+            # If the VM is running, run the necessary provisioners
+            if env[:result]
+              b2.use action_provision
+              next
+            end
 
             b2.use Call, IsSuspended do |env2, b3|
               # if vm is suspended resume it then exit


### PR DESCRIPTION
Allows `vagrant up` command to handle whether or not to run the
provisioners should the machine already be up. This allows re-running
certain provisioners in parallel using:

  vagrant up --provision --provision-with puppet_server

Which in turn allows for certain scripts that are bootstrap related
only to be skipped.

In general however it is better to let the middleware from vagrant
decided whether provisioners should run or not, as enhancements to that
functionality will then be automatically picked up.

With this change if a user runs `vagrant up` on already running
machines, without the `--provision` option they will be greeted with a
message from vagrant stating "Machine already provisioned. Run ...",
basically letting them know what to do next.

Without this change you simply see a message about "Bringing machine
'<name>' up with 'libvirt' provider..." and then nothing further.

Change-Id: I73ca4262abaa6431a838e4cf6468c06223643dea