### PR TITLE
USB controller configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,7 +845,7 @@ Don't forget to [set](#domain-specific-options) `kvm_hidden` option to `true` es
 
 ## USB Controller Configuration
 
-The USB controller can be configured using `libvirt.usbctl`, with the following options:
+The USB controller can be configured using `libvirt.usb_controller`, with the following options:
 
 * `model` - The USB controller device model to emulate. (mandatory)
 * `ports` - The number of devices that can be connected to the controller.
@@ -856,7 +856,7 @@ See the [libvirt documentation](https://libvirt.org/formatdomain.html#elementsCo
 Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |libvirt|
     # Set up a USB3 controller
-    libvirt.usbctl :model => "nec-xhci"
+    libvirt.usb_controller :model => "nec-xhci"
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ In the table below, build passing means that specific version combination of Vag
 - [CDROMs](#cdroms)
 - [Input](#input)
 - [PCI device passthrough](#pci-device-passthrough)
+- [USB Controller Configuration](#usb-controller-configuration)
 - [USB Redirector Devices](#usb-redirector-devices)
 - [Random number generator passthrough](#random-number-generator-passthrough)
 - [Watchdog·Device](#watchdog-device)
@@ -840,6 +841,26 @@ end
 Note! Above options affect configuration only at domain creation. It won't change VM behaviour on `vagrant reload` after domain was created.
 
 Don't forget to [set](#domain-specific-options) `kvm_hidden` option to `true` especially if you are passthroughing NVIDIA GPUs. Otherwise GPU is visible from VM but cannot be operated.
+
+
+## USB Controller Configuration
+
+The USB controller can be configured using `libvirt.usbctl`, with the following options:
+
+* `model` - The USB controller device model to emulate. (mandatory)
+* `ports` - The number of devices that can be connected to the controller.
+
+See the [libvirt documentation](https://libvirt.org/formatdomain.html#elementsControllers) for a list of valid models.
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    # Set up a USB3 controller
+    libvirt.usbctl :model => "nec-xhci"
+  end
+end
+```
+
 
 ## USB Redirector Devices
 You can specify multiple redirect devices via `libvirt.redirdev`. There are two types, `tcp` and `spicevmc` supported, for forwarding USB-devices to the guest. Available options are listed below.

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -94,6 +94,9 @@ module VagrantPlugins
           # Watchdog device
           @watchdog_dev = config.watchdog_dev
 
+          # USB controller
+          @usbctl_dev = config.usbctl_dev
+
           # USB device passthrough
           @usbs = config.usbs
 
@@ -254,6 +257,12 @@ module VagrantPlugins
 
           if not @watchdog_dev.empty?
             env[:ui].info(" -- Watchdog device:   model=#{@watchdog_dev[:model]}, action=#{@watchdog_dev[:action]}")
+          end
+
+          if not @usbctl_dev.empty?
+            msg = " -- USB controller:    model=#{@usbctl_dev[:model]}"
+            msg += ", ports=#{@usbctl_dev[:ports]}" if @usbctl_dev[:ports]
+            env[:ui].info(msg)
           end
 
           @usbs.each do |usb|

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -425,7 +425,7 @@ module VagrantPlugins
       end
 
 
-      def usbctl(options = {})
+      def usb_controller(options = {})
         if options[:model].nil?
           raise 'USB controller model must be specified.'
         end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -126,6 +126,9 @@ module VagrantPlugins
       # Watchdog device
       attr_accessor :watchdog_dev
 
+      # USB controller
+      attr_accessor :usbctl_dev
+
       # USB device passthrough
       attr_accessor :usbs
 
@@ -230,6 +233,9 @@ module VagrantPlugins
 
         # Watchdog device
         @watchdog_dev      = UNSET_VALUE
+
+        # USB controller
+        @usbctl_dev        = UNSET_VALUE
 
         # USB device passthrough
         @usbs              = UNSET_VALUE
@@ -418,6 +424,19 @@ module VagrantPlugins
         @watchdog_dev[:action] = options[:action] || 'reset'
       end
 
+
+      def usbctl(options = {})
+        if options[:model].nil?
+          raise 'USB controller model must be specified.'
+        end
+
+        if @usbctl_dev == UNSET_VALUE
+            @usbctl_dev = {}
+        end
+
+        @usbctl_dev[:model] = options[:model]
+        @usbctl_dev[:ports] = options[:ports]
+      end
 
       def usb(options = {})
         if (options[:bus].nil? || options[:device].nil?) && options[:vendor].nil? && options[:product].nil?
@@ -683,6 +702,9 @@ module VagrantPlugins
 
         # Watchdog device
         @watchdog_dev = {} if @watchdog_dev == UNSET_VALUE
+
+        # USB controller
+        @usbctl_dev = {} if @usbctl_dev == UNSET_VALUE
 
         # USB device passthrough
         @usbs = [] if @usbs == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -232,6 +232,14 @@
       </backend>
     </tpm>
     <% end -%>
+    <% unless @usbctl_dev.empty? %>
+    <%# USB Controller -%>
+    <controller type='usb' model='<%= @usbctl_dev[:model] %>'
+      <% if @usbctl_dev[:ports] %>
+        ports="<%= @usbctl_dev[:ports] %>"
+      <% end %>
+    />
+    <% end %>
   </devices>
 
   <% unless @qargs.empty? %>

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -232,13 +232,9 @@
       </backend>
     </tpm>
     <% end -%>
-    <% unless @usbctl_dev.empty? %>
+    <% if not @usbctl_dev.empty? %>
     <%# USB Controller -%>
-    <controller type='usb' model='<%= @usbctl_dev[:model] %>'
-      <% if @usbctl_dev[:ports] %>
-        ports="<%= @usbctl_dev[:ports] %>"
-      <% end %>
-    />
+    <controller type='usb' model='<%= @usbctl_dev[:model] %>' <%= "ports=\"#{@usbctl_dev[:ports]}\" " if @usbctl_dev[:ports] %>/>
     <% end %>
   </devices>
 

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -128,6 +128,9 @@
         <device path='/dev/tpm0'/>
       </backend>
     </tpm>
+    <controller type='usb' model='nec-xhci'
+        ports="4"
+    />
   </devices>
 
   <qemu:commandline>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -128,9 +128,7 @@
         <device path='/dev/tpm0'/>
       </backend>
     </tpm>
-    <controller type='usb' model='nec-xhci'
-        ports="4"
-    />
+    <controller type='usb' model='nec-xhci' ports="4" />
   </devices>
 
   <qemu:commandline>

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -64,7 +64,7 @@ describe 'templates/domain' do
       domain.random(model: 'random')
       domain.pci(bus: '0x06', slot: '0x12', function: '0x5')
       domain.pci(bus: '0x03', slot: '0x00', function: '0x0')
-      domain.usbctl(model: 'nec-xhci', ports: '4')
+      domain.usb_controller(model: 'nec-xhci', ports: '4')
       domain.usb(bus: '1', device: '2', vendor: '0x1234', product: '0xabcd')
       domain.redirdev(type: 'tcp', host: 'localhost', port: '4000')
       domain.redirfilter(class: '0x0b', vendor: '0x08e6',

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -64,6 +64,7 @@ describe 'templates/domain' do
       domain.random(model: 'random')
       domain.pci(bus: '0x06', slot: '0x12', function: '0x5')
       domain.pci(bus: '0x03', slot: '0x00', function: '0x0')
+      domain.usbctl(model: 'nec-xhci', ports: '4')
       domain.usb(bus: '1', device: '2', vendor: '0x1234', product: '0xabcd')
       domain.redirdev(type: 'tcp', host: 'localhost', port: '4000')
       domain.redirfilter(class: '0x0b', vendor: '0x08e6',


### PR DESCRIPTION
Resolves #597 

Libvirt gives VMs a USB1.1 controller by default, so use of USB2/USB3 devices is not possible without manually reconfiguring the VM and restarting it. This PR allows the USB controller to be configured up front in the Vagrantfile.

```
config.vm.provider "libvirt" do |libvirt|
    libvirt.usb_controller :model => 'nec-xhci'
end
```

Supports setting the model as per [libvirt's USB controller options](https://libvirt.org/formatdomain.html#elementsControllers) along with the optional `:ports` attribute to set the number of ports on the controller.