### PR TITLE
Fix Broken `/etc/machine-id` by `vagrant package` due to virt-sysprep's `customize` operation

### DIFF
--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -50,7 +50,7 @@ module VagrantPlugins
           # remove hw association with interface
           # working for centos with lvs default disks
           options = ENV.fetch('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPTIONS', '')
-          operations = ENV.fetch('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS', 'defaults,-ssh-userdir')
+          operations = ENV.fetch('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS', 'defaults,-ssh-userdir,-customize')
           `virt-sysprep --no-logfile --operations #{operations} -a #{@tmp_img} #{options}`
           # add any user provided file
           extra = ''


### PR DESCRIPTION
virt-sysprep by default enable the `customize` operation, which will regenerate the `/etc/machine-id` by the end of the operation. This cause all newly created VMs by `vagrant up` coming with idential `/etc/machine-id` and so receive conflicted IP from DHCP.

~~Moreover, virt-sysprep also by default enable the `ssh-hostkeys` operation. On Debian/Ubuntu `openssh-server` package will NOT regenerate the SSH host keys if they are missing BEFORE `systemctl start ssh`, therefore all newly created VMs by `vagrant up` will not able to complete the initial SSH connection phase.~~

This PR disable ~~both~~ `customize` ~~and `ssh-hostkeys`~~ as per https://github.com/vagrant-libvirt/vagrant-libvirt/issues/851#issuecomment-520799720 recommendation.

Fixes https://github.com/vagrant-libvirt/vagrant-libvirt/issues/851