### PR TITLE
Don't silently ignore udp port forwarding option

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -47,6 +47,11 @@ module VagrantPlugins
                              message_attributes
             ))
 
+            if fp[:protocol] == 'udp'
+              env[:ui].warn I18n.t('vagrant_libvirt.warnings.forwarding_udp')
+              next
+            end
+
             ssh_pid = redirect_port(
               @env[:machine],
               fp[:host_ip] || 'localhost',

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -54,6 +54,8 @@ en:
       ignoring_virtual_size_too_small: |-
         Ignoring requested virtual disk size of '%{requested}' as it is below
         the minimum box image size of '%{minimum}'.
+      forwarding_udp: |-
+        Forwarding UDP ports is not supported. Ignoring.
 
     errors:
       package_not_supported: No support for package with libvirt. Create box manually.


### PR DESCRIPTION
Currently it ignores the option and turns it into a tcp port.
Instead warn about the UDP option and skip it.

Fixes #260 