### PR TITLE
Make LIBVIRT_DEFAULT_URI a fackball mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,14 @@ URI](http://libvirt.org/uri.html):
   vagrant-libvirt should use. Overrides all other connection configuration
   options
 
+In the event that none of these are set (excluding the `driver` option) the
+provider will attempt to retrieve the uri from the environment variable
+`LIBVIRT_DEFAULT_URI` similar to how virsh works. If any of them are set, it
+will ignore the environment variable. The reason the driver option is ignored
+is that it is not uncommon for this to be explicitly set on the box itself
+and there is no easily to determine whether it is being set by the user or
+the box packager.
+
 Connection-independent options:
 
 * `storage_pool_name` - Libvirt storage pool name, where box image and instance

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -123,41 +123,30 @@ describe VagrantPlugins::ProviderLibvirt::Config do
           {:uri => 'qemu:///system'},
           {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
         ],
-        [ # when driver explicitly set
-          {:driver => 'qemu'},
-          {:uri => 'qemu:///system?no_verify=1'},
-          {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
-          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
-        ],
         [ # when host explicitly set
           {:host => 'remote'},
-          {:uri => 'qemu://remote/system?no_verify=1'},
+          {:uri => 'qemu://remote/system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa'},
           {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
-          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
         ],
         [ # when connect_via_ssh explicitly set
           {:connect_via_ssh => true},
-          {:uri => 'qemu+ssh:///system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa'},
+          {:uri => 'qemu+ssh://localhost/system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa'},
           {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
-          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
         ],
         [ # when username explicitly set without host
           {:username => 'my_user' },
-          {:uri => 'qemu://my_user@localhost/system?no_verify=1'},
+          {:uri => 'qemu:///system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa'},
           {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
-          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
         ],
         [ # when username explicitly set with host
           {:username => 'my_user', :host => 'remote'},
-          {:uri => 'qemu://my_user@remote/system?no_verify=1'},
+          {:uri => 'qemu://remote/system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa'},
           {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
-          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
         ],
         [ # when password explicitly set
           {:password => 'some_password'},
-          {:uri => 'qemu:///system?no_verify=1'},
+          {:uri => 'qemu:///system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa'},
           {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
-          "LIBVIRT_DEFAULT_URI is not yet just a fallback behaviour"
         ],
 
         # driver settings


### PR DESCRIPTION
Switch to only picking up LIBVIRT_DEFAULT_URI if no settings that could
affect the uri have been explicitly set. Some of these may not actually
appear in the URI depending on what is actually set or not set, however
it is important that should only use the env variable if the user has
not explicitly configured options relevant and instead allow them to
configure as needed.
