### PR TITLE
Use ps keyword `command` instead of `cmd`

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -210,9 +210,9 @@ module VagrantPlugins
         end
 
         def ssh_pid?(pid)
-          @logger.debug 'Checking if #{pid} is an ssh process '\
-                        'with `ps -o cmd= #{pid}`'
-          `ps -o cmd= #{pid}`.strip.chomp =~ /ssh/
+          @logger.debug "Checking if #{pid} is an ssh process "\
+                        "with `ps -o command= #{pid}`"
+          `ps -o command= #{pid}`.strip.chomp =~ /ssh/
         end
 
         def remove_ssh_pids


### PR DESCRIPTION
For Darwin operating systems, `cmd` is not a valid keyword, thus resulting in the following error when executing Vagrant `reload` and `destroy` commands:

    ps: cmd: keyword not found
    ps: no valid keywords; valid keywords:

This commit ensures that SSH sessions for forwarded ports are terminated via their respective process ID for Darwin *and* Linux operating systems.

Both Darwin and Linux operating systems support the `command` keyword, as reflected in the following documents, respectively:

- https://apple.co/2H7jFwl
- https://bit.ly/2HakfW0

Also replaces the single quotes with double quotes for the `logger.debug` statement, as string interpolation was not behaving as anticipated.