### PR TITLE
Gemfile: update branch-name of 'vagrant-spec'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :development do
   if vagrant_gem_version <= Gem::Version.new('2.2.7')
     gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :ref => '161128f2216cee8edb7bcd30da18bd4dea86f98a'
   else
-    gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec'
+    gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :branch => "main"
   end
 
   gem 'pry'


### PR DESCRIPTION
fixes `bundle install` step from the README, currently broken by https://github.com/hashicorp/vagrant-spec/issues/41

```
~/src/vagrant-libvirt $ bundle install
....
Fetching git://github.com/hashicorp/vagrant-spec.git
fatal: Needed a single revision
Revision master does not exist in the repository git://github.com/hashicorp/vagrant-spec.git. Maybe you misspelled it?
```


Works fine now on my workstation with the new name:
```
Using vagrant-spec 0.0.1 from git://github.com/hashicorp/vagrant-spec.git (at main@b6b56c8)
Bundle complete! 10 Gemfile dependencies, 73 gems now installed.
```