### PR TITLE
Enable QEMU Session by default

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -656,7 +656,7 @@ module VagrantPlugins
         @management_network_pci_slot = nil if @management_network_pci_slot == UNSET_VALUE
         @system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
 
-        @qemu_use_session = false if @qemu_use_session == UNSET_VALUE
+        @qemu_use_session = true if @qemu_use_session == UNSET_VALUE
 
         # generate a URI if none is supplied
         @uri = _generate_uri if @uri == UNSET_VALUE


### PR DESCRIPTION
sets default for `@qemu_use_session` to true.

_ _ _ _

We in Fedora want to enable it on default Vagrant-Libvirt installation (and we [intend to](https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session), soon).

Are there any obstacles, apart from the unability to use `private_network`?
Basic functionality works out of the box for us.

Is there plan to make it default in future vagrant-libvirt releases? If not, why?