### PR TITLE
Ensure docker image build has history for version resolving

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -74,6 +74,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
           platforms: linux/amd64
           push: ${{ steps.have_credentials.outputs.access }}
           tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       -
         name: Prepare
         id: prep


### PR DESCRIPTION
With the switch to using git to resolve the version it's necessary to
ensure the history is available in the clone during the github action.
