### PR TITLE
Defer to Warden to call recover

### DIFF
--- a/lib/vagrant-libvirt/action/wait_till_up.rb
+++ b/lib/vagrant-libvirt/action/wait_till_up.rb
@@ -37,8 +37,8 @@ module VagrantPlugins
           if env[:machine].provider_config.qemu_use_session
             env[:metrics]['instance_ip_time'] = Util::Timer.time do
               retryable(on: Fog::Errors::TimeoutError, tries: 300) do
-                # If we're interrupted don't worry about waiting
-                return terminate(env) if env[:interrupted]
+                # just return if interrupted and let the warden call recover
+                return if env[:interrupted]
 
                 # Wait for domain to obtain an ip address
                 domain.wait_for(2) do
@@ -50,8 +50,8 @@ module VagrantPlugins
           else
             env[:metrics]['instance_ip_time'] = Util::Timer.time do
               retryable(on: Fog::Errors::TimeoutError, tries: 300) do
-                # If we're interrupted don't worry about waiting
-                return terminate(env) if env[:interrupted]
+                # just return if interrupted and let the warden call recover
+                return if env[:interrupted]
 
                 # Wait for domain to obtain an ip address
                 domain.wait_for(2) do
@@ -84,8 +84,8 @@ module VagrantPlugins
               end
             end
           end
-          # if interrupted above, just terminate immediately
-          return terminate(env) if env[:interrupted]
+          # just return if interrupted and let the warden call recover
+          return if env[:interrupted]
           @logger.info("Time for SSH ready: #{env[:metrics]['instance_ssh_time']}")
 
           # Booted and ready for use.
@@ -95,8 +95,6 @@ module VagrantPlugins
         end
 
         def recover(env)
-          return if env['vagrant.error'].is_a?(Vagrant::Errors::VagrantError)
-
           # Undo the import
           terminate(env)
         end


### PR DESCRIPTION
Warden will call the recover method when env[:interrupted] is set, so
just return instead and let it walk the stack to perform cleanup. This
ensures that during the WaitTillUp action that the user setting to
disable destroy_on_error is respected should the exception occur during
looking for the IP address or SSH connection.