### PR TITLE
Limit docker image push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ jobs:
         name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=${DOCKERHUB_ORGANIZATION}/vagrant-libvirt
+          DOCKER_IMAGE=${DOCKERHUB_ORGANIZATION:-vagrantlibvirt}/vagrant-libvirt
           VERSION=noop
           if [ "${{ github.event_name }}" = "schedule" ]; then
             VERSION=nightly

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ jobs:
         name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=vagrantlibvirt/vagrant-libvirt
+          DOCKER_IMAGE=${{ github.repository_owner }}/vagrant-libvirt
           VERSION=noop
           if [ "${{ github.event_name }}" = "schedule" ]; then
             VERSION=nightly
@@ -55,7 +55,7 @@ jobs:
 
       -
         name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: secrets.DOCKERHUB_USERNAME != "" && github.event_name != 'pull_request'
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -66,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ secrets.DOCKERHUB_USERNAME != "" && github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,7 +62,7 @@ jobs:
           echo ::set-output name=access::${{ secrets.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request' }}
       -
         name: Login to DockerHub
-        if: steps.have_credentials.outputs.access == true
+        if: steps.have_credentials.outputs.access == 'true'
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ jobs:
         name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=${{ github.repository_owner }}/vagrant-libvirt
+          DOCKER_IMAGE=${DOCKERHUB_ORGANIZATION}/vagrant-libvirt
           VERSION=noop
           if [ "${{ github.event_name }}" = "schedule" ]; then
             VERSION=nightly
@@ -44,6 +44,8 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        env:
+          DOCKERHUB_ORGANIZATION: ${{ secrets.DOCKERHUB_ORGANIZATION }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,7 +62,7 @@ jobs:
           echo ::set-output name=access::${{ secrets.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request' }}
       -
         name: Login to DockerHub
-        if: steps.have_credentials.outputs.access
+        if: steps.have_credentials.outputs.access == true
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,7 +57,7 @@ jobs:
 
       -
         name: Login to DockerHub
-        if: secrets.DOCKERHUB_USERNAME != "" && github.event_name != 'pull_request'
+        if: secrets.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request'
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -68,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64
-          push: ${{ secrets.DOCKERHUB_USERNAME != "" && github.event_name != 'pull_request' }}
+          push: ${{ secrets.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,8 +56,13 @@ jobs:
           driver-opts: image=moby/buildkit:master
 
       -
+        name: Check have credentials
+        id: have_credentials
+        run: |
+          echo ::set-output name=access::${{ secrets.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request' }}
+      -
         name: Login to DockerHub
-        if: secrets.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request'
+        if: steps.have_credentials.outputs.access
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -68,7 +73,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64
-          push: ${{ secrets.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request' }}
+          push: ${{ steps.have_credentials.outputs.access }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}


### PR DESCRIPTION
Tweak workflow to skip attempting to push the docker image without
credentials additionally modify to allow the dockerhub organization to
be managed via a secret so that forked repos may push locally modified
images to their own dockerhub with a minimum of effort.

Additionally given the way github status checks works, this should allow
maintainers of this project to push the same commit to a local branch in
order to build and publish the image to the org dockerhub repository to
allow testing of the image before merging. Based on having first
reviewed and decided it was safe to allow access to any secrets.
