### PR TITLE
fog-core 1.44.0 depends on xmlrpc, which depends on Vagrant-incompatible ruby version

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fog-libvirt', '0.0.3'
   gem.add_runtime_dependency 'nokogiri', '~> 1.6.0'
+  gem.add_runtime_dependency 'fog-core', '~> 1.43.0'
 
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
The `fog-core` gem v1.44.0 now depends on `xmlrpc`: https://rubygems.org/gems/fog-core/versions/1.44.0

The version of ruby installed with Vagrant isn't compatible:
```
$ vagrant plugin install vagrant-libvirt --plugin-version 0.0.35
Installing the 'vagrant-libvirt --version '0.0.35'' plugin. This can take a few minutes...
Bundler, the underlying system Vagrant uses to install plugins,
reported an error. The error is shown below. These errors are usually
caused by misconfigured plugin installations or transient network
issues. The error from Bundler is:

xmlrpc requires Ruby version >= 2.3.
```
This patch adds a single line holding the version of `fog-core` back at version 1.43.0, which lacks the `xmlrpc` dependency: https://rubygems.org/gems/fog-core/versions/1.43.0