### PR TITLE
Add a simple Proc extension to support bindings

### DIFF
--- a/spec/support/binding_proc.rb
+++ b/spec/support/binding_proc.rb
@@ -1,0 +1,24 @@
+##
+# A simple extension of the Proc class that supports setting a custom binding
+# and evaluates everything in the Proc using the new binding.
+
+class ProcWithBinding < Proc
+  ##
+  # Set the binding for this instance
+
+  def apply_binding(bind, *args)
+    @binding = bind
+    instance_exec(*args, &self)
+  end
+
+  def method_missing(method, *args)
+    begin
+      method_from_binding = eval("method(#{method.inspect})", @binding)
+      return method_from_binding.call(*args)
+    rescue NameError
+      # fall through on purpose
+    end
+
+    super
+  end
+end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,4 +1,4 @@
-require 'contextual_proc'
+require 'support/binding_proc'
 
 require 'spec_helper'
 require 'support/sharedcontext'
@@ -103,7 +103,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
             :id_ssh_key_file => nil,
           },
           {
-            :setup => ContextualProc.new {
+            :setup => ProcWithBinding.new {
               expect(File).to_not receive(:file?)
             }
           }
@@ -116,7 +116,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
             :id_ssh_key_file => "/home/tests/.ssh/id_rsa",
           },
           {
-            :setup => ContextualProc.new {
+            :setup => ProcWithBinding.new {
               expect(File).to receive(:file?).with("/home/tests/.ssh/id_rsa").and_return(true)
             }
           }
@@ -263,7 +263,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
           {:connect_via_ssh => true},
           {:uri => 'qemu+ssh://localhost/system?no_verify=1', :id_ssh_key_file => nil},
           {
-            :setup => ContextualProc.new {
+            :setup => ProcWithBinding.new {
               expect(File).to receive(:file?).with("/home/tests/.ssh/id_rsa").and_return(false)
             }
           }
@@ -272,7 +272,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
           {:connect_via_ssh => true},
           {:uri => 'qemu+ssh://localhost/system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa', :id_ssh_key_file => '/home/tests/.ssh/id_rsa'},
           {
-            :setup => ContextualProc.new {
+            :setup => ProcWithBinding.new {
               expect(File).to receive(:file?).with("/home/tests/.ssh/id_rsa").and_return(true)
             }
           }
@@ -294,7 +294,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
           end
 
           if !opts[:setup].nil?
-            opts[:setup].apply(binding)
+            opts[:setup].apply_binding(binding)
           end
 
           inputs.each do |k, v|
@@ -362,7 +362,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
           {:connect_via_ssh => true, :host => 'remote', :username => 'myuser'},
           "ssh 'remote' -l 'myuser' -i '/home/tests/.ssh/id_rsa' -W %h:%p",
           {
-            :setup => ContextualProc.new {
+            :setup => ProcWithBinding.new {
               expect(File).to receive(:file?).with("/home/tests/.ssh/id_rsa").and_return(true)
             }
           }
@@ -417,7 +417,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
           end
 
           if !opts[:setup].nil?
-            opts[:setup].apply(binding)
+            opts[:setup].apply_binding(binding)
           end
 
           inputs.each do |k, v|

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.version       = VagrantPlugins::ProviderLibvirt.get_version
 
-  s.add_development_dependency "contextual_proc"
   s.add_development_dependency "rspec-core", "~> 3.5.0"
   s.add_development_dependency "rspec-expectations", "~> 3.5.0"
   s.add_development_dependency "rspec-mocks", "~> 3.5.0"


### PR DESCRIPTION
This removes the dependency on the contextual_proc gem

This fixes https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1238