### PR TITLE
Fix failing domain tests due to missing property

### DIFF
--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -8,6 +8,11 @@ describe 'templates/domain' do
 
   class DomainTemplateHelper < VagrantPlugins::ProviderLibvirt::Config
     include VagrantPlugins::ProviderLibvirt::Util::ErbTemplate
+
+    def finalize!
+      super
+      @qargs = @qemu_args
+    end
   end
 
   let(:domain) { DomainTemplateHelper.new }


### PR DESCRIPTION
Changes in names of data being passed through from the config object to
the CreateDomain action means that to test the domain xml template,
need to add an additional variable of qargs when testing.