### PR TITLE
allow setting the URI from the environment

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -538,6 +538,15 @@ module VagrantPlugins
       end
 
       def finalize!
+        @uri = ENV['VAGRANT_LIBVIRT_URI'] if (@uri == UNSET_VALUE && ENV['VAGRANT_LIBVIRT_URI'])
+        if (@uri && @uri != UNSET_VALUE)
+          uri = URI(@uri)
+          @driver = u.scheme.sub('+ssh','') if @driver == UNSET_VALUE
+          @host = uri.host if @host == UNSET_VALUE
+          @connect_via_ssh = uri.scheme.include?("+ssh") if @connect_via_ssh == UNSET_VALUE
+          @username = uri.user if @username == UNSET_VALUE
+          @password = uri.password if @password == UNSET_VALUE
+        end
         @driver = 'kvm' if @driver == UNSET_VALUE
         @host = nil if @host == UNSET_VALUE
         @connect_via_ssh = false if @connect_via_ssh == UNSET_VALUE


### PR DESCRIPTION
this allows running vagrant-libvirt against a remote libvirt without modifying the Vagrantfile.

example:
  VAGRANT_LIBVIRT_URI="qemu+ssh://user@192.0.2.1/system" vagrant up

this basically behaves as libvirt's own LIBVIRT_DEFAULT_URI

the patch also automates setting `connect_via_ssh` if the URI contains `+ssh://`

Fixes: #763