### PR TITLE
Include rsync to support syncing folders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN apt update \
         git \
         gosu \
         kmod \
-        openssh-client \
         libvirt-bin \
+        openssh-client \
+        rsync \
     && rm -rf /var/lib/apt/lists \
     ;
 


### PR DESCRIPTION
Add rsync to enable vagrant folder syncing.

Closes: #1183
