### PR TITLE
Fix forward_ports with ruby 3.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,6 +39,7 @@ jobs:
           - ruby: 2.6.6
             vagrant: v2.2.14
             allow_fail: false
+          # TODO: We should add ruby 3.0, once vagrant can be tested with it.
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -44,7 +44,7 @@ module VagrantPlugins
 
             @env[:ui].info(I18n.t(
                              'vagrant.actions.vm.forward_ports.forwarding_entry',
-                             message_attributes
+                             **message_attributes
             ))
 
             if fp[:protocol] == 'udp'


### PR DESCRIPTION
Hi,

I updated to fedora 34, which uses ruby 3.0, and I get the following error on a project I contribute to:

```
/usr/share/gems/gems/i18n-1.8.7/lib/i18n.rb:195:in `translate': wrong number of arguments (given 2, expected 0..1) (ArgumentError)
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/forward_ports.rb:45:in `block in forward_ports'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/forward_ports.rb:38:in `each'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/forward_ports.rb:38:in `forward_ports'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/forward_ports.rb:33:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/wait_till_up.rb:94:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/start_domain.rb:302:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/set_boot_order.rb:78:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/create_network_interfaces.rb:184:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/create_networks.rb:31:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/share_folders.rb:20:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/prepare_nfs_settings.rb:19:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/synced_folders.rb:87:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/delayed.rb:19:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/synced_folder_cleanup.rb:28:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/synced_folders/nfs/action_cleanup.rb:25:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/prepare_nfs_valid_ids.rb:12:in `call'
        ...
```

I'm not a ruby expert, but the change below fixes it for me. I believe this is due to [these changes in 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).