### PR TITLE
fix remove_stale_volume.rb:26:in call: undefined method name for nil:…

### DIFF
--- a/lib/vagrant-libvirt/action/remove_stale_volume.rb
+++ b/lib/vagrant-libvirt/action/remove_stale_volume.rb
@@ -16,13 +16,19 @@ module VagrantPlugins
 
         def call(env)
           # Remove stale server volume
-          env[:ui].info(I18n.t('vagrant_libvirt.remove_stale_volume'))
-
           config = env[:machine].provider_config
           # Check for storage pool, where box image should be created
           fog_pool = ProviderLibvirt::Util::Collection.find_matching(
             env[:machine].provider.driver.connection.pools.all, config.storage_pool_name
           )
+
+          env[:result] = nil
+
+          if not fog_pool
+            @logger.debug("**** Pool #{config.storage_pool_name} not found")
+            return @app.call(env)
+          end
+
           @logger.debug("**** Pool #{fog_pool.name}")
 
           # This is name of newly created image for vm.
@@ -34,13 +40,11 @@ module VagrantPlugins
             env[:machine].provider.driver.connection.volumes.all, name
           )
           if box_volume && box_volume.pool_name == fog_pool.name
+            env[:ui].info(I18n.t('vagrant_libvirt.remove_stale_volume'))
             @logger.info("Deleting volume #{box_volume.key}")
             box_volume.destroy
             env[:result] = box_volume
-          else
-            env[:result] = nil
           end
-
           # Continue the middleware chain.
           @app.call(env)
         end


### PR DESCRIPTION
hi,
using the actual vagrant master version and vagrant-libvirt master, removing a non-existant domain fails with:



> ==> default: Remove stale volume...
> Traceback (most recent call last):
>         23: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/batch_action.rb:86:in `block (2 levels) in run'
>         22: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/machine.rb:198:in `action'
>         21: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/machine.rb:198:in `call'
>         20: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/environment.rb:613:in `lock'
>         19: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/machine.rb:212:in `block in action'
>         18: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/machine.rb:240:in `action_raw'
>         17: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/runner.rb:89:in `run'
>         16: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/util/busy.rb:19:in `busy'
>         15: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/runner.rb:89:in `block in run'
>         14: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/builder.rb:116:in `call'
>         13: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:48:in `call'
>         12: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
>         11: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:48:in `call'
>         10: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/builtin/call.rb:53:in `call'
>          9: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/runner.rb:89:in `run'
>          8: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/util/busy.rb:19:in `busy'
>          7: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/runner.rb:89:in `block in run'
>          6: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/builder.rb:116:in `call'
>          5: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:48:in `call'
>          4: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:107:in `block in finalize_action'
>          3: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:48:in `call'
>          2: from /home/vagrant/vagrant-libvirt/lib/vagrant-libvirt/action/set_name_of_domain.rb:35:in `call'
>          1: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:48:in `call'
> /home/vagrant/vagrant-libvirt/lib/vagrant-libvirt/action/remove_stale_volume.rb:26:in `call': undefined method `name' for nil:NilClass (NoMethodError)
> 

Reproduce by:

vagrant init ..
vagrant remove -f

Attached patch fixes this issue by only producing log output if fog_pool is set.