### PR TITLE
remove redundant setting of default volume/backingStore mode

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -51,7 +51,6 @@ module VagrantPlugins
                   xml.permissions do
                     xml.owner storage_uid(env)
                     xml.group storage_gid(env)
-                    xml.mode '0600'
                     xml.label 'virt_image_t'
                   end
                 end
@@ -61,7 +60,6 @@ module VagrantPlugins
                   xml.permissions do
                     xml.owner storage_uid(env)
                     xml.group storage_gid(env)
-                    xml.mode '0600'
                     xml.label 'virt_image_t'
                   end
                 end


### PR DESCRIPTION
According to the docs, for volumes and backingStores: "The mode defaults to 0600 when not provided.  Removing this setting here allows the pool configuration to set the default mode.

* https://gitlab.com/libvirt/libvirt/-/blob/v6.5.0/docs/formatstorage.html.in#L801
* https://libvirt.org/formatstorage.html