### PR TITLE
Ensure provisioner cleanup run early in destroy

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -186,11 +186,11 @@ module VagrantPlugins
 
             b2.use Call, DestroyConfirm do |env2, b3|
               if env2[:result]
+                b3.use ProvisionerCleanup, :before
                 b3.use ClearForwardedPorts
                 b3.use PruneNFSExports
                 b3.use DestroyDomain
                 b3.use DestroyNetworks
-                b3.use ProvisionerCleanup
               else
                 b3.use MessageWillNotDestroy
               end


### PR DESCRIPTION
Move the provisioner cleanup to both run at the start of the destroy
sequence and ensure it performs the cleanup as part of the in chain.

Fixes: #839
