### PR TITLE
Add option to specify CPU topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,17 @@ end
   libvirt](https://libvirt.org/formatdomain.html#elementsNICSModel).
 * `memory` - Amount of memory in MBytes. Defaults to 512 if not set.
 * `cpus` - Number of virtual cpus. Defaults to 1 if not set.
+* `cputopology` - Number of CPU sockets, cores and threads running per core. All fields of `:sockets`, `:cores` and `:threads` are mandatory, `cpus` domain option must be present and must be equal to total count of **sockets * cores * threads**. For more details see [documentation](https://libvirt.org/formatdomain.html#elementsCPU).
+
+  ```ruby
+  Vagrant.configure("2") do |config|
+    config.vm.provider :libvirt do |libvirt|
+      libvirt.cpus = 4
+      libvirt.cputopology :sockets => '2', :cores => '2', :threads => '1'
+    end
+  end
+  ```
+
 * `nested` - [Enable nested
   virtualization](https://github.com/torvalds/linux/blob/master/Documentation/virtual/kvm/nested-vmx.txt).
   Default is false.

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
           @uuid = config.uuid
           @cpus = config.cpus.to_i
           @cpu_features = config.cpu_features
+          @cpu_topology = config.cpu_topology
           @features = config.features
           @cpu_mode = config.cpu_mode
           @cpu_model = config.cpu_model
@@ -176,6 +177,10 @@ module VagrantPlugins
           env[:ui].info(" -- Forced UUID:       #{@uuid}") if @uuid != ''
           env[:ui].info(" -- Domain type:       #{@domain_type}")
           env[:ui].info(" -- Cpus:              #{@cpus}")
+          if not @cpu_topology.empty?
+            env[:ui].info(" -- CPU topology:   sockets=#{@cpu_topology[:sockets]}, cores=#{@cpu_topology[:cores]}, threads=#{@cpu_topology[:threads]}")
+          end
+          env[:ui].info("")
           @cpu_features.each do |cpu_feature|
             env[:ui].info(" -- CPU Feature:       name=#{cpu_feature[:name]}, policy=#{cpu_feature[:policy]}")
           end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -65,6 +65,7 @@ module VagrantPlugins
       attr_accessor :cpu_model
       attr_accessor :cpu_fallback
       attr_accessor :cpu_features
+      attr_accessor :cpu_topology
       attr_accessor :features
       attr_accessor :numa_nodes
       attr_accessor :loader
@@ -171,6 +172,7 @@ module VagrantPlugins
         @cpu_model         = UNSET_VALUE
         @cpu_fallback      = UNSET_VALUE
         @cpu_features      = UNSET_VALUE
+        @cpu_topology      = UNSET_VALUE
         @features          = UNSET_VALUE
         @numa_nodes        = UNSET_VALUE
         @loader            = UNSET_VALUE
@@ -313,6 +315,20 @@ module VagrantPlugins
 
         @cpu_features.push(name:   options[:name],
                            policy: options[:policy])
+      end
+
+      def cputopology(options = {})
+        if options[:sockets].nil? || options[:cores].nil? || options[:threads].nil?
+          raise 'CPU topology must have all of sockets, cores and threads specified'
+        end
+
+        if @cpu_topology == UNSET_VALUE
+          @cpu_topology = {}
+        end
+
+        @cpu_topology[:sockets] = options[:sockets]
+        @cpu_topology[:cores] = options[:cores]
+        @cpu_topology[:threads] = options[:threads]        
       end
 
       def memorybacking(option, config = {})
@@ -594,6 +610,7 @@ module VagrantPlugins
                      elsif @cpu_mode != 'custom'
                        ''
           end
+        @cpu_topology = {} if @cpu_topology == UNSET_VALUE
         @cpu_fallback = 'allow' if @cpu_fallback == UNSET_VALUE
         @cpu_features = [] if @cpu_features == UNSET_VALUE
         @features = ['acpi','apic','pae'] if @features == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -15,6 +15,10 @@
       <% @cpu_features.each do |cpu_feature| %>
         <feature name='<%= cpu_feature[:name] %>' policy='<%= cpu_feature[:policy] %>'/>
       <% end %>
+      <% unless @cpu_topology.empty? %>
+        <%# CPU topology -%>
+        <topology sockets='<%= @cpu_topology[:sockets] %>' cores='<%= @cpu_topology[:cores] %>' threads='<%= @cpu_topology[:threads] %>'/>
+      <% end %>
     <% end %>
     <% if @numa_nodes %>
       <numa>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -8,6 +8,7 @@
   <cpu mode='custom'>
       <model fallback='allow'>qemu64</model>
         <feature name='AAA' policy='required'/>
+        <topology sockets='1' cores='3' threads='2'/>
   </cpu>
 
 

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -31,6 +31,7 @@ describe 'templates/domain' do
       domain.instance_variable_set('@domain_type', 'kvm')
       domain.cpu_mode = 'custom'
       domain.cpu_feature(name: 'AAA', policy: 'required')
+      domain.cputopology(sockets: '1', cores: '3', threads: '2')
       domain.machine_type = 'pc-compatible'
       domain.machine_arch = 'x86_64'
       domain.loader = '/efi/loader'


### PR DESCRIPTION
By default libvirt creates very strange CPU topology of multiple sockets of one core each. 

This pull request allows user to write an exact topology in Vagrantfile in the form of ```libvirt.cputopology``` call:

  ```ruby
  Vagrant.configure("2") do |config|
    config.vm.provider :libvirt do |libvirt|
      libvirt.cpus = 4
      libvirt.cputopology :sockets => '2', :cores => '2', :threads => '1'
    end
  end
  ```
User have to provide ```libvirt.cpus``` option and make sure its value is equal to multiple of all numbers given to ```libvirt.cputopology``` call, just as required by libvirt.