### PR TITLE
Update test syntax to remove stubs

### DIFF
--- a/spec/support/libvirt_context.rb
+++ b/spec/support/libvirt_context.rb
@@ -25,6 +25,6 @@ shared_context 'libvirt' do
     # return some information for domain when needed
     allow(domain).to receive(:mac).and_return('9C:D5:53:F1:5A:E7')
 
-    machine.stub(id: id)
+    allow(machine).to receive(:id).and_return(id)
   end
 end

--- a/spec/support/sharedcontext.rb
+++ b/spec/support/sharedcontext.rb
@@ -28,7 +28,7 @@ shared_context 'unit' do
   let(:plugin)           { register_plugin }
 
   before (:each) do
-    machine.stub(guest: guest)
-    machine.stub(communicator: communicator)
+    allow(machine).to receive(:guest).and_return(guest)
+    allow(machine).to receive(:communicator).and_return(communicator)
   end
 end

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -33,7 +33,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
       before do
         allow(libvirt_domain).to receive(:list_snapshots).and_return([])
         allow(libvirt_domain).to receive(:has_managed_save?).and_return(nil)
-        root_disk.stub(name: 'test.img')
+        allow(root_disk).to receive(:name).and_return('test.img')
       end
 
       context 'when only has root disk' do
@@ -57,7 +57,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
 
         let(:extra_disk) { double('libvirt_extra_disk') }
         before do
-          extra_disk.stub(name: 'test-vdb.qcow2')
+          allow(extra_disk).to receive(:name).and_return('test-vdb.qcow2')
         end
 
         it 'destroys disks individually' do

--- a/spec/unit/action/set_name_of_domain_spec.rb
+++ b/spec/unit/action/set_name_of_domain_spec.rb
@@ -10,12 +10,12 @@ describe VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain do
     dmn = VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain.new(Object.new, @env)
     first  = dmn.build_domain_name(@env)
     second = dmn.build_domain_name(@env)
-    first.should_not eq(second)
+    expect(first).to_not eq(second)
   end
 
   it 'builds simple domain name' do
     @env.default_prefix = 'pre_'
     dmn = VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain.new(Object.new, @env)
-    dmn.build_domain_name(@env).should eq('pre_')
+    expect(dmn.build_domain_name(@env)).to eq('pre_')
   end
 end


### PR DESCRIPTION
Use of stubs are deprecated, switch to the newer expect/allow syntax.
