### PR TITLE
Do not remove SSH hostkeys or update LVM UUIDs on package

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ can help a lot :-)
 - [Customized Graphics](#customized-graphics)
 - [Box Format](#box-format)
 - [Create Box](#create-box)
+- [Package Box from VM](#package-box-from-vm)
 - [Development](#development)
 - [Contributing](#contributing)
 
@@ -1418,6 +1419,28 @@ you can build a vagrant-libvirt box by running:
 ```shell
 $ cd packer-qemu-templates
 $ packer build ubuntu-14.04-server-amd64-vagrant.json
+```
+
+## Package Box from VM
+
+vagrant-libvirt has native support for [`vagrant
+package`](https://www.vagrantup.com/docs/cli/package.html) via
+libguestfs [virt-sysprep](http://libguestfs.org/virt-sysprep.1.html).
+virt-sysprep operations can be customized via the
+`VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS` environment variable; see the
+[upstream
+documentation](http://libguestfs.org/virt-sysprep.1.html#operations) for
+further details especially on default sysprep operations enabled for
+your system.
+
+For example, on Chef [bento](https://github.com/chef/bento) VMs that
+require SSH hostkeys already set (e.g. bento/debian-7) as well as leave
+existing LVM UUIDs untouched (e.g. bento/ubuntu-18.04), these can be
+packaged into vagrant-libvirt boxes like so:
+
+```shell
+$ export VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS="defaults,-ssh-userdir,-ssh-hostkeys,-lvm-uuids"
+$ vagrant package
 ```
 
 ## Development

--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -38,7 +38,8 @@ module VagrantPlugins
           `qemu-img rebase -p -b "" #{@tmp_img}`
           # remove hw association with interface
           # working for centos with lvs default disks
-          `virt-sysprep --no-logfile --operations defaults,-ssh-userdir,-ssh-hostkeys,-lvm-uuids -a #{@tmp_img}`
+          operations = ENV.get('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS', 'defaults,-ssh-userdir')
+          `virt-sysprep --no-logfile --operations #{operations} -a #{@tmp_img}`
           # add any user provided file
           extra = ''
           @tmp_include = @tmp_dir + '/_include'

--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
           `qemu-img rebase -p -b "" #{@tmp_img}`
           # remove hw association with interface
           # working for centos with lvs default disks
-          `virt-sysprep --no-logfile --operations defaults,-ssh-userdir -a #{@tmp_img}`
+          `virt-sysprep --no-logfile --operations defaults,-ssh-userdir,-ssh-hostkeys,-lvm-uuids -a #{@tmp_img}`
           # add any user provided file
           extra = ''
           @tmp_include = @tmp_dir + '/_include'


### PR DESCRIPTION
Fix `vagrant package` of e.g. [bento](https://github.com/chef/bento)-derived boxes that require SSH hostkeys already set (as in the case of bento/debian-7 and above,) as well as leave existing LVM UUIDs untouched (e.g. in bento/ubuntu-18.04.)