### PR TITLE
Add support for spinlocks hyperv feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,6 +1258,8 @@ Vagrant.configure("2") do |config|
     libvirt.hyperv_feature :name => 'relaxed', :state => 'on'
     # Enable virtual APIC
     libvirt.hyperv_feature :name => 'vapic', :state => 'on'
+    # Enable spinlocks (requires retries to be specified)
+    libvirt.hyperv_feature :name => 'spinlocks', :state => 'on', :retries => '8191'
   end
 end
 ```

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -237,7 +237,11 @@ module VagrantPlugins
             env[:ui].info(" -- Feature:           #{feature}")
           end
           @features_hyperv.each do |feature|
-            env[:ui].info(" -- Feature (HyperV):  name=#{feature[:name]}, state=#{feature[:state]}")
+            if feature[:name] == 'spinlocks'
+              env[:ui].info(" -- Feature (HyperV):  name=#{feature[:name]}, state=#{feature[:state]}, retries=#{feature[:retries]}")
+            else
+              env[:ui].info(" -- Feature (HyperV):  name=#{feature[:name]}, state=#{feature[:state]}")
+            end
           end
           env[:ui].info(" -- Clock offset:      #{@clock_offset}")
           @clock_timers.each do |timer|

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -398,10 +398,20 @@ module VagrantPlugins
           raise 'Feature name AND state must be specified'
         end
 
+        if options[:name] == 'spinlocks' && options[:retries].nil?
+          raise 'Feature spinlocks requires retries parameter'
+        end
+
         @features_hyperv = []  if @features_hyperv == UNSET_VALUE
 
-        @features_hyperv.push(name: options[:name],
-                              state: options[:state])
+        if options[:name] == 'spinlocks'
+          @features_hyperv.push(name:   options[:name],
+                             state: options[:state],
+                             retries: options[:retries])
+        else
+          @features_hyperv.push(name:   options[:name],
+                             state: options[:state])
+        end
       end
 
       def clock_timer(options = {})

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -99,7 +99,7 @@
     <% if !@features_hyperv.empty? %>
     <hyperv>
       <% @features_hyperv.each do |feature| %>
-      <<%= feature[:name] %> state='<%= feature[:state] %>' />
+      <<%= feature[:name] %> state='<%= feature[:state] %>'<% if feature[:name] == 'spinlocks' %> retries='<%= feature[:retries] %>'<% end %> />
       <% end %>
     </hyperv>
     <% end %>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -34,6 +34,7 @@
     <pae/>
     <hyperv>
       <BBB state='on' />
+      <spinlocks state='on' retries='4096' />
     </hyperv>
   </features>
   <clock offset='variable'>

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -43,6 +43,7 @@ describe 'templates/domain' do
       domain.clock_offset = 'variable'
       domain.clock_timer(name: 't1')
       domain.clock_timer(name: 't2', track: 'b', tickpolicy: 'c', frequency: 'd', mode: 'e',  present: 'yes')
+      domain.hyperv_feature(name: 'spinlocks', state: 'on', retries: '4096')
       domain.cputopology(sockets: '1', cores: '3', threads: '2')
       domain.machine_type = 'pc-compatible'
       domain.machine_arch = 'x86_64'


### PR DESCRIPTION
This adds support for spinlocks hyperv feature, by adding ability to specify retries count (to spinlocks feature).

Without being able to specify retries, libvirt ends with following error on RHEL-7:
Error while creating domain: Error saving the server: Call to virDomainDefineXML failed: XML error: invalid HyperV spinlock retry count