### PR TITLE
handle_box_image.rb:89: syntax error, unexpected tIDENTIFIER, expecting keyword_do

### DIFF
--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -80,14 +80,17 @@ module VagrantPlugins
             message << " in storage pool #{config.storage_pool_name}."
             @logger.info(message)
 
+            @storage_volume_uid = storage_uid env
+            @storage_volume_gid = storage_gid env
+
             begin
               fog_volume = env[:machine].provider.driver.connection.volumes.create(
                 name: env[:box_volume_name],
                 allocation: "#{box_image_size / 1024 / 1024}M",
                 capacity: "#{box_virtual_size}G",
                 format_type: box_format,
-                owner: storage_uid env,
-                group: storage_gid env,
+                owner: @storage_volume_uid,
+                group: @storage_volume_gid,
                 pool_name: config.storage_pool_name
               )
             rescue Fog::Errors::Error => e


### PR DESCRIPTION
hi,

using the actual master build i fail to spin up a vagrant box, it fails with:

```
Bringing machine 'default' up with 'libvirt' provider...
Traceback (most recent call last):
        17: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/batch_action.rb:86:in `block (2 levels) in run'
        16: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/machine.rb:198:in `action'
        15: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/machine.rb:198:in `call'
        14: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/environment.rb:613:in `lock'
        13: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/machine.rb:212:in `block in action'
        12: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/machine.rb:240:in `action_raw'
        11: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/runner.rb:89:in `run'
        10: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/util/busy.rb:19:in `busy'
         9: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/runner.rb:89:in `block in run'
         8: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/builder.rb:116:in `call'
         7: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:48:in `call'
         6: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
         5: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:48:in `call'
         4: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/builtin/box_check_outdated.rb:31:in `call'
         3: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/warden.rb:48:in `call'
         2: from /var/lib/gems/2.5.0/bundler/gems/vagrant-10332d7ec66c/lib/vagrant/action/builtin/call.rb:47:in `call'
         1: from /home/vagrant/vagrant-libvirt/lib/vagrant-libvirt/action.rb:36:in `block (2 levels) in action_up'
/home/vagrant/vagrant-libvirt/lib/vagrant-libvirt/action.rb:36:in `require': /home/vagrant/vagrant-libvirt/lib/vagrant-libvirt/action/handle_box_image.rb:89: syntax error, unexpected tIDENTIFIER, expecting keyword_do or '{' or '(' (SyntaxError)
...         owner: storage_uid env,
...                            ^~~
/home/vagrant/vagrant-libvirt/lib/vagrant-libvirt/action/handle_box_image.rb:92: syntax error, unexpected ')', expecting keyword_end
              )
              ^
/home/vagrant/vagrant-libvirt/lib/vagrant-libvirt/action/handle_box_image.rb:93: syntax error, unexpected =>
...   rescue Fog::Errors::Error => e
```

pull request attempts to solve this issue.