### PR TITLE
Qemu Session Support

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
               if !env[:machine].config.vm.box
                 b2.use CreateDomain
                 b2.use CreateNetworks
-                #b2.use CreateNetworkInterfaces
+                b2.use CreateNetworkInterfaces
                 b2.use SetBootOrder
                 b2.use StartDomain
               else
@@ -44,7 +44,7 @@ module VagrantPlugins
                 b2.use PrepareNFSSettings
                 b2.use ShareFolders
                 b2.use CreateNetworks
-                #b2.use CreateNetworkInterfaces
+                b2.use CreateNetworkInterfaces
                 b2.use SetBootOrder
 
                 b2.use StartDomain

--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
               if !env[:machine].config.vm.box
                 b2.use CreateDomain
                 b2.use CreateNetworks
-                b2.use CreateNetworkInterfaces
+                #b2.use CreateNetworkInterfaces
                 b2.use SetBootOrder
                 b2.use StartDomain
               else
@@ -44,7 +44,7 @@ module VagrantPlugins
                 b2.use PrepareNFSSettings
                 b2.use ShareFolders
                 b2.use CreateNetworks
-                b2.use CreateNetworkInterfaces
+                #b2.use CreateNetworkInterfaces
                 b2.use SetBootOrder
 
                 b2.use StartDomain

--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
       # image as new domain volume.
       class CreateDomainVolume
         include VagrantPlugins::ProviderLibvirt::Util::ErbTemplate
+        include VagrantPlugins::ProviderLibvirt::Util::StorageUtil
 
         def initialize(app, _env)
           @logger = Log4r::Logger.new('vagrant_libvirt::action::create_domain_volume')
@@ -48,8 +49,8 @@ module VagrantPlugins
                 xml.target do
                   xml.format(type: 'qcow2')
                   xml.permissions do
-                    xml.owner 0
-                    xml.group 0
+                    xml.owner storage_uid(env)
+                    xml.group storage_gid(env)
                     xml.mode '0600'
                     xml.label 'virt_image_t'
                   end
@@ -58,8 +59,8 @@ module VagrantPlugins
                   xml.path(@backing_file)
                   xml.format(type: 'qcow2')
                   xml.permissions do
-                    xml.owner 0
-                    xml.group 0
+                    xml.owner storage_uid(env)
+                    xml.group storage_gid(env)
                     xml.mode '0600'
                     xml.label 'virt_image_t'
                   end

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -27,6 +27,11 @@ module VagrantPlugins
         end
 
         def call(env)
+          if env[:machine].provider_config.qemu_use_session
+            @app.call(env)
+            return
+          end
+
           # only one vm at a time should try to set up networks
           # otherwise they'll have inconsitent views of current state
           # and conduct redundant operations that cause errors

--- a/lib/vagrant-libvirt/action/destroy_networks.rb
+++ b/lib/vagrant-libvirt/action/destroy_networks.rb
@@ -13,6 +13,11 @@ module VagrantPlugins
         end
 
         def call(env)
+          if env[:machine].provider_config.qemu_use_session
+            @app.call(env)
+            return
+          end
+
           # If there were some networks created for this machine, in machines
           # data directory, created_networks file holds UUIDs of each network.
           created_networks_file = env[:machine].data_dir + 'created_networks'

--- a/lib/vagrant-libvirt/action/handle_storage_pool.rb
+++ b/lib/vagrant-libvirt/action/handle_storage_pool.rb
@@ -5,6 +5,8 @@ module VagrantPlugins
     module Action
       class HandleStoragePool
         include VagrantPlugins::ProviderLibvirt::Util::ErbTemplate
+        include VagrantPlugins::ProviderLibvirt::Util::StorageUtil
+
 
         @@lock = Mutex.new
 
@@ -37,6 +39,9 @@ module VagrantPlugins
             # Fog libvirt currently doesn't support creating pools. Use
             # ruby-libvirt client directly.
             begin
+              @storage_pool_path = storage_pool_path(env)
+              @storage_pool_uid = storage_uid(env)
+              @storage_pool_gid = storage_gid(env)
               libvirt_pool = env[:machine].provider.driver.connection.client.define_storage_pool_xml(
                 to_xml('default_storage_pool')
               )

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -46,6 +46,7 @@ module VagrantPlugins
       attr_accessor :random_hostname
 
       # Libvirt default network
+      attr_accessor :management_network_device
       attr_accessor :management_network_name
       attr_accessor :management_network_address
       attr_accessor :management_network_mode
@@ -54,6 +55,9 @@ module VagrantPlugins
       attr_accessor :management_network_autostart
       attr_accessor :management_network_pci_bus
       attr_accessor :management_network_pci_slot
+
+      # System connection information
+      attr_accessor :system_uri
 
       # Default host prefix (alternative to use project folder name)
       attr_accessor :default_prefix
@@ -162,6 +166,7 @@ module VagrantPlugins
         @id_ssh_key_file   = UNSET_VALUE
         @storage_pool_name = UNSET_VALUE
         @random_hostname   = UNSET_VALUE
