### PR TITLE
Fix USB redirfilter parameter configuration

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -491,9 +491,9 @@ module VagrantPlugins
         @redirfilters = [] if @redirfilters == UNSET_VALUE
 
         @redirfilters.push(class: options[:class] || -1,
-                           vendor: options[:class] || -1,
-                           product: options[:class] || -1,
-                           version: options[:class] || -1,
+                           vendor: options[:vendor] || -1,
+                           product: options[:product] || -1,
+                           version: options[:version] || -1,
                            allow: options[:allow])
       end
 

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -120,7 +120,7 @@
         <redirdev bus='usb' type='tcp'>
         </redirdev>
         <redirfilter>
-          <usbdev class='0x0b' vendor='0x0b' product='0x0b' version='0x0b' allow='yes'/>
+          <usbdev class='0x0b' vendor='0x08e6' product='0x3437' version='2.00' allow='yes'/>
         </redirfilter>
     <watchdog model='i6300esb' action='reset'/>
 


### PR DESCRIPTION
Closes #729 

The code that configures the USB 'redirfilter' has four parameters, but the value of the 'class' parameter is cloned into all others. This PR fixes the settings to use the correct values, and fixes the associated unit test which had been set with incorrect values as compared to domain_spec.rb.