### PR TITLE
Allow to specify multiple hyperv features

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -355,7 +355,10 @@ module VagrantPlugins
           raise 'Feature name AND state must be specified'
         end
 
-        @features_hyperv = [{name: options[:name], state: options[:state]}]  if @features_hyperv == UNSET_VALUE
+        @features_hyperv = []  if @features_hyperv == UNSET_VALUE
+
+        @features_hyperv.push(name:   options[:name],
+                           state: options[:state])
       end
 
       def cputopology(options = {})


### PR DESCRIPTION
There is a bug in code preventing multiple hyperv features to be used.
(if @features_hyperv is not UNSET_VALUE additional feature is not added -> it is ignored )

Support for hyperv features comes from this PR:
https://github.com/vagrant-libvirt/vagrant-libvirt/pull/870

simplification done in that PR is not correct
