### PR TITLE
Move proxy_command to config and support templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,11 @@ URI](http://libvirt.org/uri.html):
   Default is `$HOME/.ssh/id_rsa`. Prepends `$HOME/.ssh/` if no directory
 * `socket` - Path to the Libvirt unix socket (e.g.
   `/var/run/libvirt/libvirt-sock`)
+* `proxy_command` - For advanced usage. When connecting to remote libvirt
+  instances, if the default constructed proxy\_command which uses `-W %h:%p`
+  does not work, set this as needed. It performs interpolation using `%`,
+  therefore it will be necessary to escape e.g.
+  `libvirt.proxy_command = "ssh %{host} -l %{username} -i %{id_ssh_key_file} nc %%h %%p"`
 * `uri` - For advanced usage. Directly specifies what Libvirt connection URI
   vagrant-libvirt should use. Overrides all other connection configuration
   options

--- a/README.md
+++ b/README.md
@@ -402,9 +402,11 @@ URI](http://libvirt.org/uri.html):
   `/var/run/libvirt/libvirt-sock`)
 * `proxy_command` - For advanced usage. When connecting to remote libvirt
   instances, if the default constructed proxy\_command which uses `-W %h:%p`
-  does not work, set this as needed. It performs interpolation using `%`,
-  therefore it will be necessary to escape e.g.
-  `libvirt.proxy_command = "ssh %{host} -l %{username} -i %{id_ssh_key_file} nc %%h %%p"`
+  does not work, set this as needed. It performs interpolation using `{key}`
+  and supports only `{host}`, `{username}`, and `{id_ssh_key_file}`. This is
+  to try and avoid issues with escaping `%` and `$` which might be necessary
+  to the ssh command itself. e.g.:
+  `libvirt.proxy_command = "ssh {host} -l {username} -i {id_ssh_key_file} nc %h %p"`
 * `uri` - For advanced usage. Directly specifies what Libvirt connection URI
   vagrant-libvirt should use. Overrides all other connection configuration
   options

--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -107,7 +107,7 @@ module VagrantPlugins
                 "IdentityFile='\"#{pk}\"'"
               end).map { |s| s.prepend('-o ') }.join(' ')
 
-          options += " -o ProxyCommand=\"#{ssh_info[:proxy_command]}\"" if machine.provider_config.connect_via_ssh
+          options += " -o ProxyCommand=\"#{ssh_info[:proxy_command]}\"" if machine.provider_config.proxy_command
 
           # TODO: instead of this, try and lock and get the stdin from spawn...
           ssh_cmd = ''

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -1039,7 +1039,11 @@ module VagrantPlugins
             inputs[:username] = @username if @username
             inputs[:id_ssh_key_file] = @id_ssh_key_file if @id_ssh_key_file
 
-            proxy_command = @proxy_command % inputs
+            proxy_command = @proxy_command
+            # avoid needing to escape '%' symbols
+            inputs.each do |key, value|
+              proxy_command.gsub!("{#{key}}", value)
+            end
           end
 
           @proxy_command = proxy_command

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -37,6 +37,8 @@ module VagrantPlugins
       # ID SSH key file
       attr_accessor :id_ssh_key_file
 
+      attr_accessor :proxy_command
+
       # Libvirt storage pool name, where box image and instance snapshots will
       # be stored.
       attr_accessor :storage_pool_name
@@ -192,6 +194,7 @@ module VagrantPlugins
         @password          = UNSET_VALUE
         @id_ssh_key_file   = UNSET_VALUE
         @socket            = UNSET_VALUE
+        @proxy_command     = UNSET_VALUE
         @storage_pool_name = UNSET_VALUE
         @snapshot_pool_name = UNSET_VALUE
         @random_hostname   = UNSET_VALUE
@@ -785,6 +788,7 @@ module VagrantPlugins
         @username = uri.user
 
         finalize_id_ssh_key_file
+        finalize_proxy_command
 
         @storage_pool_name = 'default' if @storage_pool_name == UNSET_VALUE
         @snapshot_pool_name = @storage_pool_name if @snapshot_pool_name == UNSET_VALUE
@@ -1017,6 +1021,27 @@ module VagrantPlugins
         end
 
         @id_ssh_key_file = id_ssh_key_file
+      end
+
+      def finalize_proxy_command
+        if @connect_via_ssh
+          if @proxy_command == UNSET_VALUE
+            proxy_command = "ssh '#{@host}' "
+            proxy_command << "-l '#{@username}' " if @username
+            proxy_command << "-i '#{@id_ssh_key_file}' " if @id_ssh_key_file
+            proxy_command << '-W %h:%p'
+          else
+            inputs = { host: @host }
+            inputs[:username] = @username if @username
+            inputs[:id_ssh_key_file] = @id_ssh_key_file if @id_ssh_key_file
+
+            proxy_command = @proxy_command % inputs
+          end
+
+          @proxy_command = proxy_command
+        else
+          @proxy_command = nil
+        end
       end
     end
   end

--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -68,13 +68,7 @@ module VagrantPlugins
           forward_x11: @machine.config.ssh.forward_x11
         }
 
-        if @machine.provider_config.connect_via_ssh
-          proxy_command = "ssh '#{@machine.provider_config.host}' "
-          proxy_command << "-l '#{@machine.provider_config.username}' " if @machine.provider_config.username
-          proxy_command << "-i '#{@machine.provider_config.id_ssh_key_file}' " if @machine.provider_config.id_ssh_key_file
-          proxy_command << '-W %h:%p'
-          ssh_info[:proxy_command] = proxy_command
-        end
+        ssh_info[:proxy_command] = @machine.provider_config.proxy_command if @machine.provider_config.proxy_command
 
         ssh_info
       end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -395,15 +395,15 @@ describe VagrantPlugins::ProviderLibvirt::Config do
 
         # provide custom template
         [
-          {:connect_via_ssh => true, :host => 'remote', :proxy_command => "ssh %{host} nc %%h %%p" },
+          {:connect_via_ssh => true, :host => 'remote', :proxy_command => "ssh {host} nc %h %p" },
           "ssh remote nc %h %p",
         ],
         [
-          {:connect_via_ssh => true, :host => 'remote', :username => 'myuser', :proxy_command => "ssh %{host} nc %%h %%p" },
+          {:connect_via_ssh => true, :host => 'remote', :username => 'myuser', :proxy_command => "ssh {host} nc %h %p" },
           "ssh remote nc %h %p",
         ],
         [
-          {:connect_via_ssh => true, :host => 'remote', :username => 'myuser', :proxy_command => "ssh %{host} -l %{username} nc %%h %%p" },
+          {:connect_via_ssh => true, :host => 'remote', :username => 'myuser', :proxy_command => "ssh {host} -l {username} nc %h %p" },
           "ssh remote -l myuser nc %h %p",
         ],
       ].each do |inputs, proxy_command, options|


### PR DESCRIPTION
Migrate the proxy_command specification to the config and add support
for user override template to be used for edge cases. Moving it to the
config allows mistakes in the interpolation to be caught before the
machine is brought up.

Fixes: #921
Already partially resolved thanks to @ElArtista, this completes the fix
by allowing users to override as needed.
