### PR TITLE
Use correct shell variable for options pass-thru

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,15 +145,6 @@ alias vagrant='
     vagrant'
 ```
 
-Known issue of Docker based Installation: SSH command option cannot be used, so below command:
-```bash
-vagrant ssh master -c 'ls -la'
-```
-should be call below way:
-```bash
-vagrant ssh master -- 'ls -la'
-```
-
 Note that if you are connecting to a remote system libvirt, you may omit the
 `-v /var/run/libvirt/:/var/run/libvirt/` mount bind. Some distributions patch the local
 vagrant environment to ensure vagrant-libvirt uses `qemu:///session`, which means you

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,4 +105,4 @@ then
     exec gosu ${USER} vagrant help
 fi
 
-exec gosu ${USER} $*
+exec gosu ${USER} "$@"


### PR DESCRIPTION
Switch using "$@" to ensure that options provided on the command line to
be interpreted by vagrant are correctly passed on with appropriate
quoting. This fixes the issue where running the docker container with
`vagrant ssh -c 'ls -la'` would fail as the `-la` option was interpreted
by vagrant instead of being passed as part of the value for the `-c`
option.
