### PR TITLE
Bring up management network if it's not started yet

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -76,6 +76,7 @@ module VagrantPlugins
             b2.use Call, IsSuspended do |env2, b3|
               # if vm is suspended resume it then exit
               if env2[:result]
+                b3.use CreateNetworks
                 b3.use ResumeDomain
                 next
               end
@@ -127,6 +128,7 @@ module VagrantPlugins
             end
 
             b2.use Call, IsSuspended do |env2, b3|
+              b3.use CreateNetworks if env2[:result]
               b3.use ResumeDomain if env2[:result]
             end
 
@@ -272,6 +274,7 @@ module VagrantPlugins
                 b3.use MessageNotSuspended
                 next
               end
+              b3.use CreateNetworks
               b3.use ResumeDomain
             end
           end


### PR DESCRIPTION
If I suspend using managedsave suspend_mode, then reboot the hypervisor,
and try to resume the box, then it fails because the management network
is not started (of course unless it's configured to autostart, which is
not the default behaviour).

This patch makes vagrant to start (and even recreate) the management
network if it's down.

Fixes vagrant-libvirt/vagrant-libvirt#761