### PR TITLE
Feature/numa nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ end
 * `cpu_fallback` - Whether to allow libvirt to fall back to a CPU model close
   to the specified model if features in the guest CPU are not supported on the
   host. Defaults to 'allow' if not set. Allowed values: `allow`, `forbid`.
-* `numa_nodes` - Specify an array of NUMA nodes for the guest. The syntax is similar to what would be set in the domain XML. `memory` must be in MB. Symmetrical and asymmetrical topologies are supported but ake sure your total count of defined CPUs adds up to v.cpus. 
+* `numa_nodes` - Specify an array of NUMA nodes for the guest. The syntax is similar to what would be set in the domain XML. `memory` must be in MB. Symmetrical and asymmetrical topologies are supported but make sure your total count of defined CPUs adds up to v.cpus. 
 
   The sum of all the memory defined here will act as your total memory for your guest VM. **This sum will override what is set in `v.memory`**
   ```

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ end
 * `cpu_fallback` - Whether to allow libvirt to fall back to a CPU model close
   to the specified model if features in the guest CPU are not supported on the
   host. Defaults to 'allow' if not set. Allowed values: `allow`, `forbid`.
-* `numa_nodes` - Specify an array of NUMA nodes for the guest. The syntax is similar to what would be set in the domain XML. `memory` must be in MB. Symmetrical and asymmetrical topologies are supported but make sure your total count of defined CPUs adds up to v.cpus. 
+* `numa_nodes` - Specify an array of NUMA nodes for the guest. The syntax is similar to what would be set in the domain XML. `memory` must be in MB. Symmetrical and asymmetrical topologies are supported but make sure your total count of defined CPUs adds up to `v.cpus`. 
 
   The sum of all the memory defined here will act as your total memory for your guest VM. **This sum will override what is set in `v.memory`**
   ```

--- a/README.md
+++ b/README.md
@@ -300,7 +300,15 @@ end
 * `cpu_fallback` - Whether to allow libvirt to fall back to a CPU model close
   to the specified model if features in the guest CPU are not supported on the
   host. Defaults to 'allow' if not set. Allowed values: `allow`, `forbid`.
