### PR TITLE
Ask for confirmation before destroying vms

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -183,11 +183,17 @@ module VagrantPlugins
               next
             end
 
-            b2.use ClearForwardedPorts
-            # b2.use PruneNFSExports
-            b2.use DestroyDomain
-            b2.use DestroyNetworks
-            b2.use ProvisionerCleanup
+            b2.use Call, DestroyConfirm do |env2, b3|
+              if env2[:result]
+                b3.use ClearForwardedPorts
+                # b3.use PruneNFSExports
+                b3.use DestroyDomain
+                b3.use DestroyNetworks
+                b3.use ProvisionerCleanup
+              else
+                b3.use MessageWillNotDestroy
+              end
+            end
           end
         end
       end
@@ -332,6 +338,7 @@ module VagrantPlugins
       autoload :MessageNotCreated, action_root.join('message_not_created')
       autoload :MessageNotRunning, action_root.join('message_not_running')
       autoload :MessageNotSuspended, action_root.join('message_not_suspended')
+      autoload :MessageWillNotDestroy, action_root.join('message_will_not_destroy')
 
       autoload :RemoveStaleVolume, action_root.join('remove_stale_volume')
 

--- a/lib/vagrant-libvirt/action/message_will_not_destroy.rb
+++ b/lib/vagrant-libvirt/action/message_will_not_destroy.rb
@@ -1,0 +1,17 @@
+module VagrantPlugins
+  module ProviderLibvirt
+    module Action
+      class MessageWillNotDestroy
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info I18n.t("vagrant.commands.destroy.will_not_destroy",
+                              name: env[:machine].name)
+          @app.call(env)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Unify behavior across providers by asking for confirmation before
deleting virtual machines with potentially valuable data.

Before destroying a vm the following message is presented:
`demo: Are you sure you want to destroy the 'demo' VM? [y/N]`
An additional --force flag provided by upstream vagrant allows skipping
the `vagrant destroy demo -f`

Practically all other providers available ask the user for confirmation
before deleting the vm.

Vagrant official providers:
https://github.com/hashicorp/vagrant/blob/master/plugins/providers/docker/action.rb#L156
https://github.com/hashicorp/vagrant/blob/master/plugins/providers/hyperv/action.rb#L34
https://github.com/hashicorp/vagrant/blob/master/plugins/providers/virtualbox/action.rb#L100

Third party providers:
https://github.com/mitchellh/vagrant-aws/blob/master/lib/vagrant-aws/action.rb#L45
https://github.com/Azure/vagrant-azure/blob/v2.0/lib/vagrant-azure/action.rb#L34
https://github.com/jesa7955/vagrant-bhyve/blob/master/lib/vagrant-bhyve/action.rb#L156
https://github.com/NeilW/vagrant-brightbox/blob/master/lib/vagrant-brightbox/action.rb#L44
https://github.com/devopsgroup-io/vagrant-digitalocean/blob/master/lib/vagrant-digitalocean/actions.rb#L27
https://github.com/fgrehm/vagrant-lxc/blob/master/lib/vagrant-lxc/action.rb#L148
https://github.com/Parallels/vagrant-parallels/blob/master/lib/vagrant-parallels/action.rb#L48