### PR TITLE
Fix for #831

### DIFF
--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -111,11 +111,16 @@
 
 <% @channels.each do |channel| %>
   <channel type='<%= channel[:type] %>' >
-      <source mode='<%= channel[:source_mode] %>'
+      <%if channel[:source_mode] or channel[:source_path] %>
+      <source
+          <% if channel[:source_mode] %>
+               mode='<%= channel[:source_mode] %>'
+          <% end %>
           <% if channel[:source_path] %>
                path="<%= channel[:source_path] %>"
           <% end %>
       />
+      <% end %>
       <target type='<%= channel[:target_type] %>'
           <% if channel[:target_name] %>
                name="<%= channel[:target_name] %>"

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -62,14 +62,17 @@
     </console>
 
   <channel type='unix' >
-      <source mode=''
-      />
       <target type='virtio'
                name="org.qemu.guest_agent.0"
       />
   </channel>
+  <channel type='spicevmc' >
+      <target type='virtio'
+               name="com.redhat.spice.0"
+      />
+  </channel>
   <channel type='unix' >
-      <source mode=''
+      <source
                path="/tmp/foo"
       />
       <target type='guestfwd'

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -52,6 +52,9 @@ describe 'templates/domain' do
       domain.channel(type: 'unix',
                      target_name: 'org.qemu.guest_agent.0',
                      target_type: 'virtio')
+      domain.channel(type: 'spicevmc',
+                     target_name: 'com.redhat.spice.0',
+                     target_type: 'virtio')
       domain.channel(type: 'unix',
                      target_type: 'guestfwd',
                      target_address: '192.0.2.42',


### PR DESCRIPTION
This patch-set should fix the issue with recent libvirt on Fedora 27.

I did not validate on older versions, but shouldn't do any harm as it removes the empty "mode=''" entries from the XML-definition which libvirt now is complaining about.