### PR TITLE
Limit CI jobs to a subset of combinations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,30 +15,18 @@ notifications:
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-  matrix:
-    - VAGRANT_VERSION=v2.0.4
-    - VAGRANT_VERSION=v2.1.5
-    - VAGRANT_VERSION=v2.2.4
-    - VAGRANT_VERSION=master
-rvm:
-  - 2.2.10
-  - 2.3.5
-  - 2.4.10
-  - 2.6.6
 
-matrix:
+jobs:
+  include:
+    - rvm: 2.2.10
+      env: VAGRANT_VERSION=v2.0.4
+    - rvm: 2.3.5
+      env: VAGRANT_VERSION=v2.1.5
+    - rvm: 2.4.10
+      env: VAGRANT_VERSION=v2.2.4
+    - rvm: 2.6.6
+      env: VAGRANT_VERSION=v2.2.4
+    - rvm: 2.6.6
+      env: VAGRANT_VERSION=master
   allow_failures:
     - env: VAGRANT_VERSION=master
-  exclude:
-    - env: VAGRANT_VERSION=v2.0.4
-      rvm: 2.6.6
-    - env: VAGRANT_VERSION=v2.1.5
-      rvm: 2.6.6
-    - env: VAGRANT_VERSION=v2.2.4
-      rvm: 2.2.10
-    - env: VAGRANT_VERSION=v2.2.4
-      rvm: 2.3.5
-    - env: VAGRANT_VERSION=master
-      rvm: 2.2.10
-    - env: VAGRANT_VERSION=master
-      rvm: 2.3.5


### PR DESCRIPTION
It's time consuming to execute many combinations of vagrant releases
along with versions of ruby. Limit to the most likely combinations.
