### PR TITLE
Make a virtual machine disk sparse with `virt-sparsify`

### DIFF
--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -52,6 +52,7 @@ module VagrantPlugins
           options = ENV.fetch('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPTIONS', '')
           operations = ENV.fetch('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS', 'defaults,-ssh-userdir,-customize')
           `virt-sysprep --no-logfile --operations #{operations} -a #{@tmp_img} #{options}`
+          `virt-sparsify --in-place #{@tmp_img}`
           # add any user provided file
           extra = ''
           @tmp_include = @tmp_dir + '/_include'


### PR DESCRIPTION
After working with `virt-sysprep`, it is a good idea to make the disk image sparse with `virt-sparsify`.

See https://libguestfs.org/virt-sparsify.1.html

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>