### PR TITLE
Use Vagrant::Util::TemplateRenderer instead of Erubis.

### DIFF
--- a/lib/vagrant-libvirt/util/erb_template.rb
+++ b/lib/vagrant-libvirt/util/erb_template.rb
@@ -1,20 +1,19 @@
-require 'erubis'
-
 module VagrantPlugins
   module ProviderLibvirt
     module Util
       module ErbTemplate
         # TODO: remove and use nokogiri builder
-        # TODO: might be a chance to use vagrant template system according to https://github.com/mitchellh/vagrant/issues/3231
         def to_xml(template_name = nil, data = binding)
           erb = template_name || self.class.to_s.split('::').last.downcase
-          path = File.join(File.dirname(__FILE__), '..', 'templates',
-                           "#{erb}.xml.erb")
-          template = File.read(path)
+          path = File.join(File.dirname(__FILE__), '..', 'templates')
+          template = "#{erb}.xml"
 
           # TODO: according to erubis documentation, we should rather use evaluate and forget about
           # binding since the template may then change variables values
-          Erubis::Eruby.new(template, trim: true).result(data)
+          Vagrant::Util::TemplateRenderer.render_with(:render, template, template_root: path) do |renderer|
+            iv = data.eval ("instance_variables.collect {|i| [i, instance_variable_get(i.to_sym)]}")
+            iv.each {|k, v| renderer.instance_variable_set(k, v)}
+          end
         end
       end
     end


### PR DESCRIPTION
Erubis is dead upstream, therefore it is good idea to avoid its usage.

Also, this allows to drop explicit dependency on Erubis, which is not specified anywhere and may cause issues when Vagrant changes its renderer.

Fixes #1142.