### PR TITLE
QEMU libvirt nvram support

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -41,6 +41,7 @@ module VagrantPlugins
           @cpu_fallback = config.cpu_fallback
           @numa_nodes = config.numa_nodes
           @loader = config.loader
+          @nvram = config.nvram
           @machine_type = config.machine_type
           @machine_arch = config.machine_arch
           @disk_bus = config.disk_bus
@@ -193,6 +194,7 @@ module VagrantPlugins
           end
           env[:ui].info(" -- Management MAC:    #{@management_network_mac}")
           env[:ui].info(" -- Loader:            #{@loader}")
+          env[:ui].info(" -- Nvram:             #{@nvram}")
           if env[:machine].config.vm.box
             env[:ui].info(" -- Base box:          #{env[:machine].box.name}")
           end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -71,6 +71,7 @@ module VagrantPlugins
       attr_accessor :features
       attr_accessor :numa_nodes
       attr_accessor :loader
+      attr_accessor :nvram
       attr_accessor :boot_order
       attr_accessor :machine_type
       attr_accessor :machine_arch
@@ -180,6 +181,7 @@ module VagrantPlugins
         @features          = UNSET_VALUE
         @numa_nodes        = UNSET_VALUE
         @loader            = UNSET_VALUE
+        @nvram             = UNSET_VALUE
         @machine_type      = UNSET_VALUE
         @machine_arch      = UNSET_VALUE
         @machine_virtual_size = UNSET_VALUE
@@ -624,6 +626,7 @@ module VagrantPlugins
         @features = ['acpi','apic','pae'] if @features == UNSET_VALUE
         @numa_nodes = @numa_nodes == UNSET_VALUE ? nil : _generate_numa
         @loader = nil if @loader == UNSET_VALUE
+        @nvram = nil if @nvram == UNSET_VALUE
         @machine_type = nil if @machine_type == UNSET_VALUE
         @machine_arch = nil if @machine_arch == UNSET_VALUE
         @machine_virtual_size = nil if @machine_virtual_size == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -52,7 +52,14 @@
       <% end %>
     <% end %>
     <% if @loader %>
-      <loader readonly='yes' type='rom'><%= @loader %></loader>
+      <% if @nvram %>
+        <loader readonly='yes' type='pflash'><%= @loader %></loader>
+      <% else %>
+        <loader readonly='yes' type='rom'><%= @loader %></loader>
+      <% end %>
+    <% end %>
+    <% if @nvram %>
+      <nvram><%= @nvram %></nvram>
     <% end %>
     <% if @boot_order.count >= 1 %>
       <bootmenu enable='yes'/>

--- a/spec/support/environment_helper.rb
+++ b/spec/support/environment_helper.rb
@@ -18,7 +18,7 @@ class EnvironmentHelper
     1024
   end
 
-  %w(cpus cpu_mode loader boot_order machine_type disk_bus disk_device nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms driver).each do |name|
+  %w(cpus cpu_mode loader nvram boot_order machine_type disk_bus disk_device nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms driver).each do |name|
     define_method(name.to_sym) do
       nil
     end

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -14,7 +14,7 @@
 
   <os>
         <type arch='x86_64' machine='pc-compatible'>hvm</type>
-      <loader readonly='yes' type='rom'>/efi/loader</loader>
+        <loader readonly='yes' type='rom'>/efi/loader</loader>
       <bootmenu enable='yes'/>
     <kernel></kernel>
     <initrd></initrd>


### PR DESCRIPTION
Some UEFI firmwares may want to use a non-volatile memory to store
variables.
This requires to specify loader and nvram to use UEFI boot in QEMU.
Specifying loader and nvram at the same time will set loader to
type 'pflash' instead of 'rom'.
If loader is used without nvram option type will remain 'rom'.

Further information can be found at libvirt documentation:
https://libvirt.org/formatdomain.html#elementsOS