### PR TITLE
Use OpenSSH functionality instead of netcat for proxy_command

### DIFF
--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -69,12 +69,11 @@ module VagrantPlugins
         }
 
         if @machine.provider_config.connect_via_ssh
-          ssh_info[:proxy_command] =
-            "ssh '#{@machine.provider_config.host}' " \
-            "-l '#{@machine.provider_config.username}' " \
-            "-i '#{@machine.provider_config.id_ssh_key_file}' " \
-            'nc %h %p'
-
+          proxy_command = "ssh '#{@machine.provider_config.host}' "
+          proxy_command << "-l '#{@machine.provider_config.username}' " if @machine.provider_config.username
+          proxy_command << "-i '#{@machine.provider_config.id_ssh_key_file}' " if @machine.provider_config.id_ssh_key_file
+          proxy_command << '-W %h:%p'
+          ssh_info[:proxy_command] = proxy_command
         end
 
         ssh_info


### PR DESCRIPTION
Solves vagrant not detecting end of ssh connection when a proxy is 
used, described in #921

Allows ssh argument population to append arguments only when 
respective values are not nil, avoiding creation of invalid 
proxy_command when ssh-agent or ssh config based connections are used