### PR TITLE
Making adapter exhaustion error message more helpful.

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -76,8 +76,7 @@ en:
       no_domain_volume: |-
         Volume for domain is missing. Try to run 'vagrant up' again.
       interface_slot_not_available: |-
-        Interface adapter number is already in use. Please specify other adapter
-        number.
+        Available interface adapters have been exhausted. Please increase the nic_adapter_count.
       rsync_error: |-
         There was an error when attempting to rsync a share folder.
         Please inspect the error message below for more info.


### PR DESCRIPTION
Consistently forget what this error message means. Trying to make it more useful to others who hit this. I'm using between 130-150 interfaces to simulate network switches and so I hit this error more often.