### PR TITLE
Reverts PR#777 and adds a new error message for a different case

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -53,7 +53,7 @@ module VagrantPlugins
             else
               free_slot = find_empty(adapters)
               @logger.debug "Adapter not specified so found slot #{free_slot}"
-              raise Errors::InterfaceSlotNotAvailable if free_slot.nil?
+              raise Errors::InterfaceSlotExhausted if free_slot.nil?
             end
 
             # We have slot for interface, fill it with interface configuration.

--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -117,6 +117,10 @@ module VagrantPlugins
         error_key(:interface_slot_not_available)
       end
 
+      class InterfaceSlotExhausted < VagrantLibvirtError
+        error_key(:interface_slot_exhausted)
+      end
+
       class RsyncError < VagrantLibvirtError
         error_key(:rsync_error)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -76,6 +76,8 @@ en:
       no_domain_volume: |-
         Volume for domain is missing. Try to run 'vagrant up' again.
       interface_slot_not_available: |-
+        Interface adapter number is already in use. Please specify other adapter number.
+      interface_slot_exhausted: |-
         Available interface adapters have been exhausted. Please increase the nic_adapter_count.
       rsync_error: |-
         There was an error when attempting to rsync a share folder.


### PR DESCRIPTION
This PR captures commentary from @electrofelix in #777  about creating a new error message that accurately represents the exhausted slot state instead of re-using another error message inappropriately.