### PR TITLE
Accept network interface MAC addresses without colon delimiters

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -674,8 +674,14 @@ module VagrantPlugins
         end
 
         machine.config.vm.networks.each do |_type, opts|
-          if opts[:mac] && opts[:mac].downcase! && !(opts[:mac] =~ /\A([0-9a-f]{2}:){5}([0-9a-f]{2})\z/)
-            errors << "Configured NIC MAC '#{opts[:mac]}' is not in 'xx:xx:xx:xx:xx:xx' format"
+          if opts[:mac]
+            opts[:mac].downcase!
+            if opts[:mac] =~ /\A([0-9a-f]{12})\z/
+              opts[:mac] = opts[:mac].scan(/../).join(':')
+            end
+            unless opts[:mac] =~ /\A([0-9a-f]{2}:){5}([0-9a-f]{2})\z/
+              errors << "Configured NIC MAC '#{opts[:mac]}' is not in 'xx:xx:xx:xx:xx:xx' or 'xxxxxxxxxxxx' format"
+            end
           end
         end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -44,8 +44,15 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         assert_valid
       end
 
+      it 'is valid with MAC containing no delimiters' do
+        network = [:public, { mac: 'aabbccddeeff' }]
+        expect(vm).to receive(:networks).and_return([network])
+        assert_valid
+        expect(network[1][:mac]).to eql('aa:bb:cc:dd:ee:ff')
+      end
+
       it 'should be invalid if MAC not formatted correctly' do
-        expect(vm).to receive(:networks).and_return([[:public, { mac: 'aabbccddeeff' }]])
+        expect(vm).to receive(:networks).and_return([[:public, { mac: 'aa/bb/cc/dd/ee/ff' }]])
         assert_invalid
       end
     end


### PR DESCRIPTION
Allows the format originally given in #638 to work, as it's used in other Vagrant providers so makes vagrant-libvirt compatible with tools that write out Vagrantfiles.

First commit also fixes an issue with the config validation specs that meant it wasn't picking up validation errors, so they passed without actually logging validation errors.