### PR TITLE
Don't add _ after user defined default_prefix

### DIFF
--- a/lib/vagrant-libvirt/action/set_name_of_domain.rb
+++ b/lib/vagrant-libvirt/action/set_name_of_domain.rb
@@ -51,7 +51,7 @@ module VagrantPlugins
               # don't have any prefix, not even "_"
               ''
             else
-              config.default_prefix.to_s.dup.concat('_')
+              config.default_prefix.to_s.dup
             end
           domain_name << env[:machine].name.to_s
           domain_name.gsub!(/[^-a-z0-9_\.]/i, '')

--- a/spec/unit/action/set_name_of_domain_spec.rb
+++ b/spec/unit/action/set_name_of_domain_spec.rb
@@ -14,7 +14,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain do
   end
 
   it 'builds simple domain name' do
-    @env.default_prefix = 'pre'
+    @env.default_prefix = 'pre_'
     dmn = VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain.new(Object.new, @env)
     dmn.build_domain_name(@env).should eq('pre_')
   end


### PR DESCRIPTION
Forcing an underscore between a defined default_prefix and the machine name
forces a naming format that the user might not want.

If they define their own default_prefix and want an underscore between that and
the machine name, they can/should add the underscore to the default_prefix.