### PR TITLE
Tidy up README and TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ can help a lot :-)
 
 ## Index
 
+<!-- note in vim set "let g:vmt_list_item_char='-'" to generate the correct output -->
+<!-- vim-markdown-toc GFM -->
 
 - [Features](#features)
 - [Future work](#future-work)
@@ -32,7 +34,7 @@ can help a lot :-)
   - [Public Network Options](#public-network-options)
   - [Management Network](#management-network)
 - [Additional Disks](#additional-disks)
-    - [Reload behavior](#reload-behavior-1)
+  - [Reload behavior](#reload-behavior-1)
 - [CDROMs](#cdroms)
 - [Input](#input)
 - [PCI device passthrough](#pci-device-passthrough)
@@ -40,23 +42,30 @@ can help a lot :-)
   - [USB Controller Configuration](#usb-controller-configuration)
   - [USB Device Passthrough](#usb-device-passthrough)
   - [USB Redirector Devices](#usb-redirector-devices)
+    - [Filter for USB Redirector Devices](#filter-for-usb-redirector-devices)
 - [Random number generator passthrough](#random-number-generator-passthrough)
-- [Watchdog·Device](#watchdog-device)
+- [Watchdog device](#watchdog-device)
 - [Smartcard device](#smartcard-device)
 - [Hypervisor Features](#hypervisor-features)
-- [CPU Features](#cpu-features)
+- [CPU features](#cpu-features)
+- [Memory Backing](#memory-backing)
 - [No box and PXE boot](#no-box-and-pxe-boot)
 - [SSH Access To VM](#ssh-access-to-vm)
 - [Forwarded Ports](#forwarded-ports)
 - [Synced Folders](#synced-folders)
 - [QEMU Session Support](#qemu-session-support)
 - [Customized Graphics](#customized-graphics)
+- [TPM Devices](#tpm-devices)
+- [Libvirt communication channels](#libvirt-communication-channels)
+- [Custom command line arguments](#custom-command-line-arguments)
 - [Box Format](#box-format)
 - [Create Box](#create-box)
 - [Package Box from VM](#package-box-from-vm)
 - [Troubleshooting VMs](#troubleshooting-vms)
 - [Development](#development)
 - [Contributing](#contributing)
+
+<!-- vim-markdown-toc -->
 
 ## Features
 
@@ -1559,3 +1568,8 @@ $ bundle exec vagrant up --provider=libvirt
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+<!--
+ # styling for TOC
+ vim: expandtab shiftwidth=2
+-->

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ end
 * `random_hostname` - To create a domain name with extra information on the end
   to prevent hostname conflicts.
 * `default_prefix` - The default Libvirt guest name becomes a concatenation of the
-   `<current_directory>_<guest_name>`. The current working directory is the default prefix 
+   `<current_directory>_<guest_name>`. The current working directory is the default prefix
    to the guest name. The `default_prefix` options allow you to set the guest name prefix.
 * `cmd_line` - Arguments passed on to the guest kernel initramfs or initrd to
   use. Equivalent to qemu `-append`, only possible to use in combination with `initrd` and `kernel`.
@@ -1495,7 +1495,7 @@ $ vagrant package
 The first step for troubleshooting a VM image that appears to not boot correctly,
 or hangs waiting to get an IP, is to check it with a VNC viewer. A key thing
 to remember is that if the VM doesn't get an IP, then vagrant can't communicate
-with it to configure anything, so a problem at this stage is likely to come from 
+with it to configure anything, so a problem at this stage is likely to come from
 the VM, but we'll outline the tools and common problems to help you troubleshoot
 that.
 
@@ -1507,8 +1507,8 @@ out which port it's listening on, or can configure it with `graphics_port` and
 
 Note: Connecting with the console (`virsh console`) requires additional config,
 so some VMs may not show anything on the console at all, instead displaying it in
-the VNC console. The issue with the text console is that you also need to build the 
-image used to tell the kernel to output to the console during boot, and typically 
+the VNC console. The issue with the text console is that you also need to build the
+image used to tell the kernel to output to the console during boot, and typically
 most do not have this built in.
 
 Problems we've seen in the past include:
@@ -1519,9 +1519,8 @@ the VM
 If you're still confused, check the Github Issues for this repo for anything that
 looks similar to your problem.
 
-[Github Issue #1032](https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1032) 
-contains some historical troubleshooting for VMs that appeared
-to hang. 
+[Github Issue #1032](https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1032)
+contains some historical troubleshooting for VMs that appeared to hang.
 
 Did you hit a problem that you'd like to note here to save time in the future?
 Please do!


### PR DESCRIPTION
Bring the TOC in line with recent additions and enable the ability to
use a vim plugin to quickly regenerate in lieu of a better alternative.

Using https://github.com/mzlogin/vim-markdown-toc

Clean up any trailing whitespace so that subsequent file updates
by other PRs will be able to simply regen using appropriate tooling
without pulling in additional changes unrelated.