### PR TITLE
Default to storage pool if snapshot pool not defined

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -120,7 +120,7 @@ module VagrantPlugins
 
           # Get path to domain image from the storage pool selected if we have a box.
           if env[:machine].config.vm.box
-            if @snapshot_pool_name != 'default'
+            if @snapshot_pool_name != @storage_pool_name
                 pool_name = @snapshot_pool_name
             else
                 pool_name = @storage_pool_name

--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -71,7 +71,7 @@ module VagrantPlugins
                          Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS |
                          Nokogiri::XML::Node::SaveOptions::FORMAT
             )
-            if config.snapshot_pool_name != 'default'
+            if config.snapshot_pool_name != config.storage_pool_name
                 pool_name = config.snapshot_pool_name
             else
                 pool_name = config.storage_pool_name

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -642,7 +642,7 @@ module VagrantPlugins
         @password = nil if @password == UNSET_VALUE
         @id_ssh_key_file = 'id_rsa' if @id_ssh_key_file == UNSET_VALUE
         @storage_pool_name = 'default' if @storage_pool_name == UNSET_VALUE
-        @snapshot_pool_name = 'default' if @snapshot_pool_name == UNSET_VALUE
+        @snapshot_pool_name = @storage_pool_name if @snapshot_pool_name == UNSET_VALUE
         @storage_pool_path = nil if @storage_pool_path == UNSET_VALUE
         @random_hostname = false if @random_hostname == UNSET_VALUE
         @management_network_device = 'virbr0' if @management_network_device == UNSET_VALUE


### PR DESCRIPTION
Default to using the same storage pool in case the user defines
storage_pool_name without defining snapshot_pool_name and only use a
separate pool when snapshot_pool_name is explicitly set.

This will ensure that setting storage_pool_name to a different pool does
not also require setting snapshot_pool_name to match previous behaviour.

Additionally it is reasonable for a user to assume that if a Vagrantfile
sets storage_pool_name to something other than 'default', then there
should be no need for a default pool.