### PR TITLE
Add environment variable for qemu_use_session

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ end
 * `random_hostname` - To create a domain name with extra information on the end
   to prevent hostname conflicts.
 * `default_prefix` - The default Libvirt guest name becomes a concatenation of the
-   `<current_directory>_<guest_name>`. The current working directory is the default prefix 
+   `<current_directory>_<guest_name>`. The current working directory is the default prefix
    to the guest name. The `default_prefix` options allow you to set the guest name prefix.
 * `cmd_line` - Arguments passed on to the guest kernel initramfs or initrd to
   use. Equivalent to qemu `-append`, only possible to use in combination with `initrd` and `kernel`.
@@ -1256,6 +1256,12 @@ Vagrant.configure("2") do |config|
       :mode => "bridge",
       :type => "bridge"
 end
+```
+
+You can globally enable or disable qemu_use_session with the environment variable `VAGRANT_LIBVIRT_QEMU_USE_SESSION`
+
+```shell
+export VAGRANT_LIBVIRT_QEMU_USE_SESSION=false
 ```
 
 ## Customized Graphics

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -659,7 +659,13 @@ module VagrantPlugins
         @management_network_domain = nil if @management_network_domain == UNSET_VALUE
         @system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
 
-        @qemu_use_session = false if @qemu_use_session == UNSET_VALUE
+        if ENV['VAGRANT_LIBVIRT_QEMU_USE_SESSION'] == 'true'
+          @qemu_use_session = true if @qemu_use_session == UNSET_VALUE
+        elsif ENV['VAGRANT_LIBVIRT_QEMU_USE_SESSION'] == 'false'
+          @qemu_use_session = false if @qemu_use_session == UNSET_VALUE
+        else
+          @qemu_use_session = false if @qemu_use_session == UNSET_VALUE
+        end
 
         # generate a URI if none is supplied
         @uri = _generate_uri if @uri == UNSET_VALUE

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -659,12 +659,8 @@ module VagrantPlugins
         @management_network_domain = nil if @management_network_domain == UNSET_VALUE
         @system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
 
-        if ENV['VAGRANT_LIBVIRT_QEMU_USE_SESSION'] == 'true'
-          @qemu_use_session = true if @qemu_use_session == UNSET_VALUE
-        elsif ENV['VAGRANT_LIBVIRT_QEMU_USE_SESSION'] == 'false'
-          @qemu_use_session = false if @qemu_use_session == UNSET_VALUE
-        else
-          @qemu_use_session = false if @qemu_use_session == UNSET_VALUE
+        if @qemu_use_session == UNSET_VALUE
+          @qemu_use_session = ENV['VAGRANT_LIBVIRT_QEMU_USE_SESSION'] == 'true'
         end
 
         # generate a URI if none is supplied

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -134,6 +134,13 @@ en:
       network_not_available_error: |-
         Network %{network_name} is not available. Specify available network
         name, or an ip address if you want to create a new network.
+
+        Note: Private networks do not work with QEMU session enabled as root
+        access is required to create new network devices.
+
+        Set libvirt.qemu_use_session = false if you want to use private networks
+        on a per VM basis or use VAGRANT_LIBVIRT_QEMU_USE_SESSION=false for
+        setting it globally.
       activate_network_error: |-
         Error while activating network: %{error_message}.
       autostart_network_error: |-


### PR DESCRIPTION
This PR adds in support for new environment variable `VAGRANT_LIBVIRT_QEMU_USE_SESSION` which allows a user to globally overwrite the `qemu_use_session` variable if it is not set within the Vagrantfile. 

It was inspired by this BZ comment https://bugzilla.redhat.com/show_bug.cgi?id=1697773#c3 which a user encountered a problem when the Fedora maintainers chose to set  qemu_use_session to true in by default.  Having this environment variable will allow users to not have to add `vm.qemu_use_session = false` their Vagrantfiles if distributions chose to change upstreams default setting.

Also, having this setting might allow for an easier transition for setting `vm.qemu_use_session = true` b default in https://github.com/vagrant-libvirt/vagrant-libvirt/pull/969.

I also added a bit to the error message from `network_not_available_error` to help make it more clear on what kind of issue a user might be having if they set `vm.qemu_use_session = true` or it is set to true by default by different distributions. 

Let me know if there needs to be anything changed.