### PR TITLE
Halt a domain before packaging it as a box

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -161,10 +161,14 @@ module VagrantPlugins
         end
       end
 
-      # not implemented and looks like not require
+      # Create/package a new Vagrant Box from the current Domain.
+      # This action requires access to the Domain disk image files and will use
+      # virt-sysprep (from libguestfs project) to clean the image, removing
+      # host SSH keys, etc.
       def self.action_package
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
+          b.use action_halt
           b.use PackageDomain
         end
       end


### PR DESCRIPTION
Ensure that we do not try to package a currently running domain (which will lead to hard to debug and strange issues, and is generally not a good idea). This may happen when creating boxes with Packer.