-* `numa_nodes` - Number of NUMA nodes on guest. Must be a factor of `cpu`.
+* `numa_nodes` - Specify an array of NUMA nodes for the guest. The syntax is similar to what would be set in the domain XML. `memory` must be in MB. Symmetrical and asymmetrical topologies are supported but ake sure your total count of defined CPUs adds up to v.cpus. 
+
+  The sum of all the memory defined here will act as your total memory for your guest VM. **This sum will override what is set in `v.memory`**
+  ```
+  v.numa_nodes = [
+    {:id => 0, :cpus => "0-1", :memory => "1024"},
+    {:id => 1, :cpus => "2-3", :memory => "4096"}
+  ] 
+  ```
 * `loader` - Sets path to custom UEFI loader.
 * `volume_cache` - Controls the cache mechanism. Possible values are "default",
   "none", "writethrough", "writeback", "directsync" and "unsafe". [See

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ end
 
   The sum of all the memory defined here will act as your total memory for your guest VM. **This sum will override what is set in `v.memory`**
   ```
+  v.cpus = 4
   v.numa_nodes = [
     {:id => 0, :cpus => "0-1", :memory => "1024"},
     {:id => 1, :cpus => "2-3", :memory => "4096"}

--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ end
   ```
   v.cpus = 4
   v.numa_nodes = [
-    {:id => 0, :cpus => "0-1", :memory => "1024"},
-    {:id => 1, :cpus => "2-3", :memory => "4096"}
+    {:cpus => "0-1", :memory => "1024"},
+    {:cpus => "2-3", :memory => "4096"}
   ] 
   ```
 * `loader` - Sets path to custom UEFI loader.

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -128,6 +128,13 @@ module VagrantPlugins
                     cpu.delete_element(svm_feature)
                   end
                 end
+              elsif config.numa_nodes == nil
+                unless cpu.elements.to_a.empty?
+                  descr_changed = true
+                  cpu.elements.each do |elem|
+                    cpu.delete_element(elem)
+                  end
+                end
               end
 
               # Graphics

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -279,8 +279,22 @@ module VagrantPlugins
       end
 
       def _generate_numa
-        # todo: compare count of NUMA defined CPUs and throw warning
-        # if config.cpu != NUMA.cpu
+        # Perform some validation of cpu values
+        @numa_nodes.each { |x|
+          unless x[:cpus] =~ /^\d+-\d+$/
+            raise 'numa_nodes[:cpus] must be in format "integer-integer"'
+          end
+        }
+        
+        # Grab the value of the last @numa_nodes[:cpus] and verify @cpus matches
+        # Note: [:cpus] is zero based and @cpus is not, so we need to +1
+        last_cpu = @numa_nodes.last[:cpus]
+        last_cpu = last_cpu.scan(/\d+$/)[0]
+        last_cpu = last_cpu.to_i + 1
+
+        if @cpus != last_cpu.to_i
+          raise 'The total number of numa_nodes[:cpus] must equal config.cpus'
+        end
 
         @numa_nodes.collect { |x| x[:memory] = x[:memory].to_i * 1024 }
 

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -279,13 +279,16 @@ module VagrantPlugins
       end
 
       def _generate_numa
-        # Perform some validation of cpu values
-        @numa_nodes.each { |x|
+        @numa_nodes.collect { |x|
+          # Perform some validation of cpu values
           unless x[:cpus] =~ /^\d+-\d+$/
             raise 'numa_nodes[:cpus] must be in format "integer-integer"'
           end
+
+          # Convert to KiB
+          x[:memory] = x[:memory].to_i * 1024
         }
-        
+
         # Grab the value of the last @numa_nodes[:cpus] and verify @cpus matches
         # Note: [:cpus] is zero based and @cpus is not, so we need to +1
         last_cpu = @numa_nodes.last[:cpus]
@@ -295,8 +298,6 @@ module VagrantPlugins
         if @cpus != last_cpu.to_i
           raise 'The total number of numa_nodes[:cpus] must equal config.cpus'
         end
-
-        @numa_nodes.collect { |x| x[:memory] = x[:memory].to_i * 1024 }
 
         @numa_nodes
       end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -279,26 +279,12 @@ module VagrantPlugins
       end
 
       def _generate_numa
-        raise 'NUMA nodes must be a factor of CPUs' if @cpus % @numa_nodes != 0
+        # todo: compare count of NUMA defined CPUs and throw warning
+        # if config.cpu != NUMA.cpu
 
-        if @memory % @numa_nodes != 0
-          raise 'NUMA nodes must be a factor of memory'
-        end
+        @numa_nodes.collect { |x| x[:memory] = x[:memory].to_i * 1024 }
 
-        numa = []
-
-        (1..@numa_nodes).each do |node|
-          numa_cpu_start = (@cpus / @numa_nodes) * (node - 1)
-          numa_cpu_end = (@cpus / @numa_nodes) * node - 1
-          numa_cpu = Array(numa_cpu_start..numa_cpu_end).join(',')
-          numa_mem = @memory / @numa_nodes
-
-          numa.push(id: node,
-                    cpu: numa_cpu,
-                    mem: numa_mem)
-        end
-
-        @numa_nodes = numa
+        @numa_nodes
       end
 
       def cpu_feature(options = {})

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -18,8 +18,8 @@
     <% end %>
     <% if @numa_nodes %>
       <numa>
-        <% @numa_nodes.each do |node| %>
-          <cell id='<%= node[:id] %>' cpus='<%= node[:cpus] %>' memory='<%= node[:memory] %>'/>
+        <% @numa_nodes.each_with_index do |node, index| %>
+          <cell id='<%= index %>' cpus='<%= node[:cpus] %>' memory='<%= node[:memory] %>'/>
         <% end %>
       </numa>
     <% end %>

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -15,14 +15,13 @@
       <% @cpu_features.each do |cpu_feature| %>
         <feature name='<%= cpu_feature[:name] %>' policy='<%= cpu_feature[:policy] %>'/>
       <% end %>
-    <% else %>
-      <% if @numa_nodes %>
-        <numa>
-          <% @numa_nodes.each do |node| %>
-            <cell id='<%= node[:id] %>' cpus='<%= node[:cpu] %>' memory='<%= node[:mem] %>'/>
-          <% end %>
-        </numa>
-      <% end %>
+    <% end %>
+    <% if @numa_nodes %>
+      <numa>
+        <% @numa_nodes.each do |node| %>
+          <cell id='<%= node[:id] %>' cpus='<%= node[:cpus] %>' memory='<%= node[:memory] %>'/>
+        <% end %>
+      </numa>
     <% end %>
   </cpu>
 


### PR DESCRIPTION
This refactors and fixes the numa_nodes domain option. 

It also allows for more flexibility when defining NUMA nodes, as asymmetrical topologies are now supported. 

Note the removal of lines 127-133 in `start_domain.xml`. These lines worked to remove all nested XML  objects within `<cpu></cpu>` if `cpu_mode` was set to `host-passthrough`. This doesn't make sense, as we may still want to define NUMA nodes here. 