+        @management_network_device  = UNSET_VALUE
         @management_network_name    = UNSET_VALUE
         @management_network_address = UNSET_VALUE
         @management_network_mode = UNSET_VALUE
@@ -170,6 +175,9 @@ module VagrantPlugins
         @management_network_autostart = UNSET_VALUE
         @management_network_pci_slot = UNSET_VALUE
         @management_network_pci_bus = UNSET_VALUE
+
+        # System connection information
+        @system_uri      = UNSET_VALUE
 
         # Domain specific settings.
         @uuid              = UNSET_VALUE
@@ -601,6 +609,7 @@ module VagrantPlugins
         @storage_pool_name = 'default' if @storage_pool_name == UNSET_VALUE
         @storage_pool_path = nil if @storage_pool_path == UNSET_VALUE
         @random_hostname = false if @random_hostname == UNSET_VALUE
+        @management_network_device = 'virbr0' if @management_network_device == UNSET_VALUE
         @management_network_name = 'vagrant-libvirt' if @management_network_name == UNSET_VALUE
         @management_network_address = '192.168.121.0/24' if @management_network_address == UNSET_VALUE
         @management_network_mode = 'nat' if @management_network_mode == UNSET_VALUE
@@ -609,6 +618,7 @@ module VagrantPlugins
         @management_network_autostart = false if @management_network_autostart == UNSET_VALUE
         @management_network_pci_bus = nil if @management_network_pci_bus == UNSET_VALUE
         @management_network_pci_slot = nil if @management_network_pci_slot == UNSET_VALUE
+        @system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
 
         # generate a URI if none is supplied
         @uri = _generate_uri if @uri == UNSET_VALUE

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -40,6 +40,7 @@ module VagrantPlugins
       # Libvirt storage pool name, where box image and instance snapshots will
       # be stored.
       attr_accessor :storage_pool_name
+      attr_accessor :storage_pool_path
 
       # Turn on to prevent hostname conflicts
       attr_accessor :random_hostname
@@ -148,6 +149,9 @@ module VagrantPlugins
       # Additional qemuargs arguments
       attr_accessor :qemu_args
 
+      # Use qemu session instead of system
+      attr_accessor :qemu_use_session
+
       def initialize
         @uri               = UNSET_VALUE
         @driver            = UNSET_VALUE
@@ -251,6 +255,7 @@ module VagrantPlugins
         @mgmt_attach       = UNSET_VALUE
 
         @qemu_args  = []
+        @qemu_use_session  = UNSET_VALUE
       end
 
       def boot(device)
@@ -542,7 +547,9 @@ module VagrantPlugins
         # Setup connection uri.
         uri = @driver.dup
         virt_path = case uri
-                    when 'qemu', 'openvz', 'uml', 'phyp', 'parallels', 'kvm'
+                    when 'qemu', 'kvm'
+                      @qemu_use_session ? '/session' : '/system'
+                    when 'openvz', 'uml', 'phyp', 'parallels'
                       '/system'
                     when '@en', 'esx'
                       '/'
@@ -592,6 +599,7 @@ module VagrantPlugins
         @password = nil if @password == UNSET_VALUE
         @id_ssh_key_file = 'id_rsa' if @id_ssh_key_file == UNSET_VALUE
         @storage_pool_name = 'default' if @storage_pool_name == UNSET_VALUE
+        @storage_pool_path = nil if @storage_pool_path == UNSET_VALUE
         @random_hostname = false if @random_hostname == UNSET_VALUE
         @management_network_name = 'vagrant-libvirt' if @management_network_name == UNSET_VALUE
         @management_network_address = '192.168.121.0/24' if @management_network_address == UNSET_VALUE
@@ -706,6 +714,7 @@ module VagrantPlugins
         @mgmt_attach = true if @mgmt_attach == UNSET_VALUE
 
         @qemu_args = [] if @qemu_args == UNSET_VALUE
+        @qemu_use_session = false if @qemu_use_session == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -29,6 +29,10 @@ module VagrantPlugins
         error_key(:creating_storage_pool_error)
       end
 
+      class CreatingVolumeError < VagrantLibvirtError
+        error_key(:creating_volume_error)
+      end
+
       class ImageUploadError < VagrantLibvirtError
         error_key(:image_upload_error)
       end

--- a/lib/vagrant-libvirt/templates/default_storage_pool.xml.erb
+++ b/lib/vagrant-libvirt/templates/default_storage_pool.xml.erb
@@ -3,11 +3,11 @@
   <source>
   </source>
   <target>
-    <path>/var/lib/libvirt/images</path>
+    <path><%= @storage_pool_path %></path>
     <permissions>
       <mode>0755</mode>
-      <owner>-1</owner>
-      <group>-1</group>
+      <owner><%= @storage_pool_uid %></owner>
+      <group><%= @storage_pool_gid %></group>
     </permissions>
   </target>
 </pool>

