### PR TITLE
prepare_nfs_settings.rb: check for 'ssh' service to see if guest network interface is up

### DIFF
--- a/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
@@ -79,7 +79,7 @@ module VagrantPlugins
         # Check if we can open a connection to the host
         def ping(host, timeout = 3)
           ::Timeout.timeout(timeout) do
-            s = TCPSocket.new(host, 'echo')
+            s = TCPSocket.new(host, 'ssh')
             s.close
           end
           true


### PR DESCRIPTION
try to open a tcp socket to 'ssh' service to determine whether guest management interface is up.

The 'ping' function tries to open a tcp socket with the 'echo' service on the guest. When it fails, it will try the next guest ip address.

The 'vagrant management interface' will have the tcp service 'ssh' available
(you wouldn't be able to vagrant ssh into your vagrant box otherwise), so it makes
sense to use the ssh tcp port for the ping.

the 'echo' service nowadays is often not available out-of-the-box, causing the 'ping' of the guest management interface to fail. When the guest has docker installed, or other network interfaces added, this results in the wrong ip addresses being used in /etc/exports, and
the vm not being able to mount the vagrant shares at 'vagrant reload', or 'vagrant halt; vagrant up' time.

This fixes the vm not being able to mount the shares over nfs after
a reload due to the wrong ip addresses being used.

related issues #544 #572 