### PR TITLE
Allow dev with latest vagrant to use newer vagrant-spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   matrix:
     - VAGRANT_VERSION=v2.0.4
     - VAGRANT_VERSION=v2.1.5
-    - VAGRANT_VERSION=v2.2.6
+    - VAGRANT_VERSION=v2.2.4
     - VAGRANT_VERSION=master
 rvm:
   - 2.2.10
@@ -34,9 +34,9 @@ matrix:
       rvm: 2.6.6
     - env: VAGRANT_VERSION=v2.1.5
       rvm: 2.6.6
-    - env: VAGRANT_VERSION=v2.2.6
+    - env: VAGRANT_VERSION=v2.2.4
       rvm: 2.2.10
-    - env: VAGRANT_VERSION=v2.2.6
+    - env: VAGRANT_VERSION=v2.2.4
       rvm: 2.3.5
     - env: VAGRANT_VERSION=master
       rvm: 2.2.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,21 @@ env:
   matrix:
     - VAGRANT_VERSION=v2.0.4
     - VAGRANT_VERSION=v2.1.5
-    - VAGRANT_VERSION=v2.2.3
+    - VAGRANT_VERSION=v2.2.7
+    - VAGRANT_VERSION=master
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - 2.6.1
+  - 2.2.10
+  - 2.3.5
+  - 2.4.10
+  - 2.6.6
 
 matrix:
   allow_failures:
     - env: VAGRANT_VERSION=master
   exclude:
     - env: VAGRANT_VERSION=v2.0.4
-      rvm: 2.6.1
+      rvm: 2.6.6
     - env: VAGRANT_VERSION=v2.1.5
-      rvm: 2.6.1
+      rvm: 2.6.6
+    - env: VAGRANT_VERSION=master
+      rvm: 2.2.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   matrix:
     - VAGRANT_VERSION=v2.0.4
     - VAGRANT_VERSION=v2.1.5
-    - VAGRANT_VERSION=v2.2.7
+    - VAGRANT_VERSION=v2.2.6
     - VAGRANT_VERSION=master
 rvm:
   - 2.2.10
@@ -34,9 +34,9 @@ matrix:
       rvm: 2.6.6
     - env: VAGRANT_VERSION=v2.1.5
       rvm: 2.6.6
-    - env: VAGRANT_VERSION=v2.2.7
+    - env: VAGRANT_VERSION=v2.2.6
       rvm: 2.2.10
-    - env: VAGRANT_VERSION=v2.2.7
+    - env: VAGRANT_VERSION=v2.2.6
       rvm: 2.3.5
     - env: VAGRANT_VERSION=master
       rvm: 2.2.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,11 @@ matrix:
       rvm: 2.6.6
     - env: VAGRANT_VERSION=v2.1.5
       rvm: 2.6.6
+    - env: VAGRANT_VERSION=v2.2.7
+      rvm: 2.2.10
+    - env: VAGRANT_VERSION=v2.2.7
+      rvm: 2.3.5
     - env: VAGRANT_VERSION=master
       rvm: 2.2.10
+    - env: VAGRANT_VERSION=master
+      rvm: 2.3.5

--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,28 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  if ENV['VAGRANT_VERSION']
+  vagrant_version = ENV['VAGRANT_VERSION']
+  if vagrant_version
     gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git',
-      tag: ENV['VAGRANT_VERSION']
+      tag: vagrant_version
   else
     gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git'
   end
 
-  gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :ref => '161128f2216cee8edb7bcd30da18bd4dea86f98a'
+  begin
+    raise if vagrant_version.empty?
+    vagrant_version = vagrant_version[1..-1] if vagrant_version && vagrant_version.start_with?('v')
+    vagrant_gem_version = Gem::Version.new(vagrant_version)
+  rescue
+    # default to newer if unable to parse
+    vagrant_gem_version = Gem::Version.new('2.2.8')
+  end
+
+  if vagrant_gem_version <= Gem::Version.new('2.2.7')
+    gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :ref => '161128f2216cee8edb7bcd30da18bd4dea86f98a'
+  else
+    gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec'
+  end
 
   gem 'pry'
 end


### PR DESCRIPTION
Latest vagrant depends on a vagrant-spec release containing a more
recent dependency on childprocess than is supported for earlier releases
of vagrant.

Adjust dependencies to pin to the specific release of vagrant-spec if
the request version of vagrant is 2.2.7 or older.

Does not attempt to handle the situation where a version is specified
that cannot be parsed.