### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,24 @@ jobs:
       env: VAGRANT_VERSION=v2.2.4
     - rvm: 2.6.6
       env: VAGRANT_VERSION=master
+      
+      
+#Power jobs added
+    - rvm: 2.2.10
+      arch: ppc64le
+      env: VAGRANT_VERSION=v2.0.4
+    - rvm: 2.3.5
+      arch: ppc64le
+      env: VAGRANT_VERSION=v2.1.5
+    - rvm: 2.4.10
+      arch: ppc64le
+      env: VAGRANT_VERSION=v2.2.4
+    - rvm: 2.6.6
+      arch: ppc64le
+      env: VAGRANT_VERSION=v2.2.4
+    - rvm: 2.6.6
+      arch: ppc64le
+      env: VAGRANT_VERSION=master
+
   allow_failures:
     - env: VAGRANT_VERSION=master


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/vagrant-libvirt/builds/202997840

Please have a look.

Regards,
Manish Kumar