### PR TITLE
Default to build and publish extendible image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,6 +45,7 @@ jobs:
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=slim_tags::$(echo $TAGS | sed "s/,/-slim,/g")-slim
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
         env:
           DOCKERHUB_ORGANIZATION: ${{ secrets.DOCKERHUB_ORGANIZATION }}
@@ -77,7 +78,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build and push main image
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -85,6 +86,28 @@ jobs:
           platforms: linux/amd64
           push: ${{ steps.have_credentials.outputs.access }}
           tags: ${{ steps.prep.outputs.tags }}
+          target: final
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+      -
+        name: Build and push slim image
+        id: docker_build_slim
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ steps.have_credentials.outputs.access }}
+          tags: ${{ steps.prep.outputs.slim_tags }}
+          target: slim
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -99,3 +122,6 @@ jobs:
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+      -
+        name: Image digest Slim
+        run: echo ${{ steps.docker_build_slim.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,11 @@ COPY . .
 RUN rake build
 RUN vagrant plugin install ./pkg/vagrant-libvirt*.gem
 
-RUN touch /vagrant/data/.remove /vagrant/boxes/.remove /vagrant/tmp/.remove
+RUN for dir in boxes data tmp; \
+    do \
+        touch /vagrant/${dir}/.remove; \
+    done \
+    ;
 
 FROM base as slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN set -e \
     ;
 
 
+ENV VAGRANT_DEFAULT_PROVIDER=libvirt
+
 FROM base as build
 
 # allow caching of packages for build
@@ -64,12 +66,14 @@ RUN for dir in boxes data tmp; \
     done \
     ;
 
-FROM base as final
-
-ENV VAGRANT_DEFAULT_PROVIDER=libvirt
+FROM base as slim
 
 COPY --from=build /vagrant /vagrant
 COPY entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["entrypoint.sh"]
+
+FROM build as final
+COPY entrypoint.sh /usr/local/bin/
+
 # vim: set expandtab sw=4:

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,21 +60,20 @@ COPY . .
 RUN rake build
 RUN vagrant plugin install ./pkg/vagrant-libvirt*.gem
 
-
-RUN for dir in boxes data tmp; \
-    do \
-        rm -rf /vagrant/${dir} && ln -s /.vagrant.d/${dir} /vagrant/${dir}; \
-    done \
-    ;
+RUN touch /vagrant/data/.remove /vagrant/boxes/.remove /vagrant/tmp/.remove
 
 FROM base as slim
 
 COPY --from=build /vagrant /vagrant
+
 COPY entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["entrypoint.sh"]
 
 FROM build as final
+
 COPY entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["entrypoint.sh"]
 
 # vim: set expandtab sw=4:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ can help a lot :-)
 * [Features](#features)
 * [Future work](#future-work)
 * [Using Docker based Installation](#using-docker-based-installation)
+  * [Extending the Docker image with additional vagrant plugins](#extending-the-docker-image-with-additional-vagrant-plugins)
 * [Installation](#installation)
   * [Possible problems with plugin installation on Linux](#possible-problems-with-plugin-installation-on-linux)
   * [Additional Notes for Fedora and Similar Linux Distributions](#additional-notes-for-fedora-and-similar-linux-distributions)
@@ -106,6 +107,10 @@ This should allow users to execute vagrant with vagrant-libvirt without needing 
 the compatibility issues, though you may need to extend the image for your own needs should
 you make use of additional plugins.
 
+Note the default image contains the full toolchain required to build and install vagrant-libvirt
+and it's dependencies. There is also a smaller image published with the `-slim` suffix if you
+just need vagrant-libvirt and don't need to install any additional plugins for your environment.
+
 To get the image:
 ```bash
 docker pull vagrantlibvirt/vagrant-libvirt:latest
@@ -150,6 +155,20 @@ Note that if you are connecting to a remote system libvirt, you may omit the
 vagrant environment to ensure vagrant-libvirt uses `qemu:///session`, which means you
 may need to set the environment variable `LIBVIRT_DEFAULT_URI` to the same value if
 looking to use this in place of your distribution provided installation.
+
+### Extending the Docker image with additional vagrant plugins
+
+By default the image published and used contains the entire tool chain required
+to reinstall the vagrant-libvirt plugin and it's dependencies, as this is the
+default behaviour of vagrant anytime a new plugin is installed. This means it
+should be possible to use a simple `FROM` statement and ask vagrant to install
+additional plugins.
+
+```
+FROM vagrantlibvirt/vagrant-libvirt:latest
+
+RUN vagrant plugin install <plugin>
+```
 
 ## Installation
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,16 @@ then
     exit 2
 fi
 
+for dir in boxes data tmp
+do
+    # if the directory hasn't been explicitly mounted over, remove it.
+    if [[ -e "/vagrant/${dir}/.remove" ]]
+    then
+        rm -rf /vagrant/${dir}
+        ln -s ${vdir}/${dir} /vagrant/${dir}
+    fi
+done
+
 vdir_mnt=$(stat -c %m ${vdir})
 case "${vdir_mnt%%/}" in
     /*)


### PR DESCRIPTION
Switch to publishing the image containing all of the libraries and build
dependencies needed to support the plugin being reinstalled as that is
the default behaviour when vagrant installs a new plugin.

This should allow the default image to be extended with additional
plugins and if needed, the authors of the new image may follow and use
the slim version as a base to provide a reduced size docker image.

Fixes: #1198
