### PR TITLE
Use fog-libvirt filters when querying libvirt host

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -126,13 +126,9 @@ module VagrantPlugins
                 pool_name = @storage_pool_name
             end
             @logger.debug "Search for volume in pool: #{pool_name}"
-            actual_volumes =
-              env[:machine].provider.driver.connection.volumes.all.select do |x|
-                x.pool_name == pool_name
-              end
-            domain_volume = ProviderLibvirt::Util::Collection.find_matching(
-              actual_volumes, "#{@name}.img"
-            )
+            domain_volume = env[:machine].provider.driver.connection.volumes.all(
+              name: "#{@name}.img"
+            ).find { |x| x.pool_name == pool_name }
             raise Errors::DomainVolumeExists if domain_volume.nil?
             @domain_volume_path = domain_volume.path
           end

--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -25,15 +25,15 @@ module VagrantPlugins
           @name = "#{env[:domain_name]}.img"
 
           # Verify the volume doesn't exist already.
-          domain_volume = ProviderLibvirt::Util::Collection.find_matching(
-            env[:machine].provider.driver.connection.volumes.all, @name
-          )
-          raise Errors::DomainVolumeExists if domain_volume
+          domain_volume = env[:machine].provider.driver.connection.volumes.all(
+            name: @name
+          ).first
+          raise Errors::DomainVolumeExists if domain_volume.id
 
           # Get path to backing image - box volume.
-          box_volume = ProviderLibvirt::Util::Collection.find_matching(
-            env[:machine].provider.driver.connection.volumes.all, env[:box_volume_name]
-          )
+          box_volume = env[:machine].provider.driver.connection.volumes.all(
+            name: env[:box_volume_name]
+          ).first
           @backing_file = box_volume.path
 
           # Virtual size of image. Take value worked out by HandleBoxImage

--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
           domain_volume = env[:machine].provider.driver.connection.volumes.all(
             name: @name
           ).first
-          raise Errors::DomainVolumeExists if domain_volume.id
+          raise Errors::DomainVolumeExists if domain_volume && domain_volume.id
 
           # Get path to backing image - box volume.
           box_volume = env[:machine].provider.driver.connection.volumes.all(

--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -63,9 +63,10 @@ module VagrantPlugins
           # locking all subsequent actions as well.
           @@lock.synchronize do
             # Don't continue if image already exists in storage pool.
-            break if env[:machine].provider.driver.connection.volumes.all(
+            box_volume = env[:machine].provider.driver.connection.volumes.all(
               name: env[:box_volume_name]
-            ).first.id
+            ).first
+            break if box_volume && box_volume.id
 
             # Box is not available as a storage pool volume. Create and upload
             # it as a copy of local box image.

--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -63,9 +63,9 @@ module VagrantPlugins
           # locking all subsequent actions as well.
           @@lock.synchronize do
             # Don't continue if image already exists in storage pool.
-            break if ProviderLibvirt::Util::Collection.find_matching(
-              env[:machine].provider.driver.connection.volumes.all, env[:box_volume_name]
-            )
+            break if env[:machine].provider.driver.connection.volumes.all(
+              name: env[:box_volume_name]
+            ).first.id
 
             # Box is not available as a storage pool volume. Create and upload
             # it as a copy of local box image.

--- a/lib/vagrant-libvirt/action/handle_storage_pool.rb
+++ b/lib/vagrant-libvirt/action/handle_storage_pool.rb
@@ -24,9 +24,9 @@ module VagrantPlugins
           # locking all subsequent actions as well.
           @@lock.synchronize do
             # Check for storage pool, where box image should be created
-            break if ProviderLibvirt::Util::Collection.find_matching(
-              env[:machine].provider.driver.connection.pools.all, config.storage_pool_name
-            )
+            break unless env[:machine].provider.driver.connection.pools.all(
+              name: config.storage_pool_name
+            ).empty?
 
             @logger.info("No storage pool '#{config.storage_pool_name}' is available.")
 

--- a/lib/vagrant-libvirt/action/set_name_of_domain.rb
+++ b/lib/vagrant-libvirt/action/set_name_of_domain.rb
@@ -13,19 +13,16 @@ module VagrantPlugins
           env[:domain_name] = build_domain_name(env)
 
           begin
-            @logger.info("Looking for domain #{env[:domain_name]} through list " \
-                         "#{env[:machine].provider.driver.connection.servers.all}")
+            @logger.info("Looking for domain #{env[:domain_name]}")
             # Check if the domain name is not already taken
 
-            domain = ProviderLibvirt::Util::Collection.find_matching(
-              env[:machine].provider.driver.connection.servers.all, env[:domain_name]
+            domain = env[:machine].provider.driver.connection.servers.all(
+              name: env[:domain_name]
             )
-          rescue Fog::Errors::Error => e
+          rescue Libvirt::RetrieveError => e
             @logger.info(e.to_s)
             domain = nil
           end
-
-          @logger.info("Looking for domain #{env[:domain_name]}")
 
           unless domain.nil?
             raise ProviderLibvirt::Errors::DomainNameExists,


### PR DESCRIPTION
This commit replaces the pattern where the metadata for all volumes,
servers, or pools was downloaded and then searched. Instead a filter
argument is passed to the connection and only the metadata for the named
resource is returned, if it exists. This results in significant speed
increases for libvirt hosts that are offsite or have many volumes.

Example timings for `vagrant up` to an offsite libvirt host with lots of volumes/images over ssh, assuming the box image is already present:
* master:
```
$ time vagrant up
Bringing machine 'default' up with 'libvirt' provider...
real    3m32.099s
user    0m5.531s
sys     0m2.176s
```
* this PR:
```
$ time vagrant up
Bringing machine 'default' up with 'libvirt' provider...
<snip>
real    1m25.364s
user    0m3.290s
sys     0m0.603s
```

All tests pass and I manually checked some of the failure/error states to make sure they still work properly:
* domain name is already in use
* domain volume exists already
* upload box image if it doesn't exist/use it if it does exist
* error if storage_pool_name doesn't exist
* box_volume doesn't exist when removing stale volumes
* pool no longer exists when removing stale volumes