### PR TITLE
Refactor uri config tests

### DIFF
--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -177,6 +177,12 @@ describe VagrantPlugins::ProviderLibvirt::Config do
           {:driver => 'openvz', :id_ssh_key_file => nil},
           {:uri => "openvz:///system?no_verify=1"},
         ],
+        [ # set to esx
+          {:driver => 'esx'},
+          {:uri => "esx:///"},
+          {},
+          "Should not be adding query options that don't work to esx connection uri",
+        ],
         [ # set to vbox only
           {:driver => 'vbox', :id_ssh_key_file => nil},
           {:uri => "vbox:///session?no_verify=1"},
@@ -250,13 +256,11 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         end
       end
 
-      context 'when @socket defined' do
-        it "should detect @socket set" do
-          subject.socket = '/var/run/libvirt/libvirt-sock'
-          subject.id_ssh_key_file = false
+      context 'when invalid @uri is defined' do
+        it "should raise exception for unrecognized" do
+          subject.uri = "://bad-uri"
 
-          subject.finalize!
-          expect(subject.uri).to eq('qemu:///system?no_verify=1&socket=/var/run/libvirt/libvirt-sock')
+          expect { subject.finalize! }.to raise_error("@uri set to invalid uri '://bad-uri'")
         end
       end
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -60,152 +60,193 @@ describe VagrantPlugins::ProviderLibvirt::Config do
     context '@uri' do
       before(:example) do
         stub_const("ENV", fake_env)
+        fake_env['HOME'] = "/home/tests"
       end
 
-      context 'when LIBVIRT_DEFAULT_URI is defined' do
-        it 'should always use this value' do
-          fake_env['LIBVIRT_DEFAULT_URI'] = "custom:///custom_path"
+      # table describing expected behaviour of inputs that affect the resulting uri as
+      # well as any subsequent settings that might be inferred if the uri was
+      # explicitly set.
+      [
+        # settings
+        [ # all default
+          {},
+          {:uri => "qemu:///system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa"},
+        ],
+
+        # with LIBVIRT_DEFAULT_URI
+        [ # all other set to default
+          {},
+          {:uri => "custom:///custom_path", :qemu_use_session => false},
+          {'LIBVIRT_DEFAULT_URI' => "custom:///custom_path"},
+        ],
+        [ # with session
+          {},
+          {:uri => "qemu:///session", :qemu_use_session => true},
+          {'LIBVIRT_DEFAULT_URI' => "qemu:///session"},
+        ],
+        [ # with session and using ssh
+          {},
+          {:uri => "qemu+ssh:///session", :qemu_use_session => true},
+          {'LIBVIRT_DEFAULT_URI' => "qemu+ssh:///session"},
+        ],
+        [ # with session and using ssh infer host and connect by ssh
+          {},
+          {:uri => "qemu+ssh:///session", :qemu_use_session => true, :connect_via_ssh => true, :host => 'localhost'},
+          {'LIBVIRT_DEFAULT_URI' => "qemu+ssh:///session"},
+          "not yet inferring connect_via_ssh", # once working remove the preceding test
+        ],
+        [ # with session and using ssh to specific host with additional query options provided
+          {},
+          {:uri => "qemu+ssh://remote/session?keyfile=my_id_rsa", :qemu_use_session => true},
+          {'LIBVIRT_DEFAULT_URI' => "qemu+ssh://remote/session?keyfile=my_id_rsa"},
+        ],
+        [ # with session and using ssh to specific host with additional query options provided, infer host and ssh
+          {},
+          {:uri => "qemu+ssh://remote/session?keyfile=my_id_rsa", :qemu_use_session => true, :connect_via_ssh => true, :host => 'remote'},
+          {'LIBVIRT_DEFAULT_URI' => "qemu+ssh://remote/session?keyfile=my_id_rsa"},
+          "not yet inferring host correctly", # once working remove the preceding test
+        ],
+        [ # when session not set
+          {},
+          {:uri => "qemu:///system", :qemu_use_session => false},
+          {'LIBVIRT_DEFAULT_URI' => "qemu:///system"},
+        ],
+        [ # when session appearing elsewhere
+          {},
+          {:uri => "qemu://remote/system?keyfile=my_session_id", :qemu_use_session => false},
+          {'LIBVIRT_DEFAULT_URI' => "qemu://remote/system?keyfile=my_session_id"},
+        ],
+
+        # ignore LIBVIRT_DEFAULT_URI due to explicit settings
+        [ # when uri explicitly set
+          {:uri => 'qemu:///system'},
+          {:uri => 'qemu:///system'},
+          {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+        ],
+        [ # when driver explicitly set
+          {:driver => 'qemu'},
+          {:uri => 'qemu:///system?no_verify=1'},
+          {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
+        ],
+        [ # when host explicitly set
+          {:host => 'remote'},
+          {:uri => 'qemu://remote/system?no_verify=1'},
+          {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
+        ],
+        [ # when connect_via_ssh explicitly set
+          {:connect_via_ssh => true},
+          {:uri => 'qemu+ssh:///system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa'},
+          {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
+        ],
+        [ # when username explicitly set without host
+          {:username => 'my_user' },
+          {:uri => 'qemu://my_user@localhost/system?no_verify=1'},
+          {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
+        ],
+        [ # when username explicitly set with host
+          {:username => 'my_user', :host => 'remote'},
+          {:uri => 'qemu://my_user@remote/system?no_verify=1'},
+          {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
+        ],
+        [ # when password explicitly set
+          {:password => 'some_password'},
+          {:uri => 'qemu:///system?no_verify=1'},
+          {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
+        ],
+
+        # driver settings
+        [ # set to kvm only
+          {:driver => 'kvm', :id_ssh_key_file => nil},
+          {:uri => "qemu:///system?no_verify=1"},
+        ],
+        [ # set to qemu only
+          {:driver => 'qemu', :id_ssh_key_file => nil},
+          {:uri => "qemu:///system?no_verify=1"},
+        ],
+        [ # set to qemu with session enabled
+          {:driver => 'qemu', :qemu_use_session => true, :id_ssh_key_file => nil},
+          {:uri => "qemu:///session?no_verify=1"},
+        ],
+        [ # set to openvz only
+          {:driver => 'openvz', :id_ssh_key_file => nil},
+          {:uri => "openvz:///system?no_verify=1"},
+        ],
+        [ # set to vbox only
+          {:driver => 'vbox', :id_ssh_key_file => nil},
+          {:uri => "vbox:///session?no_verify=1"},
+        ],
+
+        # connect_via_ssh settings
+        [ # enabled
+          {:connect_via_ssh => true},
+          {:uri => "qemu+ssh://localhost/system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa"},
+        ],
+        [ # enabled with user
+          {:connect_via_ssh => true, :username => 'my_user'},
+          {:uri => "qemu+ssh://my_user@localhost/system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa"},
+        ],
+        [ # enabled with host
+          {:connect_via_ssh => true, :host => 'remote_server'},
+          {:uri => "qemu+ssh://remote_server/system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa"},
+        ],
+
+        # id_ssh_key_file behaviour
+        [ # set
+          {:id_ssh_key_file => '/path/to/keyfile'},
+          {:uri => "qemu:///system?no_verify=1&keyfile=/path/to/keyfile"},
+        ],
+        [ # set infer use of ssh
+          {:id_ssh_key_file => '/path/to/keyfile'},
+          {:uri => "qemu+ssh:///system?no_verify=1&keyfile=/path/to/keyfile"},
+          {},
+          "setting of ssh key file does not yet enable connect via ssh",
+        ],
+
+        # socket behaviour
+        [ # set
+          {:socket => '/var/run/libvirt/libvirt-sock'},
+          {:uri => "qemu:///system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa&socket=/var/run/libvirt/libvirt-sock"},
+        ],
+      ].each do |inputs, outputs, env, allow_failure|
+        it "should handle inputs #{inputs} with env #{env}" do
+          # allow some of these to fail for now if marked as such
+          if !allow_failure.nil?
+            pending(allow_failure)
+          end
+
+          inputs.each do |k, v|
+            subject.instance_variable_set("@#{k}", v)
+          end
+
+          if !env.nil?
+            env.each do |k, v|
+              fake_env[k] = v
+            end
+          end
 
           subject.finalize!
-          expect(subject.uri).to eq("custom:///custom_path")
-          expect(subject.qemu_use_session).to eq(false)
-        end
 
-        context 'when LIBVIRT_DEFAULT_URI contains "qemu"' do
-          [
-            [
-              'set qemu_use_session if "session" present',
-              'qemu:///session',
-              true,
-            ],
-            [
-              'handle different protocol additions',
-              'qemu+ssh:///session',
-              true,
-            ],
-            [
-              'handle options before and after path',
-              'qemu://remote/session?keyfile=my_id_rsa',
-              true,
-            ],
-            [
-              'identify when session not set',
-              'qemu://remote/system',
-              false,
-            ],
-            [
-              'handle session appearing elsewhere',
-              'qemu://remote/system?keyfile=my_session_id',
-              false,
-            ],
-          ].each do |title, uri, session|
-            it "should #{title}" do
-              fake_env['LIBVIRT_DEFAULT_URI'] = uri
-
-              subject.finalize!
-              expect(subject.uri).to eq(uri)
-              expect(subject.qemu_use_session).to eq(session)
+          # ensure failed output indicates which settings are incorrect in the failed test
+          got = subject.instance_variables.each_with_object({}) do |name, hash|
+            if outputs.key?(name.to_s[1..-1].to_sym)
+              hash["#{name.to_s[1..-1]}".to_sym] =subject.instance_variable_get(name)
             end
           end
+          expect(got).to eq(outputs)
         end
       end
 
-      context 'when @driver is defined' do
-        defaults = {'id_ssh_key_file' => nil}
-        [
-          [
-            {'driver' => 'kvm'},
-            'qemu:///system?no_verify=1',
-            false,
-          ],
-          [
-            {'driver' => 'qemu'},
-            'qemu:///system?no_verify=1',
-            false,
-          ],
-          [
-            {'driver' => 'qemu', 'qemu_use_session' => true},
-            'qemu:///session?no_verify=1',
-            true,
-          ],
-          [
-            {'driver' => 'openvz'},
-            'openvz:///system?no_verify=1',
-            false,
-          ],
-          [
-            {'driver' => 'vbox'},
-            'vbox:///session?no_verify=1',
-            false,
-          ],
-        ].each do |inputs, output_uri, output_session|
-          it "should detect #{inputs}" do
-            inputs.merge(defaults).each do |k, v|
-              subject.instance_variable_set("@#{k}", v)
-            end
-
-            subject.finalize!
-            expect(subject.uri).to eq(output_uri)
-            expect(subject.qemu_use_session).to eq(output_session)
-          end
-        end
-
+      context 'when invalid @driver is defined' do
         it "should raise exception for unrecognized" do
           subject.driver = "bad-driver"
 
           expect { subject.finalize! }.to raise_error("Require specify driver bad-driver")
-        end
-      end
-
-      context 'when @connect_via_ssh defined' do
-        defaults = {'driver' => 'qemu', 'id_ssh_key_file' => nil}
-        [
-          [
-            {'connect_via_ssh' => true},
-            'qemu+ssh://localhost/system?no_verify=1',
-          ],
-          [
-            {'connect_via_ssh' => true, 'username' => 'my_user'},
-            'qemu+ssh://my_user@localhost/system?no_verify=1',
-          ],
-          [
-            {'connect_via_ssh' => true, 'host' => 'remote_server'},
-            'qemu+ssh://remote_server/system?no_verify=1',
-          ],
-        ].each do |inputs, output_uri|
-          it "should detect #{inputs}" do
-            inputs.merge(defaults).each do |k, v|
-              subject.instance_variable_set("@#{k}", v)
-            end
-
-            subject.finalize!
-            expect(subject.uri).to eq(output_uri)
-          end
-        end
-      end
-
-      context 'when @id_ssh_key_file defined' do
-        defaults = {'driver' => 'qemu'}
-        [
-          [
-            {},
-            'qemu:///system?no_verify=1&keyfile=/home/user/.ssh/id_rsa',
-          ],
-          [
-            {'id_ssh_key_file' => '/path/to/keyfile'},
-            'qemu:///system?no_verify=1&keyfile=/path/to/keyfile',
-          ],
-        ].each do |inputs, output_uri|
-          it "should detect #{inputs}" do
-            inputs.merge(defaults).each do |k, v|
-              subject.instance_variable_set("@#{k}", v)
-            end
-
-            fake_env['HOME'] = '/home/user'
-
-            subject.finalize!
-            expect(subject.uri).to eq(output_uri)
-          end
         end
       end
 


### PR DESCRIPTION
Update config tests replacing the multiple sets of tests exercising
aspects of how the uri setting should be constructed with a single table
of tests including some pending tests to describe how the code should
work not just how it currently works.

This should make it easier to identify and describe the correct
behaviour that should occur and then ensure the code in the future
implements the needed changes.
