### PR TITLE
Fix for :public_network and :private_network in the same VM

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -186,7 +186,6 @@ module VagrantPlugins
           if not @cpu_topology.empty?
             env[:ui].info(" -- CPU topology:   sockets=#{@cpu_topology[:sockets]}, cores=#{@cpu_topology[:cores]}, threads=#{@cpu_topology[:threads]}")
           end
-          env[:ui].info("")
           @cpu_features.each do |cpu_feature|
             env[:ui].info(" -- CPU Feature:       name=#{cpu_feature[:name]}, policy=#{cpu_feature[:policy]}")
           end

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -80,6 +80,8 @@ module VagrantPlugins
             @pci_bus = iface_configuration.fetch(:bus, nil)
             @pci_slot = iface_configuration.fetch(:slot, nil)
             template_name = 'interface'
+            @type = nil
+            @udp_tunnel = nil
             # Configuration for public interfaces which use the macvtap driver
             if iface_configuration[:iface_type] == :public_network
               @device = iface_configuration.fetch(:dev, 'eth0')


### PR DESCRIPTION
Original config which did not work (network part):
```
    red.vm.network :public_network,
      :dev => "red_br_out",
      :mode => "bridge",
      :type => "bridge",
      :bus => "02",
      :slot => "02",
      :ip => '0.0.0.0' # Dummy IP 

    red.vm.network :private_network,
      :ip => "192.168.125.31"
```
If you change their places VM would start but because of another bug in Vagrant it won't configure network interfaces correctly (due to my need for specific PCI addresses).

I don't know how to create tests for that specific issue so none were added in that PR.