### PR TITLE
Do not destroy domain when starting existing domain

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -54,6 +54,7 @@ module VagrantPlugins
                 # b2.use SyncFolders
               end
             else
+              env[:halt_on_error] = true
               b2.use action_start
             end
           end

--- a/lib/vagrant-libvirt/action/wait_till_up.rb
+++ b/lib/vagrant-libvirt/action/wait_till_up.rb
@@ -89,11 +89,18 @@ module VagrantPlugins
             # If we're not supposed to destroy on error then just return
             return unless env[:destroy_on_error]
 
-            destroy_env = env.dup
-            destroy_env.delete(:interrupted)
-            destroy_env[:config_validate] = false
-            destroy_env[:force_confirm_destroy] = true
-            env[:action_runner].run(Action.action_destroy, destroy_env)
+            if env[:halt_on_error]
+              halt_env = env.dup
+              halt_env.delete(:interrupted)
+              halt_env[:config_validate] = false
+              env[:action_runner].run(Action.action_halt, halt_env)
+            else
+              destroy_env = env.dup
+              destroy_env.delete(:interrupted)
+              destroy_env[:config_validate] = false
+              destroy_env[:force_confirm_destroy] = true
+              env[:action_runner].run(Action.action_destroy, destroy_env)
+            end
           end
         end
       end


### PR DESCRIPTION
WaitTillUp is re-used in action_start but failures (and interruptions)
during action_start are not expected to cause domain destruction:
do halt instead of destroy in WaitTillUp if called from action_start