### PR TITLE
Add option to specify PCI bus/slot for network interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,8 @@ starts with `libvirt__` string. Here is a list of those options:
   info](http://www.linux-kvm.org/page/Multiqueue)
 * `:autostart` - Automatic startup of network by the libvirt daemon.
   If not specified the default is 'false'.
+* `:bus` - The bus of the PCI device. Both :bus and :slot have to be defined.
+* `:slot` - The slot of the PCI device. Both :bus and :slot have to be defined.
 
 When the option `:libvirt__dhcp_enabled` is to to 'false' it shouldn't matter
 whether the virtual network contains a DHCP server or not and vagrant-libvirt

--- a/README.md
+++ b/README.md
@@ -689,6 +689,8 @@ used by this network are configurable at the provider level.
   for for more information.
 * `management_network_autostart` - Automatic startup of mgmt network, if not
   specified the default is 'false'.
+* `:management_network_pci_bus` -  The bus of the PCI device.
+* `:management_network_pci_slot` -  The slot of the PCI device.
 
 You may wonder how vagrant-libvirt knows the IP address a VM received.  Libvirt
 doesn't provide a standard way to find out the IP address of a running domain.

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -77,6 +77,8 @@ module VagrantPlugins
             @driver_queues = iface_configuration.fetch(:driver_queues, false)
             @device_name = iface_configuration.fetch(:iface_name, false)
             @mtu = iface_configuration.fetch(:mtu, nil)
+            @pci_bus = iface_configuration.fetch(:bus, nil)
+            @pci_slot = iface_configuration.fetch(:slot, nil)
             template_name = 'interface'
             # Configuration for public interfaces which use the macvtap driver
             if iface_configuration[:iface_type] == :public_network
@@ -146,7 +148,9 @@ module VagrantPlugins
                                     @model_type,
                                     @mtu,
                                     driver_options,
-                                    @udp_tunnel)
+                                    @udp_tunnel,
+                                    @pci_bus,
+                                    @pci_slot)
                     else
                       to_xml(template_name)
                     end
@@ -237,7 +241,7 @@ module VagrantPlugins
 
         def interface_xml(type, source_options, mac, device_name,
                           iface_number, model_type, mtu, driver_options,
-                          udp_tunnel={})
+                          udp_tunnel={}, pci_bus, pci_slot)
           Nokogiri::XML::Builder.new do |xml|
             xml.interface(type: type || 'network') do
               xml.source(source_options) do
@@ -249,6 +253,7 @@ module VagrantPlugins
               xml.model(type: model_type.to_s)
               xml.mtu(size: Integer(mtu)) if mtu
               xml.driver(driver_options)
+              xml.address(type: 'pci', bus: pci_bus, slot: pci_slot) if pci_bus and pci_slot
             end
           end.to_xml(
             save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION |

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -51,6 +51,8 @@ module VagrantPlugins
       attr_accessor :management_network_mac
       attr_accessor :management_network_guest_ipv6
       attr_accessor :management_network_autostart
+      attr_accessor :management_network_pci_bus
+      attr_accessor :management_network_pci_slot
 
       # Default host prefix (alternative to use project folder name)
       attr_accessor :default_prefix
@@ -161,6 +163,8 @@ module VagrantPlugins
         @management_network_mac  = UNSET_VALUE
         @management_network_guest_ipv6 = UNSET_VALUE
         @management_network_autostart = UNSET_VALUE
+        @management_network_pci_slot = UNSET_VALUE
+        @management_network_pci_bus = UNSET_VALUE
 
         # Domain specific settings.
         @uuid              = UNSET_VALUE
@@ -579,6 +583,8 @@ module VagrantPlugins
         @management_network_mac = nil if @management_network_mac == UNSET_VALUE
         @management_network_guest_ipv6 = 'yes' if @management_network_guest_ipv6 == UNSET_VALUE
         @management_network_autostart = false if @management_network_autostart == UNSET_VALUE
+        @management_network_pci_bus = nil if @management_network_pci_bus == UNSET_VALUE
+        @management_network_pci_slot = nil if @management_network_pci_slot == UNSET_VALUE
 
         # generate a URI if none is supplied
         @uri = _generate_uri if @uri == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/public_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/public_interface.xml.erb
@@ -20,4 +20,7 @@
   <% if @ovs %>
   <virtualport type='openvswitch'/>
   <% end %>
+  <% if @pci_bus and @pci_slot %>
+  <address type='pci' bus='<%=@pci_bus%>' slot='<%=@pci_slot%>' />
+  <% end %>
 </interface>

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -14,6 +14,8 @@ module VagrantPlugins
           management_network_mac = env[:machine].provider_config.management_network_mac
           management_network_guest_ipv6 = env[:machine].provider_config.management_network_guest_ipv6
           management_network_autostart = env[:machine].provider_config.management_network_autostart
+          management_network_pci_bus = env[:machine].provider_config.management_network_pci_bus
+          management_network_pci_slot = env[:machine].provider_config.management_network_pci_slot
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -39,11 +41,18 @@ module VagrantPlugins
             dhcp_enabled: true,
             forward_mode: management_network_mode,
             guest_ipv6: management_network_guest_ipv6,
-            autostart: management_network_autostart
+            autostart: management_network_autostart,
+            bus: management_network_pci_bus,
+            slot: management_network_pci_slot
           }
 
           unless management_network_mac.nil?
             management_network_options[:mac] = management_network_mac
+          end
+
+          unless management_network_pci_bus.nil? and management_network_pci_slot.nil?
+            management_network_options[:bus] = management_network_pci_bus
+            management_network_options[:slot] = management_network_pci_slot
           end
 
           if (env[:machine].config.vm.box &&


### PR DESCRIPTION
Also for the management interface.
Requires both bus and slot to be defined.