### PR TITLE
Remove NFS exports on domain destroy

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -187,7 +187,7 @@ module VagrantPlugins
             b2.use Call, DestroyConfirm do |env2, b3|
               if env2[:result]
                 b3.use ClearForwardedPorts
-                # b3.use PruneNFSExports
+                b3.use PruneNFSExports
                 b3.use DestroyDomain
                 b3.use DestroyNetworks
                 b3.use ProvisionerCleanup

--- a/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
   module ProviderLibvirt
     module Action
       class PrepareNFSSettings
-        include Vagrant::Action::Builtin::MixinSyncedFolders
+        include VagrantPlugins::ProviderLibvirt::Util::Nfs
 
         def initialize(app, _env)
           @app = app
@@ -26,13 +26,6 @@ module VagrantPlugins
 
             raise Vagrant::Errors::NFSNoHostonlyNetwork if !env[:nfs_machine_ip] || !env[:nfs_host_ip]
           end
-        end
-
-        # We're using NFS if we have any synced folder with NFS configured. If
-        # we are not using NFS we don't need to do the extra work to
-        # populate these fields in the environment.
-        def using_nfs?
-          !!synced_folders(@machine)[:nfs]
         end
 
         # Returns the IP address of the host

--- a/lib/vagrant-libvirt/action/prune_nfs_exports.rb
+++ b/lib/vagrant-libvirt/action/prune_nfs_exports.rb
@@ -3,20 +3,27 @@ module VagrantPlugins
   module ProviderLibvirt
     module Action
       class PruneNFSExports
+        include VagrantPlugins::ProviderLibvirt::Util::Nfs
+
         def initialize(app, _env)
           @app = app
         end
 
         def call(env)
-          if env[:host]
-            uuid = env[:machine].id
-            # get all uuids
-            uuids = env[:machine].provider.driver.connection.servers.all.map(&:id)
-            # not exiisted in array will removed from nfs
-            uuids.delete(uuid)
-            env[:host].capability(
-              :nfs_prune, env[:machine].ui, uuids
-            )
+	  @machine = env[:machine]
+
+	  if using_nfs?
+            @logger.info('Using NFS, prunning NFS settings from host')
+	    if env[:host]
+              uuid = env[:machine].id
+              # get all uuids
+              uuids = env[:machine].provider.driver.connection.servers.all.map(&:id)
+              # not exiisted in array will removed from nfs
+              uuids.delete(uuid)
+              env[:host].capability(
+                :nfs_prune, env[:machine].ui, uuids
+              )
+            end
           end
 
           @app.call(env)

--- a/lib/vagrant-libvirt/util/nfs.rb
+++ b/lib/vagrant-libvirt/util/nfs.rb
@@ -1,0 +1,17 @@
+module VagrantPlugins
+  module ProviderLibvirt
+    module Util
+      module Nfs
+        include Vagrant::Action::Builtin::MixinSyncedFolders
+
+        # We're using NFS if we have any synced folder with NFS configured. If
+        # we are not using NFS we don't need to do the extra work to
+        # populate these fields in the environment.
+        def using_nfs?
+          !!synced_folders(@machine)[:nfs]
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
When using vagrant with the default virtualbox provider, NFS exports are removed as guests are destroyed. With the libvirt provider, NFS exports are left in `/etc/exports` following a destroy. They are only removed if a `vagrant up` operation subsequently takes place using the libvirt provider.

This leaves the host machine exporting the local filesystem to the IP(s) used previously by the libvirt domains. I think this behaviour is undesirable and potentially a security risk as those IP(s) may now be used for other purposes.

This PR duplicates the existing code used during NFS pruning on a `vagrant up` and places it in the `DestroyDomain` class. NFS exports will therefore be removed as domains are destroyed. I suggest we also leave the existing NFS pruning code in-place to catch any situations where vagrant/libvirt fails during the destroy steps.