### PR TITLE
Invalid variable, qargs since the last change

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -280,10 +280,10 @@ module VagrantPlugins
             env[:ui].info(" -- smartcard device:  mode=#{@smartcard_dev[:mode]}, type=#{@smartcard_dev[:type]}")
           end
 
-          @qargs = config.qemu_args
-          if not @qargs.empty?
+          @qemu_args = config.qemu_args
+          if not @qemu_args.empty?
             env[:ui].info(' -- Command line args: ')
-            @qargs.each do |arg|
+            @qemu_args.each do |arg|
               msg = "    -> value=#{arg[:value]}, "
               env[:ui].info(msg)
             end

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -219,9 +219,9 @@
     <% end -%>
   </devices>
 
-  <% unless @qargs.empty? %>
+  <% unless @qemu_args.empty? %>
   <qemu:commandline>
-    <% @qargs.each do |arg| %>
+    <% @qemu_args.each do |arg| %>
     <qemu:arg value='<%= arg[:value] %>'/>
     <% end %>
   </qemu:commandline>


### PR DESCRIPTION
Test is broken due to qargs variable which is invalid since the last change below.
https://github.com/vagrant-libvirt/vagrant-libvirt/commit/5696ac8da648152db15e780315a3b66714e705eb


Test result
```
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
.....................FF

Failures:

  1) templates/domain when only defaults used renders template
     Failure/Error: expect(domain.to_xml('domain')).to eq xml_expected
     NoMethodError:
       undefined method `empty?' for nil:NilClass
     # (erubis:222:in `to_xml'
     # ./lib/vagrant-libvirt/util/erb_template.rb:17:in `to_xml'
     # ./spec/unit/templates/domain_spec.rb:20:in `block (3 levels) in <top (required)>'

  2) templates/domain when all settings enabled renders template
     Failure/Error: expect(domain.to_xml('domain')).to eq xml_expected
     NoMethodError:
       undefined method `empty?' for nil:NilClass
     # (erubis:222:in `to_xml'
     # ./lib/vagrant-libvirt/util/erb_template.rb:17:in `to_xml'
     # ./spec/unit/templates/domain_spec.rb:72:in `block (3 levels) in <top (required)>'

Finished in 0.79264 seconds
23 examples, 2 failures

Failed examples:

rspec ./spec/unit/templates/domain_spec.rb:18 # templates/domain when only defaults used renders template
rspec ./spec/unit/templates/domain_spec.rb:70 # templates/domain when all settings enabled renders template
[Coveralls] Outside the Travis environment, not sending data.
```
