### PR TITLE
Include `-n` option for forwarded port ssh processes

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -120,7 +120,7 @@ module VagrantPlugins
             end
           end
 
-          ssh_cmd << "ssh #{options} #{params}"
+          ssh_cmd << "ssh -n #{options} #{params}"
 
           @logger.debug "Forwarding port with `#{ssh_cmd}`"
           log_file = ssh_forward_log_file(host_ip, host_port,


### PR DESCRIPTION
In configurations where ControlMaster is used with ControlPersist set, not including this option results in "stolen" input. Easy reproduction of the behavior provided below:

Vagrantfile:

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = 'generic/ubuntu1604'
  config.vm.network :forwarded_port, guest: 9999, host: 9999
end
```

~/.ssh/config:

```
Host *
     ControlMaster yes
     ControlPath ~/.ssh/controlmasters/%C
     ControlPersist 600
```

and ensure the `~/.ssh/controlmasters` directory exists. After running a `vagrant up` typed characters in the same console will be missing from the input.

(Original issue: hashicorp/vagrant#10372)

