### PR TITLE
Rudimentary start domain action spec

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -94,7 +94,7 @@ module VagrantPlugins
                   cpu_model.attributes['fallback'] = 'allow'
                   cpu_model.text = config.cpu_model
                 else
-                  if cpu_model.text != config.cpu_model
+                  if cpu_model.text.strip != config.cpu_model.strip
                     descr_changed = true
                     cpu_model.text = config.cpu_model
                   end

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'support/sharedcontext'
+require 'support/libvirt_context'
+
+require 'vagrant-libvirt/errors'
+require 'vagrant-libvirt/action/start_domain'
+
+describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
+  subject { described_class.new(app, env) }
+
+  include_context 'unit'
+  include_context 'libvirt'
+
+  let(:libvirt_domain) { double('libvirt_domain') }
+  let(:libvirt_client) { double('libvirt_client') }
+  let(:servers) { double('servers') }
+
+  let(:domain_xml) { File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), test_file)) }
+
+  describe '#call' do
+    before do
+      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
+        .to receive(:connection).and_return(connection)
+      allow(connection).to receive(:client).and_return(libvirt_client)
+      allow(libvirt_client).to receive(:lookup_domain_by_uuid).and_return(libvirt_domain)
+
+      allow(connection).to receive(:servers).and_return(servers)
+      allow(servers).to receive(:get).and_return(domain)
+    end
+
+    context 'default config' do
+      let(:test_file) { 'default.xml' }
+
+      before do
+        allow(libvirt_domain).to receive(:xml_desc).and_return(domain_xml)
+
+        allow(libvirt_domain).to receive(:max_memory).and_return(512*1024)
+        allow(libvirt_domain).to receive(:num_vcpus).and_return(1)
+      end
+
+      it 'should execute correctly' do
+        expect(libvirt_domain).to receive(:autostart=)
+        expect(domain).to receive(:start)
+
+        expect(subject.call(env)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/action/start_domain_spec/default.xml
+++ b/spec/unit/action/start_domain_spec/default.xml
@@ -1,0 +1,48 @@
+<domain xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0' type=''>
+  <name/>
+  <title/>
+  <description/>
+  <uuid/>
+  <memory/>
+  <vcpu>1</vcpu>
+
+
+  <cpu mode='host-model'>
+      <model fallback='allow'></model>
+  </cpu>
+
+
+  <os>
+        <type>hvm</type>
+    <kernel/>
+    <initrd></initrd>
+    <cmdline/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'/>
+  <devices>
+
+
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+
+
+    <input bus='ps2' type='mouse'/>
+
+      <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+      <video>
+        <model heads='1' type='cirrus' vram='9216'/>
+      </video>
+
+
+  </devices>
+
+</domain>


### PR DESCRIPTION
Add default domain start spec test and fix bug triggered by whitespace
mismatch in string comparison that would trigger unexpected domain
undefine and recreate.
