### PR TITLE
Remove flag-name due to behaviour mismatch

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,7 +75,6 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.github_token }}
-        flag-name: run-${{ matrix.vagrant }}
         parallel: true
 
 


### PR DESCRIPTION
It appears that the suggestion that flag-name should be set when doing
parallel builds, appears to lead to incorrect reporting by coveralls of
the overall coverage of all runs combined back onto the PR.
