### PR TITLE
Support testing against ruby 3.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -87,7 +87,7 @@ jobs:
         pushd ../vagrant/
         # ensure main branch exists
         git checkout -b main
-        sed -e 's@s.required_ruby_version.*=.*@s.required_ruby_version     = "~> 3.0"@' vagrant.gemspec
+        sed -i -e 's@s.required_ruby_version.*=.*@s.required_ruby_version     = "~> 3.0"@' vagrant.gemspec
         bundle config local.vagrant `pwd`
         popd
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -88,14 +88,20 @@ jobs:
         # ensure main branch exists
         git checkout -b main
         sed -i -e 's@s.required_ruby_version.*=.*@s.required_ruby_version     = "~> 3.0"@' vagrant.gemspec
-        bundle config local.vagrant `pwd`
         popd
+
+        bundle config local.vagrant ${PWD}/../vagrant/
 
         # build gem of latest bindings that contain fix for ruby include path
         pushd ../libvirt-ruby
         rake gem
-        gem install pkg/ruby-libvirt-*.gem
         popd
+
+        mkdir -p vendor/bundle/ruby/3.0.0/cache/
+        cp ../libvirt-ruby/pkg/ruby-libvirt-*.gem vendor/bundle/ruby/3.0.0/cache/
+        # need the following to allow the local provided gem to be used instead of the
+        # one from rubygems
+        bundle config set --local disable_checksum_validation true
       working-directory: vagrant-libvirt
     - name: Run bundler using cached path
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,17 +39,35 @@ jobs:
           - ruby: 2.6.6
             vagrant: v2.2.14
             allow_fail: false
-          # TODO: We should add ruby 3.0, once vagrant can be tested with it.
+          - ruby: 3.0.0
+            vagrant: HEAD
+            allow_fail: false
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        path: vagrant-libvirt
+    - name: Clone vagrant for ruby 3.0 support
+      if: ${{ matrix.ruby == '3.0.0' }}
+      uses: actions/checkout@v2
+      with:
+        repository: hashicorp/vagrant
+        path: vagrant
+        ref: f7973f00edb9438d0b36085f210c80af71cfe5c5
+    - name: Clone ruby-libvirt for ruby 3.0 support
+      if: ${{ matrix.ruby == '3.0.0' }}
+      uses: actions/checkout@v2
+      with:
+        repository: libvirt/libvirt-ruby
+        path: libvirt-ruby
+        ref: 43444be184e4d877c5ce110ee5475c952d7590f7
     - name: Set up libvirt
       run: |
         sudo apt-get update
         sudo apt-get install libvirt-dev
     - uses: actions/cache@v2
       with:
-        path: vendor/bundle
+        path: vagrant-libvirt/vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
@@ -61,15 +79,33 @@ jobs:
       run: |
         gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
         gem update bundler --conservative
+      working-directory: vagrant-libvirt
+    - name: Handle additional ruby 3.0 setup
+      if: ${{ matrix.ruby == '3.0.0' }}
+      run: |
+        # ensure vagrant gemspec allows ruby 3.0
+        pushd ../vagrant/
+        sed -e 's@s.required_ruby_version.*=.*@s.required_ruby_version     = "~> 3.0"@' vagrant.gemspec
+        bundle config local.vagrant `pwd`
+        popd
+
+        # build gem of latest bindings that contain fix for ruby include path
+        pushd ../libvirt-ruby
+        rake gem
+        gem install pkg/ruby-libvirt-*.gem
+        popd
+      working-directory: vagrant-libvirt
     - name: Run bundler using cached path
       run: |
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
+      working-directory: vagrant-libvirt
       env:
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - name: Run tests
       run: |
         bundle exec rspec --color --format documentation
+      working-directory: vagrant-libvirt
       env:
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - name: Coveralls Parallel
@@ -77,6 +113,7 @@ jobs:
       with:
         github-token: ${{ secrets.github_token }}
         parallel: true
+        base-path: vagrant-libvirt
 
 
   finish:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -113,7 +113,7 @@ jobs:
       with:
         github-token: ${{ secrets.github_token }}
         parallel: true
-        base-path: vagrant-libvirt
+        path-to-lcov: ./vagrant-libvirt/coverage/lcov.info
 
 
   finish:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
             vagrant: v2.2.14
             allow_fail: false
           - ruby: 3.0.0
-            vagrant: HEAD
+            vagrant:
             allow_fail: false
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         repository: hashicorp/vagrant
         path: vagrant
-        ref: f7973f00edb9438d0b36085f210c80af71cfe5c5
+        ref: main
     - name: Clone ruby-libvirt for ruby 3.0 support
       if: ${{ matrix.ruby == '3.0.0' }}
       uses: actions/checkout@v2
@@ -85,6 +85,8 @@ jobs:
       run: |
         # ensure vagrant gemspec allows ruby 3.0
         pushd ../vagrant/
+        # pick a known sha1
+        git reset --hard f7973f00edb9438d0b36085f210c80af71cfe5c5
         sed -e 's@s.required_ruby_version.*=.*@s.required_ruby_version     = "~> 3.0"@' vagrant.gemspec
         bundle config local.vagrant `pwd`
         popd

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         repository: hashicorp/vagrant
         path: vagrant
-        ref: main
+        ref: f7973f00edb9438d0b36085f210c80af71cfe5c5
     - name: Clone ruby-libvirt for ruby 3.0 support
       if: ${{ matrix.ruby == '3.0.0' }}
       uses: actions/checkout@v2
@@ -85,8 +85,8 @@ jobs:
       run: |
         # ensure vagrant gemspec allows ruby 3.0
         pushd ../vagrant/
-        # pick a known sha1
-        git reset --hard f7973f00edb9438d0b36085f210c80af71cfe5c5
+        # ensure main branch exists
+        git checkout -b main
         sed -e 's@s.required_ruby_version.*=.*@s.required_ruby_version     = "~> 3.0"@' vagrant.gemspec
         bundle config local.vagrant `pwd`
         popd

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,10 @@ group :development do
   vagrant_version = ENV['VAGRANT_VERSION']
   if vagrant_version
     gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git',
-      tag: vagrant_version
+      :ref => vagrant_version
   else
-    gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git'
+    gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git',
+      :branch => 'main'
   end
 
   begin
@@ -28,6 +29,10 @@ group :development do
     gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :ref => '161128f2216cee8edb7bcd30da18bd4dea86f98a'
   else
     gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :branch => "main"
+  end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+    gem 'rexml'
   end
 
   gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
   vagrant_version = ENV['VAGRANT_VERSION']
-  if vagrant_version
+  if !vagrant_version.nil? && !vagrant_version.empty?
     gem 'vagrant', :git => 'https://github.com/hashicorp/vagrant.git',
       :ref => vagrant_version
   else


### PR DESCRIPTION
Retrieve vagrant and ruby-libvirt dependencies and modify as needed to
allow testing against ruby 3.0 until released versions support.

Use conditionals to skip steps when not needed.

Note that in order to use the locally built gem added to the cache
manually, need to disable checksums. However as all other ruby
versions will continue to use it, shouldn't be an issue as long as the
cache for ruby 3.0.0 is wiped clean before being used for anything such
as publishing.

Fixes: #1244 