### PR TITLE
Bugfix some stray machine args after tidy up

### DIFF
--- a/lib/vagrant-libvirt/action/wait_till_up.rb
+++ b/lib/vagrant-libvirt/action/wait_till_up.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
           env[:metrics] ||= {}
 
           # Get domain object
-          domain = env[:machine].provider.driver.get_domain(env[:machine].id.to_s)
+          domain = env[:machine].provider.driver.get_domain
           if domain.nil?
             raise Errors::NoDomainError,
                   error_message: "Domain #{env[:machine].id} not found"

--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -75,14 +75,14 @@ module VagrantPlugins
         domain
       end
 
-      def created?(mid)
-        domain = get_domain(mid)
+      def created?
+        domain = get_domain
         !domain.nil?
       end
 
       def get_ipaddress
         # Find the machine
-        domain = get_domain(@machine.id)
+        domain = get_domain
 
         if domain.nil?
           # The machine can't be found
@@ -112,12 +112,12 @@ module VagrantPlugins
         ip_address
       end
 
-      def state(machine)
+      def state
         # may be other error states with initial retreival we can't handle
         begin
-          domain = get_domain(machine.id)
+          domain = get_domain
         rescue Libvirt::RetrieveError => e
-          @logger.debug("Machine #{machine.id} not found #{e}.")
+          @logger.debug("Machine #{@machine.id} not found #{e}.")
           return :not_created
         end
 

--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -97,9 +97,9 @@ module VagrantPlugins
         state_id = nil
         state_id = :not_created unless @machine.id
         state_id = :not_created if
-          !state_id && (!@machine.id || !driver.created?(@machine.id))
+          !state_id && (!@machine.id || !driver.created?)
         # Query the driver for the current state of the machine
-        state_id = driver.state(@machine) if @machine.id && !state_id
+        state_id = driver.state if @machine.id && !state_id
         state_id = :unknown unless state_id
 
         # This is a special pseudo-state so that we don't set the


### PR DESCRIPTION
Clean up the remaining references to the old functions after the
wait-till-up networking code tidy up.