--- a/lib/vagrant-libvirt/templates/default_storage_volume.xml.erb
+++ b/lib/vagrant-libvirt/templates/default_storage_volume.xml.erb
@@ -1,0 +1,14 @@
+<volume>
+  <name><%= @name %></name>
+  <allocation unit="<%= split_size_unit(@allocation)[1] %>"><%= split_size_unit(@allocation)[0] %></allocation>
+  <capacity unit="<%= split_size_unit(@capacity)[1] %>"><%= split_size_unit(@capacity)[0] %></capacity>
+  <target>
+    <format type="<%= @format_type %>"/>
+    <permissions>
+      <owner><%= @storage_volume_uid %></owner>
+      <group><%= @storage_volume_gid %></group>
+      <mode>0744</mode>
+      <label>virt_image_t</label>
+    </permissions>
+  </target>
+</volume>

--- a/lib/vagrant-libvirt/util.rb
+++ b/lib/vagrant-libvirt/util.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
       autoload :Collection,  'vagrant-libvirt/util/collection'
       autoload :Timer, 'vagrant-libvirt/util/timer'
       autoload :NetworkUtil, 'vagrant-libvirt/util/network_util'
+      autoload :StorageUtil, 'vagrant-libvirt/util/storage_util'
       autoload :ErrorCodes, 'vagrant-libvirt/util/error_codes'
     end
   end

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
         include Vagrant::Util::NetworkIP
 
         def configured_networks(env, logger)
+          qemu_use_session = env[:machine].provider_config.qemu_use_session
+          management_network_device = env[:machine].provider_config.management_network_device
           management_network_name = env[:machine].provider_config.management_network_name
           management_network_address = env[:machine].provider_config.management_network_address
           management_network_mode = env[:machine].provider_config.management_network_mode
@@ -33,18 +35,31 @@ module VagrantPlugins
                   error_message: "#{management_network_address} does not include both an address and subnet mask"
           end
 
-          management_network_options = {
-            iface_type: :private_network,
-            network_name: management_network_name,
-            ip: Regexp.last_match(1),
-            netmask: Regexp.last_match(2),
-            dhcp_enabled: true,
-            forward_mode: management_network_mode,
-            guest_ipv6: management_network_guest_ipv6,
-            autostart: management_network_autostart,
-            bus: management_network_pci_bus,
-            slot: management_network_pci_slot
-          }
+          if qemu_use_session
+            management_network_options = {
+              iface_type: :public_network,
+              dev: management_network_device,
+              mode: 'bridge',
+              type: 'bridge',
+              bus: management_network_pci_bus,
+              slot: management_network_pci_slot
+            }
+          else
+            management_network_options = {
+              iface_type: :private_network,
+              network_name: management_network_name,
+              ip: Regexp.last_match(1),
+              netmask: Regexp.last_match(2),
+              dhcp_enabled: true,
+              forward_mode: management_network_mode,
+              guest_ipv6: management_network_guest_ipv6,
+              autostart: management_network_autostart,
+              bus: management_network_pci_bus,
+              slot: management_network_pci_slot
+            }
+          end
+
+
 
           unless management_network_mac.nil?
             management_network_options[:mac] = management_network_mac

--- a/lib/vagrant-libvirt/util/storage_util.rb
+++ b/lib/vagrant-libvirt/util/storage_util.rb
@@ -1,0 +1,27 @@
+
+module VagrantPlugins
+  module ProviderLibvirt
+    module Util
+      module StorageUtil
+        def storage_uid(env)
+          env[:machine].provider_config.qemu_use_session ? Process.uid : 0
+        end
+
+        def storage_gid(env)
+          env[:machine].provider_config.qemu_use_session ? Process.gid : 0
+        end
+
+        def storage_pool_path(env)
+          if env[:machine].provider_config.storage_pool_path
+            env[:machine].provider_config.storage_pool_path
+          elsif env[:machine].provider_config.qemu_use_session
+            File.expand_path('~/.local/share/libvirt/images')
+          else
+            '/var/lib/libvirt/images'
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -107,6 +107,8 @@ en:
         `vagrant up` command again.
       creating_storage_pool_error: |-
         There was error while creating libvirt storage pool: %{error_message}
+      creating_volume_error: |-
+        There was error while creating libvirt volume: %{error_message}
       image_upload_error: |-
         Error while uploading image to storage pool: %{error_message}
       no_domain_error: |-


### PR DESCRIPTION
Added basic qemu support in response to issue #272. The patch supports creating storage pools under user directories and using existing networks created under the qemu:///system connection. Using existing networks requires the qemu-bridge-helper to be installed and the relevant permissions granted (this is the default on some distros but others may need to configure this).

To assist with this the following configuration options where added
-  **qemu_use_session** 
    - Enable usage of qemu session, changes default connection URL to qemu:///session and enables support for qemu session
-  **storage_pool_path**
    -  Storage pool path to use for libvirt images 
    - Defaults to /var/lib/libvirt/images
    - If session enabled defaults to ~/.local/share/libvirt/images)
-  **management_network_device**
    - Device to use for management network
    - Defaults to 'virbr0'
-  **system_uri**
    - QEMU system URL to connect to as read-only to retrieve DHCP leases for obtaining IP addresses
