### PR TITLE
update to the recent changes of default behavior in netcat.openbsd (fixes #796)

### DIFF
--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -73,7 +73,7 @@ module VagrantPlugins
             "ssh '#{@machine.provider_config.host}' " \
             "-l '#{@machine.provider_config.username}' " \
             "-i '#{@machine.provider_config.id_ssh_key_file}' " \
-            'nc %h %p'
+            'nc -q0 %h %p'
 
         end
 


### PR DESCRIPTION
netcat.openbsd, mostly used on libvirt servers (libvirt debian daemon
depends on netcat.openbsd) has changed (revision 1.111)
it's default behavior - it no more closes connection when stdin closes
by default. They suggest using "-N" flag for turning on former
behavior, but looks like "-q0", which is common with earlier versions
and netcat.traditional, will also work.