### PR TITLE
Use socat instead of netcat to forward ssh when using `connect_via_ssh`

### DIFF
--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -73,7 +73,7 @@ module VagrantPlugins
             "ssh '#{@machine.provider_config.host}' " \
             "-l '#{@machine.provider_config.username}' " \
             "-i '#{@machine.provider_config.id_ssh_key_file}' " \
-            'nc %h %p'
+            "socat STDIO TCP:%h:%p,retry=5,interval=5"
 
         end
 


### PR DESCRIPTION
Due to the fact that some distributions use nmap's version of netcat and
some use OpenBSD's version of netcat, there should be a more standard
choice of doing this.

Additionally, sometimes some guests (mainly saw this with OpenBSD) take
a moment to spin up sshd, which causes nmap's netcat to report either
connection refused or broken pipe, which makes `vagrant up` fail.

```
==> openbsd61: Creating shared folders metadata...
==> openbsd61: Starting domain.
==> openbsd60: Waiting for domain to get an IP address...
==> openbsd61: Waiting for domain to get an IP address...
==> openbsd60: Waiting for SSH to become available...
==> openbsd61: Waiting for SSH to become available...
Ncat: Connection refused.
Ncat: Connection refused.
==> openbsd60: Removing domain...
==> openbsd60: An error occurred. The error will be shown after all tasks complete.
==> openbsd61: Removing domain...
==> openbsd61: An error occurred. The error will be shown after all tasks complete.
An error occurred while executing multiple actions in parallel.
Any errors that occurred are shown below.

An unexpected error occurred when executing the action on the
'openbsd60' machine. Please report this as a bug:

Broken pipe
```