### PR TITLE
Add ability to manage bridge STP and delay parameters

### DIFF
--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -297,6 +297,9 @@ module VagrantPlugins
 
           @network_ipv6_address = @interface_network[:ipv6_address]
           @network_ipv6_prefix = @interface_network[:ipv6_prefix]
+          
+          @network_bridge_stp = @options[:bridge_stp].nil? ? 'on' : @options[:bridge_stp] ? 'on' : 'off'
+          @network_bridge_delay = @options[:bridge_delay] ? @options[:bridge_delay] : 0
 
           @network_forward_mode = @options[:forward_mode]
           if @options[:forward_device]

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -298,7 +298,7 @@ module VagrantPlugins
           @network_ipv6_address = @interface_network[:ipv6_address]
           @network_ipv6_prefix = @interface_network[:ipv6_prefix]
           
-          @network_bridge_stp = @options[:bridge_stp].nil? ? 'on' : @options[:bridge_stp] ? 'on' : 'off'
+          @network_bridge_stp = @options[:bridge_stp].nil? || @options[:bridge_stp] ? 'on' : 'off'
           @network_bridge_delay = @options[:bridge_delay] ? @options[:bridge_delay] : 0
 
           @network_forward_mode = @options[:forward_mode]

--- a/lib/vagrant-libvirt/templates/private_network.xml.erb
+++ b/lib/vagrant-libvirt/templates/private_network.xml.erb
@@ -1,6 +1,6 @@
 <network ipv6='<%= @guest_ipv6 %>'>
   <name><%= @network_name %></name>
-  <bridge name="<%= @network_bridge_name %>" />
+  <bridge name="<%= @network_bridge_name %>" stp="<%= @network_bridge_stp %>" delay="<%= @network_bridge_delay %>" />
 
   <% if @network_domain_name %>
     <domain name="<%= @network_domain_name %>" localOnly="yes" />


### PR DESCRIPTION
Second part of PR #1038 - ability to manage Bridge STP and Delay parameters

Follows defaults defined at https://libvirt.org/formatnetwork.html#elementsConnect