### PR TITLE
package_domain.rb: Fix getting virt-sysprep operations envvar

### DIFF
--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
           `qemu-img rebase -p -b "" #{@tmp_img}`
           # remove hw association with interface
           # working for centos with lvs default disks
-          operations = ENV.get('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS', 'defaults,-ssh-userdir')
+          operations = ENV['VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS'] || 'defaults,-ssh-userdir'
           `virt-sysprep --no-logfile --operations #{operations} -a #{@tmp_img}`
           # add any user provided file
           extra = ''


### PR DESCRIPTION
Follow up to #955.

Use `ENV.[]` for getting the environment variable instead of the
non-standard `ENV.get`.