### PR TITLE
Add doc on ssh key replacement if repackaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1532,6 +1532,23 @@ The box is a tarball containing:
 
 ## Create Box
 
+If creating a box from a modified vagrant-libvirt machine, ensure that
+you have set the `config.ssh.insert_key = false` in the original Vagrantfile
+as otherwise Vagrant will replace the default connection key-pair that is
+required on first boot with one specific to the machine and prevent
+the default key from working on the exported result.
+```ruby
+Vagrant.configure("2") do |config|
+  # this setting is only recommended if planning to export the
+  # resulting machine
+  config.ssh.insert_key = false
+
+  config.vm.define :test_vm do |test_vm|
+    test_vm.vm.box = "fedora/32-cloud-base"
+  end
+end
+```
+
 To create a vagrant-libvirt box from a qcow2 image, run `create_box.sh`
 (located in the tools directory):
 

--- a/tools/create_box.sh
+++ b/tools/create_box.sh
@@ -11,6 +11,10 @@ usage() {
     echo "Usage: ${0} IMAGE [BOX] [Vagrantfile.add]"
     echo
     echo "Package a qcow2 image into a vagrant-libvirt reusable box"
+    echo ""
+    echo "If packaging from a Vagrant machine ensure 'config.ssh.insert_key = false' was "
+    echo "set in the original Vagrantfile to avoid removal of the default ssh key, "
+    echo "otherwise vagrant will not be able to connect to machines created from this box"
 }
 
 # Print the image's backing file


### PR DESCRIPTION
If planning to repackage a machine that is brought up with vagrant and
modified, it is necessary to avoid the default ssh replacement that
normally takes place to ensure the subsequent box that is halted and
packaged can be accessed by vagrant using the default ssh key
subsequently.

Add some small documentation notes to help users be aware to this so
that they know to set `config.ssh.insert_key = false` when using vagrant
to build a box.

Fixes: #1116
