### PR TITLE
README (Debian install): Don't autorun dnsmasq

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ vagrant-libvirt. This depends on your distro. An overview:
 * Ubuntu 12.04/14.04/16.04, Debian:
 ```shell
 apt-get build-dep vagrant ruby-libvirt
-apt-get install qemu libvirt-bin ebtables dnsmasq
+apt-get install qemu libvirt-bin ebtables dnsmasq-base
 apt-get install libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 ```
 


### PR DESCRIPTION
Current install instructions for Debian/Ubuntu install the package
"dnsmasq", which results in dnsmasq being immediately started and
configured to run as a system service.  This is probably not something
vagrant-libvirt users typically want.

Instead, package "dnsmasq-base" exists, which achieves precisely what is
probably desired here.