### PR TITLE
Add memory backing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,24 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+## Memory Backing
+
+You can specify memoryBacking options via `libvirt.memorybacking`. Available options are shown below. Full documentation is available at the [libvirt _memoryBacking_ section](https://libvirt.org/formatdomain.html#elementsMemoryBacking).
+
+NOTE: The hugepages `<page>` element is not yet supported
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memorybacking :hugepages
+    libvirt.memorybacking :nosharepages
+    libvirt.memorybacking :locked
+    libvirt.memorybacking :source, :type => 'file'
+    libvirt.memorybacking :access, :mode => 'shared'
+    libvirt.memorybacking :allocation, :mode => 'immediate'
+  end
+end
+```
 ## USB device passthrough
 
 You can specify multiple USB devices to passthrough to the VM via

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -46,6 +46,7 @@ module VagrantPlugins
           @disk_device = config.disk_device
           @nested = config.nested
           @memory_size = config.memory.to_i * 1024
+          @memory_backing = config.memory_backing
           @management_network_mac = config.management_network_mac
           @domain_volume_cache = config.volume_cache
           @kernel = config.kernel
@@ -182,6 +183,9 @@ module VagrantPlugins
             env[:ui].info(" -- Feature:           #{feature}")
           end
           env[:ui].info(" -- Memory:            #{@memory_size / 1024}M")
+          @memory_backing.each do |backing|
+            env[:ui].info(" -- Memory Backing:    #{backing[:name]}: #{backing[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')}")
+          end
           env[:ui].info(" -- Management MAC:    #{@management_network_mac}")
           env[:ui].info(" -- Loader:            #{@loader}")
           if env[:machine].config.vm.box

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -58,6 +58,7 @@ module VagrantPlugins
       # Domain specific settings used while creating new domain.
       attr_accessor :uuid
       attr_accessor :memory
+      attr_accessor :memory_backing
       attr_accessor :channel
       attr_accessor :cpus
       attr_accessor :cpu_mode
@@ -164,6 +165,7 @@ module VagrantPlugins
         # Domain specific settings.
         @uuid              = UNSET_VALUE
         @memory            = UNSET_VALUE
+        @memory_backing    = UNSET_VALUE
         @cpus              = UNSET_VALUE
         @cpu_mode          = UNSET_VALUE
         @cpu_model         = UNSET_VALUE
@@ -311,6 +313,21 @@ module VagrantPlugins
 
         @cpu_features.push(name:   options[:name],
                            policy: options[:policy])
+      end
+
+      def memorybacking(option, config = {})
+        case option
+        when :source
+          raise 'Source type must be specified' if config[:type].nil?
+        when :access
+          raise 'Access mode must be specified' if config[:mode].nil?
+        when :allocation
+          raise 'Allocation mode must be specified' if config[:mode].nil?
+        end
+
+        @memory_backing = [] if @memory_backing == UNSET_VALUE
+        @memory_backing.push(name: option,
+                             config: config)
       end
 
       def input(options = {})
@@ -569,6 +586,7 @@ module VagrantPlugins
         # Domain specific settings.
         @uuid = '' if @uuid == UNSET_VALUE
         @memory = 512 if @memory == UNSET_VALUE
+        @memory_backing = [] if @memory_backing == UNSET_VALUE
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
         @cpu_model = if (@cpu_model == UNSET_VALUE) && (@cpu_mode == 'custom')

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -25,6 +25,13 @@
     <% end %>
   </cpu>
 
+<% unless @memory_backing.empty? %>
+  <memoryBacking>
+  <% @memory_backing.each do |backing| %>
+    <<%= backing[:name] %> <%= backing[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')  %>/>
+  <% end %>
+  </memoryBacking>
+<% end%>
 
   <os>
     <% if @machine_type %>


### PR DESCRIPTION
I came across #776 when looking for hugepage support in this vagrant plugin and decided to implement that myself. 

This pull request gives users the ability to configure memoryBacking settings for their vagrant VM with a general form of:

```ruby
libvirt.memorybacking :Option, {Settings}
```

where `:Option` is one of 
* `:hugepages`
* `:nosharepages`
* `:locked`
* `:source`
* `:access`
* `:allocation`

and `Settings` is an Hash of settings and their values for the configured `:Option`. This Hash is only required for certain options as shown in the [libvirt documentation](https://libvirt.org/formatdomain.html#elementsMemoryBacking)

A full example is found in the README that is part of this request.

The `<page>` option under `<hugepages>` is not implemented as it does not seem to be a very common use case.