### PR TITLE
Remove nested section in domain template

### DIFF
--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -8,10 +8,6 @@
   <cpu mode='<%= @cpu_mode %>'>
     <% if @cpu_mode != 'host-passthrough' %>
       <model fallback='<%= @cpu_fallback %>'><% if @cpu_mode == 'custom' %><%= @cpu_model %><% end %></model>
-      <% if @nested %>
-        <feature policy='optional' name='vmx'/>
-        <feature policy='optional' name='svm'/>
-      <% end %>
       <% @cpu_features.each do |cpu_feature| %>
         <feature name='<%= cpu_feature[:name] %>' policy='<%= cpu_feature[:policy] %>'/>
       <% end %>

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -8,6 +8,14 @@
   <cpu mode='<%= @cpu_mode %>'>
     <% if @cpu_mode != 'host-passthrough' %>
       <model fallback='<%= @cpu_fallback %>'><% if @cpu_mode == 'custom' %><%= @cpu_model %><% end %></model>
+      <% if @nested %>
+        <% if @cpu_features.select{|x| x[:name] == 'vmx'}.empty? %>
+          <feature policy='optional' name='vmx'/>
+        <% end %>
+        <% if @cpu_features.select{|x| x[:name] == 'svm'}.empty? %>
+          <feature policy='optional' name='svm'/>
+        <% end %>
+      <% end %>
       <% @cpu_features.each do |cpu_feature| %>
         <feature name='<%= cpu_feature[:name] %>' policy='<%= cpu_feature[:policy] %>'/>
       <% end %>


### PR DESCRIPTION
An unnecessary nested xml section was removed in the domain template, since code in start_domain.rb handles this logic.