### PR TITLE
Enable provisioning by providing ssh access -ssh-hostkeys parameter to virt-sysprep step

### DIFF
--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
           `qemu-img rebase -p -b "" #{@tmp_img}`
           # remove hw association with interface
           # working for centos with lvs default disks
-          `virt-sysprep --no-logfile --operations defaults,-ssh-userdir -a #{@tmp_img}`
+          `virt-sysprep --no-logfile --operations defaults,-ssh-userdir,-ssh-hostkeys -a #{@tmp_img}`
           # add any user provided file
           extra = ''
           @tmp_include = @tmp_dir + '/_include'


### PR DESCRIPTION
The actual configuration for virt-sysprep step (lib/vagrant-libvirt/action/package_domain.rb) removes all of ssh server hostkeys. The vagrant machines are unable to connect through ssh, and hangs indefinitely.

I just added the keys generation to virt-sysprep command, like shown on https://github.com/vagrant-libvirt/vagrant-libvirt/issues/759

Thx