### PR TITLE
Use json format when calling qemu-img

### DIFF
--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -40,7 +40,8 @@ module VagrantPlugins
           # working for centos with lvs default disks
           `virt-sysprep --no-logfile --operations defaults,-ssh-userdir -a #{@tmp_img}`
           Dir.chdir(@tmp_dir)
-          img_size = `qemu-img info #{@tmp_img} | grep 'virtual size' | awk '{print $3;}' | tr -d 'G'`.chomp
+          info = JSON.parse(`qemu-img info --output=json #{@tmp_img}`)
+          img_size = (Float(info['virtual-size'])/(1024**3)).ceil
           File.write(@tmp_dir + '/metadata.json', metadata_content(img_size))
           File.write(@tmp_dir + '/Vagrantfile', vagrantfile_content)
           assebmle_box(boxname)

--- a/tools/create_box.sh
+++ b/tools/create_box.sh
@@ -88,7 +88,7 @@ cd "$TMP_DIR"
 #Using the awk int function here to truncate the virtual image size to an
 #integer since the fog-libvirt library does not seem to properly handle
 #floating point.
-IMG_SIZE=$(qemu-img info "$TMP_IMG" | awk '/virtual size/{print int($3)+1;}' | tr -d 'G')
+IMG_SIZE=$(qemu-img info --output=json "$TMP_IMG" | awk '/virtual-size/{s=int($2)/(1024^3); print (s == int(s)) ? s : int(s)+1 }')
 
 echo "{$IMG_SIZE}"
 


### PR DESCRIPTION
Switch from using the default human readable format to request the json
format from qemu-img as this will provide disk sizes in bytes.

This avoids assuming that the returned size is in GigaBytes.

Fixes #743