### PR TITLE
Fix remote libvirt functionality through LIBVIRT_DEFAULT_URI

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -764,14 +764,22 @@ module VagrantPlugins
           @uri = _generate_uri(@qemu_use_session == UNSET_VALUE ? false : @qemu_use_session)
         end
 
+        # Parse uri to extract individual components
+        uri = _parse_uri(@uri)
+
         # Set qemu_use_session based on the URI if it wasn't set by the user
         if @qemu_use_session == UNSET_VALUE
-          uri = _parse_uri(@uri)
           if (uri.scheme.start_with? "qemu") && (uri.path.include? "session")
             @qemu_use_session = true
           else
             @qemu_use_session = false
           end
+        end
+
+        # Extract host and username values from uri if not set when connect_via_ssh option is used
+        if @connect_via_ssh
+          @host = uri.host if @host == nil
+          @username = uri.user if @username == nil
         end
 
         # Domain specific settings.

--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -69,12 +69,11 @@ module VagrantPlugins
         }
 
         if @machine.provider_config.connect_via_ssh
-          ssh_info[:proxy_command] =
-            "ssh '#{@machine.provider_config.host}' " \
-            "-l '#{@machine.provider_config.username}' " \
-            "-i '#{@machine.provider_config.id_ssh_key_file}' " \
-            'nc %h %p'
-
+          proxy_command = "ssh '#{@machine.provider_config.host}' "
+          proxy_command << "-l '#{@machine.provider_config.username}' " if @machine.provider_config.username
+          proxy_command << "-i '#{@machine.provider_config.id_ssh_key_file}' " if @machine.provider_config.id_ssh_key_file
+          proxy_command << '-W %h:%p'
+          ssh_info[:proxy_command] = proxy_command
         end
 
         ssh_info


### PR DESCRIPTION
One can now set `LIBVIRT_DEFAULT_URI` to something like 
`qemu+ssh://user@beefy/system` along with `connect_via_ssh` option to 
true and use vagrant on remote machines, without needing to 
duplicate/hardcode remote server username and identity key inside the 
Vagrantfile.

Partial Fixes: #1217