### PR TITLE
add domain name for the management network

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,9 +699,10 @@ used by this network are configurable at the provider level.
   for for more information.
 * `management_network_autostart` - Automatic startup of mgmt network, if not
   specified the default is 'false'.
-* `:management_network_pci_bus` -  The bus of the PCI device.
-* `:management_network_pci_slot` -  The slot of the PCI device.
+* `management_network_pci_bus` -  The bus of the PCI device.
+* `management_network_pci_slot` -  The slot of the PCI device.
 * `management_network_mac` - MAC address of management network interface.
+* `management_network_domain` - Domain name assigned to the management network.
 
 You may wonder how vagrant-libvirt knows the IP address a VM received.  Libvirt
 doesn't provide a standard way to find out the IP address of a running domain.

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -58,6 +58,7 @@ module VagrantPlugins
       attr_accessor :management_network_autostart
       attr_accessor :management_network_pci_bus
       attr_accessor :management_network_pci_slot
+      attr_accessor :management_network_domain
 
       # System connection information
       attr_accessor :system_uri
@@ -184,6 +185,7 @@ module VagrantPlugins
         @management_network_autostart = UNSET_VALUE
         @management_network_pci_slot = UNSET_VALUE
         @management_network_pci_bus = UNSET_VALUE
+        @management_network_domain = UNSET_VALUE
 
         # System connection information
         @system_uri      = UNSET_VALUE
@@ -654,6 +656,7 @@ module VagrantPlugins
         @management_network_autostart = false if @management_network_autostart == UNSET_VALUE
         @management_network_pci_bus = nil if @management_network_pci_bus == UNSET_VALUE
         @management_network_pci_slot = nil if @management_network_pci_slot == UNSET_VALUE
+        @management_network_domain = nil if @management_network_domain == UNSET_VALUE
         @system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
 
         @qemu_use_session = false if @qemu_use_session == UNSET_VALUE

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
           management_network_autostart = env[:machine].provider_config.management_network_autostart
           management_network_pci_bus = env[:machine].provider_config.management_network_pci_bus
           management_network_pci_slot = env[:machine].provider_config.management_network_pci_slot
+          management_network_domain = env[:machine].provider_config.management_network_domain
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -63,6 +64,10 @@ module VagrantPlugins
 
           unless management_network_mac.nil?
             management_network_options[:mac] = management_network_mac
+          end
+
+          unless management_network_domain.nil?
+            management_network_options[:domain_name] = management_network_domain
           end
 
           unless management_network_pci_bus.nil? and management_network_pci_slot.nil?


### PR DESCRIPTION
this allows users to have a dedicated domain for their vagrant VMs and point their regular resolver at the libvirt dnsmasq for that domain to make them reachable by a full name instead of the IP when accessing the services on said VM.

 an example for such a setup can be found in [1] and [2]

 [1] https://liquidat.wordpress.com/2017/03/03/howto-automated-dns-resolution-for-kvmlibvirt-guests-with-a-local-domain/
 [2] https://m0dlx.com/blog/Automatic_DNS_updates_from_libvirt_guests.html