### PR TITLE
Ensure multi machine IP retrieval works

### DIFF
--- a/lib/vagrant-libvirt/action/wait_till_up.rb
+++ b/lib/vagrant-libvirt/action/wait_till_up.rb
@@ -21,7 +21,7 @@ module VagrantPlugins
           env[:metrics] ||= {}
 
           # Get domain object
-          domain = env[:machine].provider.driver.get_domain
+          domain = env[:machine].provider.driver.get_domain(env[:machine])
           if domain.nil?
             raise Errors::NoDomainError,
                   error_message: "Domain #{env[:machine].id} not found"
@@ -40,7 +40,7 @@ module VagrantPlugins
               return if env[:interrupted]
 
               # Wait for domain to obtain an ip address
-              env[:ip_address] = env[:machine].provider.driver.get_domain_ipaddress(domain)
+              env[:ip_address] = env[:machine].provider.driver.get_domain_ipaddress(env[:machine], domain)
             end
           end
 

--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -60,12 +60,12 @@ module VagrantPlugins
         @@system_connection
       end
 
-      def get_domain
+      def get_domain(machine)
         begin
-          domain = connection.servers.get(@machine.id)
+          domain = connection.servers.get(machine.id)
         rescue Libvirt::RetrieveError => e
           if e.libvirt_code == ProviderLibvirt::Util::ErrorCodes::VIR_ERR_NO_DOMAIN
-            @logger.debug("machine #{@machine.name} domain not found #{e}.")
+            @logger.debug("machine #{machine.name} domain not found #{e}.")
             return nil
           else
             raise e
@@ -75,24 +75,24 @@ module VagrantPlugins
         domain
       end
 
-      def created?
-        domain = get_domain
+      def created?(machine)
+        domain = get_domain(machine)
         !domain.nil?
       end
 
-      def get_ipaddress
+      def get_ipaddress(machine)
         # Find the machine
-        domain = get_domain
+        domain = get_domain(machine)
 
         if domain.nil?
           # The machine can't be found
           return nil
         end
 
-        get_domain_ipaddress(domain)
+        get_domain_ipaddress(machine, domain)
       end
 
-      def get_domain_ipaddress(domain)
+      def get_domain_ipaddress(machine, domain)
         if @machine.provider_config.qemu_use_session
           return get_ipaddress_from_system domain.mac
         end
@@ -101,23 +101,23 @@ module VagrantPlugins
         begin
           ip_address = get_ipaddress_from_domain(domain)
         rescue Fog::Errors::TimeoutError
-          @logger.info('Timeout at waiting for an ip address for machine %s' % @machine.name)
+          @logger.info('Timeout at waiting for an ip address for machine %s' % machine.name)
         end
 
         unless ip_address
-          @logger.info('No arp table entry found for machine %s' % @machine.name)
+          @logger.info('No arp table entry found for machine %s' % machine.name)
           return nil
         end
 
         ip_address
       end
 
-      def state
+      def state(machine)
         # may be other error states with initial retreival we can't handle
         begin
-          domain = get_domain
+          domain = get_domain(machine)
         rescue Libvirt::RetrieveError => e
-          @logger.debug("Machine #{@machine.id} not found #{e}.")
+          @logger.debug("Machine #{machine.id} not found #{e}.")
           return :not_created
         end
 

--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -55,7 +55,7 @@ module VagrantPlugins
         # be called from other threads of execution.
         return nil if state.id != :running
 
-        ip = driver.get_ipaddress
+        ip = driver.get_ipaddress(@machine)
 
         # if can't determine the IP, just return nil and let the core
         # deal with it, similar to the docker provider
@@ -97,9 +97,9 @@ module VagrantPlugins
         state_id = nil
         state_id = :not_created unless @machine.id
         state_id = :not_created if
-          !state_id && (!@machine.id || !driver.created?)
+          !state_id && (!@machine.id || !driver.created?(@machine))
         # Query the driver for the current state of the machine
-        state_id = driver.state if @machine.id && !state_id
+        state_id = driver.state(@machine) if @machine.id && !state_id
         state_id = :unknown unless state_id
 
         # This is a special pseudo-state so that we don't set the


### PR DESCRIPTION
When working with multi machine configurations, various provisioners may
query the IP addresses of all of the other machines from the current
provider, in which case it is necessary to ensure that calls to the
driver use the provided context and not it's current instance variables
as these may reference a different machine.
