### PR TITLE
Tag version from git tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Vagrantfile
 !example_box/Vagrantfile
 .vagrant
 *.swp
+
+# don't commit the generated version
+lib/vagrant-libvirt/version

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,23 @@
 #require 'rubygems'
 #require 'bundler/setup'
 require 'bundler/gem_tasks'
+require File.expand_path('../lib/vagrant-libvirt/version', __FILE__)
+
 Bundler::GemHelper.install_tasks
 task default: [:deftask]
 task :deftask do
   puts 'call rake -T'
 end
+
+task :write_version do
+  VagrantPlugins::ProviderLibvirt.write_version()
+end
+
+task :clean_version do
+  rm_rf File.expand_path('../lib/vagrant-libvirt/version', __FILE__)
+end
+
+task "clean" => :clean_version
+task :write_version => :clean_version
+task "build" => :write_version
+task "release" => :write_version

--- a/lib/vagrant-libvirt/version.rb
+++ b/lib/vagrant-libvirt/version.rb
@@ -1,5 +1,28 @@
 module VagrantPlugins
   module ProviderLibvirt
-    VERSION = '0.2.1'.freeze
+    VERSION_FILE = File.dirname(__FILE__) + "/version"
+
+    def self.get_version
+      if File.exist?(VERSION_FILE)
+        version = File.read(VERSION_FILE)
+      else
+        git_version = `git describe --tags`
+        version_parts = git_version.split('-').first(2) # drop the git sha if it exists
+        if version_parts.length > 1
+          # increment the patch number so that this is marked as a pre-release of the
+          # next possible release
+          main_version_parts = Gem::Version.new(version_parts[0]).segments
+          main_version_parts[-1] = main_version_parts.last + 1
+          version_parts = main_version_parts + ["pre", version_parts[1]]
+        end
+        version = version_parts.join(".")
+      end
+
+      return version.freeze
+    end
+
+    def self.write_version
+      File.write(VERSION_FILE, self.get_version)
+    end
   end
 end

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |s|
   s.summary       = %q{libvirt provider for Vagrant.}
   s.homepage      = 'https://github.com/vagrant-libvirt/vagrant-libvirt'
 
-  s.files         = Dir.glob("{lib,locales}/**/*.*") + %w(LICENSE README.md)
+  s.files         = Dir.glob("{lib,locales}/**/*") + %w(LICENSE README.md)
   s.executables   = Dir.glob("bin/*.*").map{ |f| File.basename(f) }
   s.test_files    = Dir.glob("{test,spec,features}/**/*.*")
   s.name          = 'vagrant-libvirt'
   s.require_paths = ['lib']
-  s.version       = VagrantPlugins::ProviderLibvirt::VERSION
+  s.version       = VagrantPlugins::ProviderLibvirt.get_version()
 
   s.add_development_dependency "rspec-core", "~> 3.5.0"
   s.add_development_dependency "rspec-expectations", "~> 3.5.0"


### PR DESCRIPTION
Switch to looking up the version from a file with a fall back to get
it directly from git tags if the file isn't available.

The version file is automatically generated by a task of building of the
gem and included in the package release to prevent reading from git.

Should allow the release process to be automated from pushing of a git
tag.
