### PR TITLE
enable IdentitiesOnly when config.ssh.keys_only is specified.

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -95,6 +95,7 @@ module VagrantPlugins
             StrictHostKeyChecking=no
             PasswordAuthentication=no
             ForwardX11=#{ssh_info[:forward_x11] ? 'yes' : 'no'}
+            IdentitiesOnly=#{ssh_info[:keys_only] ? 'yes' : 'no'}
           ) + ssh_info[:private_key_path].map do |pk|
                 "IdentityFile='\"#{pk}\"'"
               end).map { |s| s.prepend('-o ') }.join(' ')


### PR DESCRIPTION
Pull request for:

https://github.com/vagrant-libvirt/vagrant-libvirt/issues/856