### PR TITLE
Add public_address provider capability

### DIFF
--- a/lib/vagrant-libvirt/cap/public_address.rb
+++ b/lib/vagrant-libvirt/cap/public_address.rb
@@ -1,0 +1,16 @@
+module VagrantPlugins
+  module ProviderLibvirt
+    module Cap
+      class PublicAddress
+        def self.public_address(machine)
+          # This does not need to be a globally routable address, it
+          # only needs to be accessible from the machine running
+          # Vagrant.
+          ssh_info = machine.ssh_info
+          return nil if !ssh_info
+          ssh_info[:host]
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -39,6 +39,11 @@ module VagrantPlugins
         Cap::NicMacAddresses
       end
 
+      provider_capability(:libvirt, :public_address) do
+        require_relative 'cap/public_address'
+        Cap::PublicAddress
+      end
+
       # lower priority than nfs or rsync
       # https://github.com/vagrant-libvirt/vagrant-libvirt/pull/170
       synced_folder('9p', 4) do


### PR DESCRIPTION
Used by [vagrant-share plugin](https://www.vagrantup.com/docs/share/) to determine local guest address for forwarding via [ngrok](https://ngrok.com).

Here is an example that exposes HTTP in the guest:

```
~/d9 $ cat Vagrantfile
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.box = "bento/debian-9"

  config.vm.network "forwarded_port", guest: 80, host: 8080

  config.vm.provision "shell", inline: <<-SHELL
    apt-get update
    apt-get install -qq apache2
  SHELL
end
~/d9 $ vagrant up
Bringing machine 'default' up with 'libvirt' provider...
==> default: Checking if box 'bento/debian-9' version '201906.17.0' is up to date...
==> default: Creating image (snapshot of base box volume).
==> default: Creating domain with the following settings...
==> default:  -- Name:              d9_default
==> default:  -- Domain type:       kvm
==> default:  -- Cpus:              1
==> default:  -- Feature:           acpi
==> default:  -- Feature:           apic
==> default:  -- Feature:           pae
==> default:  -- Memory:            512M
==> default:  -- Management MAC:    
==> default:  -- Loader:            
==> default:  -- Nvram:             
==> default:  -- Base box:          bento/debian-9
==> default:  -- Storage pool:      default
==> default:  -- Image:             /home/libvirt-images/d9_default.img (64G)
==> default:  -- Volume Cache:      default
==> default:  -- Kernel:            
==> default:  -- Initrd:            
==> default:  -- Graphics Type:     vnc
==> default:  -- Graphics Port:     -1
==> default:  -- Graphics IP:       127.0.0.1
==> default:  -- Graphics Password: Not defined
==> default:  -- Video Type:        cirrus
==> default:  -- Video VRAM:        9216
==> default:  -- Sound Type:	
==> default:  -- Keymap:            en-us
==> default:  -- TPM Path:          
==> default:  -- INPUT:             type=mouse, bus=ps2
==> default: Creating shared folders metadata...
==> default: Starting domain.
==> default: Waiting for domain to get an IP address...
==> default: Waiting for SSH to become available...
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Forwarding ports...
==> default: 80 (guest) => 8080 (host) (adapter eth0)
==> default: Installing rsync to the VM...
==> default: Rsyncing folder: /home/zakame/d9/ => /vagrant
==> default: Running provisioner: shell...
    default: Running: inline script
    ...
    default: Setting up apache2 (2.4.25-3+deb9u7) ...
    ...
    default: Created symlink /etc/systemd/system/multi-user.target.wants/apache2.service → /lib/systemd/system/apache2.service.
    default: Created symlink /etc/systemd/system/multi-user.target.wants/apache-htcacheclean.service → /lib/systemd/system/apache-htcacheclean.service.
    default: Processing triggers for libc-bin (2.24-11+deb9u4) ...
    default: Processing triggers for systemd (232-25+deb9u11) ...
~/d9 $ vagrant share
Vagrant Share now defaults to using the `ngrok` driver.
The `classic` driver has been deprecated.

For more information about the `ngrok` driver, please
refer to the documentation:

  https://www.vagrantup.com/docs/share/

==> default: Detecting network information for machine...
    default: Local machine address: 192.168.121.88
    default: Local HTTP port: 8080
    default: Local HTTPS port: disabled
==> default: Creating Vagrant Share session...
==> default: HTTP URL: http://203d39b4.ngrok.io
==> default: 
```

Currently works with ngrok 2.2.x (also works in the latest ngrok 2.3.x but needs `vagrant share --debug` due to the ngrok URL [not being printed](https://github.com/hashicorp/vagrant/issues/10799).)