### PR TITLE
Handle rubygems >= 3 dropping support for ruby < 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: trusty
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libvirt-dev
-  - gem update --system
-  - gem install bundler
+  - gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
+  - gem update bundler --conservative
 install: bundle install
 script: bundle exec rspec --color --format documentation
 notifications:


### PR DESCRIPTION
Rubygems releases >= 3 have removed support for older versions of ruby
(<2.3). While testing with distributions with older versions of ruby
make sure to use the conservative install method as suggested from
https://github.com/rubygems/rubygems/issues/2534#issuecomment-448843746