### PR TITLE
action/forward_ports.rb: Fix SSH tunnel spawning and PID tracking

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -98,6 +98,7 @@ module VagrantPlugins
             Port=#{ssh_info[:port]}
             UserKnownHostsFile=/dev/null
             ExitOnForwardFailure=yes
+            ControlMaster=no
             StrictHostKeyChecking=no
             PasswordAuthentication=no
             ForwardX11=#{ssh_info[:forward_x11] ? 'yes' : 'no'}
@@ -109,7 +110,7 @@ module VagrantPlugins
           options += " -o ProxyCommand=\"#{ssh_info[:proxy_command]}\"" if machine.provider_config.connect_via_ssh
 
           # TODO: instead of this, try and lock and get the stdin from spawn...
-          ssh_cmd = 'exec '
+          ssh_cmd = ''
           if host_port <= 1024
             @@lock.synchronize do
               # TODO: add i18n
@@ -127,7 +128,7 @@ module VagrantPlugins
           log_file = ssh_forward_log_file(host_ip, host_port,
                                           guest_ip, guest_port)
           @logger.info "Logging to #{log_file}"
-          spawn(ssh_cmd, [:out, :err] => [log_file, 'w'])
+          spawn(ssh_cmd, [:out, :err] => [log_file, 'w'], :pgroup => true)
         end
 
         def ssh_forward_log_file(host_ip, host_port, guest_ip, guest_port)


### PR DESCRIPTION
By-product while developing for #1036:

- Explicitly disable any SSH multiplexing here so PID tracking of
  tunnels works correctly.

- Using `exec ssh` in the spawn forces Ruby to use a subshell (as exec
  is a shell builtin) instead of spawning the ssh process directly, which
  results in getting the wrong (and dead, as the exec replaces the
  subshell) PID to track and clean up later.

- Run the ssh tunnel command on its own process group, essentially
  daemonizing it and keeping its PID intact even when `vagrant up` command
  is run on shell/consoles without an explicit TTY, such as Emacs Eshell.