### PR TITLE
Default Port Forwarding to All Host Addresses

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
 
             ssh_pid = redirect_port(
               @env[:machine],
-              fp[:host_ip] || 'localhost',
+              fp[:host_ip] || '*',
               fp[:host],
               fp[:guest_ip] || @env[:machine].provider.ssh_info[:host],
               fp[:guest],


### PR DESCRIPTION
This change would make it so that the default for forwarded ports would be to listen on all ports. This change brings vagrant-libvirt in line with the default set of plugins, that function this way. It also makes sharing configurations between multiple hosts easier, as the VirtualBox provider (at least on Windows 10) will fail to start the guest VM if "host_ip: *" is used.