### PR TITLE
Raise expected Timeout to ensure retryable retries

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -97,11 +97,13 @@ module VagrantPlugins
           return get_ipaddress_from_system domain.mac
         end
 
-        # Get IP address from arp table
+        # Get IP address from dhcp leases table
         begin
           ip_address = get_ipaddress_from_domain(domain)
         rescue Fog::Errors::TimeoutError
           @logger.info('Timeout at waiting for an ip address for machine %s' % machine.name)
+
+          raise
         end
 
         unless ip_address

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -26,6 +26,7 @@ module VagrantPlugins
       end
 
       action_hook(:remove_libvirt_image) do |hook|
+        require_relative 'action'
         hook.after Vagrant::Action::Builtin::BoxRemove, Action.remove_libvirt_image
       end
 


### PR DESCRIPTION
With the refactor to where the domain addresses are looked up, a log
message was added in case of timeout, however it was missed that when
this occurs still need to raise the exception to ensure that checks for
this timeout can occur within the original calling function.

Update tests to ensure that the code will retry the expected number of
times before triggering the expected failure message and aborting the
machine bring up.

Additionally to allow running the wait_till_up_spec.rb separately,
needed to ensure the plugin.rb which is loaded by the code pulls in the
action.rb to ensure `Action.remove_libvirt_image` can be correctly
resolved when the rest of the test suite is not running.

Fixes: #1239
