### PR TITLE
Allow usage of public/private networks as management networks

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -99,7 +99,14 @@ module VagrantPlugins
             addresses.each_pair do |_type, ip|
               # Multiple leases are separated with a newline, return only
               # the most recent address
-              ip_address = ip[0].split("\n").first unless ip[0].nil?
+              unless ip[0].nil?
+                ip_address = ip[0].split("\n").first
+              else
+                domain.nics.each do |nic|
+                  ip_address = %x(awk '/#{nic.mac}/ {print \$1}' /proc/net/arp).strip
+                  break unless ip_address.nil?
+                end
+              end
             end
             !ip_address.nil?
           end

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -70,10 +70,10 @@ module VagrantPlugins
             management_network_options[:slot] = management_network_pci_slot
           end
 
-          if (env[:machine].config.vm.box &&
-              !env[:machine].provider_config.mgmt_attach)
-            raise Errors::ManagementNetworkRequired
-          end
+          # if (env[:machine].config.vm.box &&
+          #     !env[:machine].provider_config.mgmt_attach)
+          #   raise Errors::ManagementNetworkRequired
+          # end
 
           # add management network to list of networks to check
           # unless mgmt_attach set to false


### PR DESCRIPTION
Hello !

I was very bored by the fact i had to use a management network to setup my VM ; I already have a public network which could be used for that.
Here's what i did. I know this is very dirty (i'm far from being a ruby expert), but I'm sure you'll see the idea. 

Thanks for your returns