### PR TITLE
Fail on port collisions

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -97,6 +97,7 @@ module VagrantPlugins
             User=#{ssh_info[:username]}
             Port=#{ssh_info[:port]}
             UserKnownHostsFile=/dev/null
+            ExitOnForwardFailure=yes
             StrictHostKeyChecking=no
             PasswordAuthentication=no
             ForwardX11=#{ssh_info[:forward_x11] ? 'yes' : 'no'}


### PR DESCRIPTION
Partial Fix #321 by enabling option ExitOnForwardFailure=yes to detect
and fail on forward port mappings failing to bind.