### PR TITLE
Support building from git-archive tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lib/vagrant-libvirt/version.rb export-subst

--- a/lib/vagrant-libvirt/version.rb
+++ b/lib/vagrant-libvirt/version.rb
@@ -1,21 +1,48 @@
+require 'open3'
+require 'tmpdir'
+
 module VagrantPlugins
   module ProviderLibvirt
     VERSION_FILE = File.dirname(__FILE__) + "/version"
 
+    GIT_ARCHIVE_VERSION = "$Format:%H %D$"
+
+    HOMEPAGE = 'https://github.com/vagrant-libvirt/vagrant-libvirt'
+
     def self.get_version
       if File.exist?(VERSION_FILE)
+        # built gem
         version = File.read(VERSION_FILE)
-      else
+      elsif self.inside_git_repository
+        # local repo
         git_version = `git describe --tags`
-        version_parts = git_version.split('-').first(2) # drop the git sha if it exists
-        if version_parts.length > 1
-          # increment the patch number so that this is marked as a pre-release of the
-          # next possible release
-          main_version_parts = Gem::Version.new(version_parts[0]).segments
-          main_version_parts[-1] = main_version_parts.last + 1
-          version_parts = main_version_parts + ["pre", version_parts[1]]
+        version = self.version_from_describe(git_version)
+      elsif !GIT_ARCHIVE_VERSION.start_with?('$Format')
+        # archive - format string replaced during export
+        hash, refs = GIT_ARCHIVE_VERSION.split(' ', 2)
+
+        tag = refs.split(',').select { |ref| ref.strip.start_with?("tag:") }.first
+        if tag != nil
+          # tagged
+          version = tag.strip.split(' ').last
+        else
+          # arbitrary branch/commit
+          Dir.mktmpdir do |dir|
+            stdout_and_stderr, status = Open3.capture2e("git -C #{dir} clone --bare #{HOMEPAGE}")
+            raise "failed to clone original to resolve version: #{stdout_and_stderr}" unless status.success?
+
+            stdout_and_stderr, status = Open3.capture2e("git --git-dir=#{dir}/vagrant-libvirt.git describe --tags #{hash}")
+            raise "failed to determine version for #{hash}: #{stdout_and_stderr}" unless status.success?
+          end
+
+          version = version_from_describe(stdout_and_stderr)
+
+          # in this case write the version file to avoid cloning a second time
+          File.write(VERSION_FILE, version)
         end
-        version = version_parts.join(".")
+      else
+        # no idea
+        version = "9999"
       end
 
       return version.freeze
@@ -23,6 +50,26 @@ module VagrantPlugins
 
     def self.write_version
       File.write(VERSION_FILE, self.get_version)
+    end
+
+    private
+
+    def self.inside_git_repository
+      _, status = Open3.capture2e("git rev-parse --git-dir")
+
+      status.success?
+    end
+
+    def self.version_from_describe(describe)
+      version_parts = git_version.split('-').first(2) # drop the git sha if it exists
+      if version_parts.length > 1
+        # increment the patch number so that this is marked as a pre-release of the
+        # next possible release
+        main_version_parts = Gem::Version.new(version_parts[0]).segments
+        main_version_parts[-1] = main_version_parts.last + 1
+        version_parts = main_version_parts + ["pre", version_parts[1]]
+      end
+      version = version_parts.join(".")
     end
   end
 end

--- a/lib/vagrant-libvirt/version.rb
+++ b/lib/vagrant-libvirt/version.rb
@@ -26,6 +26,7 @@ module VagrantPlugins
           # tagged
           version = tag.strip.split(' ').last
         else
+          version = ""
           # arbitrary branch/commit
           Dir.mktmpdir do |dir|
             stdout_and_stderr, status = Open3.capture2e("git -C #{dir} clone --bare #{HOMEPAGE}")
@@ -33,9 +34,9 @@ module VagrantPlugins
 
             stdout_and_stderr, status = Open3.capture2e("git --git-dir=#{dir}/vagrant-libvirt.git describe --tags #{hash}")
             raise "failed to determine version for #{hash}: #{stdout_and_stderr}" unless status.success?
-          end
 
-          version = version_from_describe(stdout_and_stderr)
+            version = version_from_describe(stdout_and_stderr)
+          end
 
           # in this case write the version file to avoid cloning a second time
           File.write(VERSION_FILE, version)
@@ -61,7 +62,7 @@ module VagrantPlugins
     end
 
     def self.version_from_describe(describe)
-      version_parts = git_version.split('-').first(2) # drop the git sha if it exists
+      version_parts = describe.split('-').first(2) # drop the git sha if it exists
       if version_parts.length > 1
         # increment the patch number so that this is marked as a pre-release of the
         # next possible release

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files    = Dir.glob("{test,spec,features}/**/*.*")
   s.name          = 'vagrant-libvirt'
   s.require_paths = ['lib']
-  s.version       = VagrantPlugins::ProviderLibvirt.get_version(s.homepage)
+  s.version       = VagrantPlugins::ProviderLibvirt.get_version
 
   s.add_development_dependency "rspec-core", "~> 3.5.0"
   s.add_development_dependency "rspec-expectations", "~> 3.5.0"

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -7,14 +7,14 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.description   = %q{libvirt provider for Vagrant.}
   s.summary       = %q{libvirt provider for Vagrant.}
-  s.homepage      = 'https://github.com/vagrant-libvirt/vagrant-libvirt'
+  s.homepage      = VagrantPlugins::ProviderLibvirt::HOMEPAGE
 
   s.files         = Dir.glob("{lib,locales}/**/*") + %w(LICENSE README.md)
   s.executables   = Dir.glob("bin/*.*").map{ |f| File.basename(f) }
   s.test_files    = Dir.glob("{test,spec,features}/**/*.*")
   s.name          = 'vagrant-libvirt'
   s.require_paths = ['lib']
-  s.version       = VagrantPlugins::ProviderLibvirt.get_version()
+  s.version       = VagrantPlugins::ProviderLibvirt.get_version(s.homepage)
 
   s.add_development_dependency "rspec-core", "~> 3.5.0"
   s.add_development_dependency "rspec-expectations", "~> 3.5.0"


### PR DESCRIPTION
Adds support for exposing the correct version via export-subst for
git-archive constructed tarballs to make it easier to consume directly
from source.

Will check in the following order of preference:
 - version file
 - format string containing "Tag:"
 - clone remote to describe commit

In the event that this is insufficient and further use-cases are broken
should consider switching back to the standard mechanism of hard
coding the version directly into the repo and using standard ruby
gem bump version tool. However it will be necessary in such cases
to enable direct pushing to the main branch again in some manner.

Fixes: #1181