### PR TITLE
Add mtu option for private networks and interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,9 @@ starts with `libvirt__` string. Here is a list of those options:
   failures](https://github.com/vagrant-libvirt/vagrant-libvirt/pull/498)
 * `:mac` - MAC address for the interface. *Note: specify this in lowercase
   since Vagrant network scripts assume it will be!*
+* `:libvirt__mtu` - MTU size for the libvirt network, if not defined, the
+  created network will use the libvirt default (1500). VMs still need to set the
+  MTU accordingly.
 * `:model_type` - parameter specifies the model of the network adapter when you
   create a domain value by default virtio KVM believe possible values, see the
   documentation for libvirt

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -76,6 +76,7 @@ module VagrantPlugins
             @driver_name = iface_configuration.fetch(:driver_name, false)
             @driver_queues = iface_configuration.fetch(:driver_queues, false)
             @device_name = iface_configuration.fetch(:iface_name, false)
+            @mtu = iface_configuration.fetch(:mtu, nil)
             template_name = 'interface'
             # Configuration for public interfaces which use the macvtap driver
             if iface_configuration[:iface_type] == :public_network
@@ -143,6 +144,7 @@ module VagrantPlugins
                                     @device_name,
                                     @iface_number,
                                     @model_type,
+                                    @mtu,
                                     driver_options,
                                     @udp_tunnel)
                     else
@@ -234,7 +236,7 @@ module VagrantPlugins
         end
 
         def interface_xml(type, source_options, mac, device_name,
-                          iface_number, model_type, driver_options,
+                          iface_number, model_type, mtu, driver_options,
                           udp_tunnel={})
           Nokogiri::XML::Builder.new do |xml|
             xml.interface(type: type || 'network') do
@@ -245,6 +247,7 @@ module VagrantPlugins
               xml.target(dev: target_dev_name(device_name, type, iface_number))
               xml.alias(name: "net#{iface_number}")
               xml.model(type: model_type.to_s)
+              xml.mtu(size: mtu) if mtu
               xml.driver(driver_options)
             end
           end.to_xml(

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -247,7 +247,7 @@ module VagrantPlugins
               xml.target(dev: target_dev_name(device_name, type, iface_number))
               xml.alias(name: "net#{iface_number}")
               xml.model(type: model_type.to_s)
-              xml.mtu(size: mtu) if mtu
+              xml.mtu(size: Integer(mtu)) if mtu
               xml.driver(driver_options)
             end
           end.to_xml(

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -286,6 +286,8 @@ module VagrantPlugins
           @network_bridge_name = @interface_network[:bridge_name]
           @network_address = @interface_network[:ip_address]
           @network_netmask = @interface_network[:netmask]
+          @network_mtu = @options[:mtu]
+
           @guest_ipv6 = @interface_network[:guest_ipv6]
 
           @network_ipv6_address = @interface_network[:ipv6_address]

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -286,7 +286,7 @@ module VagrantPlugins
           @network_bridge_name = @interface_network[:bridge_name]
           @network_address = @interface_network[:ip_address]
           @network_netmask = @interface_network[:netmask]
-          @network_mtu = @options[:mtu]
+          @network_mtu = Integer(@options[:mtu]) if @options[:mtu]
 
           @guest_ipv6 = @interface_network[:guest_ipv6]
 

--- a/lib/vagrant-libvirt/templates/private_network.xml.erb
+++ b/lib/vagrant-libvirt/templates/private_network.xml.erb
@@ -6,7 +6,7 @@
     <domain name="<%= @network_domain_name %>" localOnly="yes" />
   <% end %>
 
-  <% if !@network_mtu.nil? %>
+  <% if @network_mtu %>
   <mtu size="<%= @network_mtu %>" />
   <% end %>
 

--- a/lib/vagrant-libvirt/templates/private_network.xml.erb
+++ b/lib/vagrant-libvirt/templates/private_network.xml.erb
@@ -6,6 +6,10 @@
     <domain name="<%= @network_domain_name %>" localOnly="yes" />
   <% end %>
 
+  <% if !@network_mtu.nil? %>
+  <mtu size="<%= @network_mtu %>" />
+  <% end %>
+
   <% if (@network_forward_mode != 'none' && @network_forward_mode != 'veryisolated') %>
     <% if @network_forward_device %>
       <forward mode="<%= @network_forward_mode %>" dev="<%= @network_forward_device %>" />


### PR DESCRIPTION
In order to create virtual networks with different MTU sizes
than the libvirt default of 1500, this patch adds a
libvirt__mtu option. This will add an mtu option to the libvirt
network definition and to the domain interface definition as well.

However, the MTU only comes into effect, if the interface on the vm was configured correctly.