### PR TITLE
Add `virtiofs` Support to vagrant-libvirt

### DIFF
--- a/lib/vagrant-libvirt/cap/mount_9p.rb
+++ b/lib/vagrant-libvirt/cap/mount_9p.rb
@@ -1,0 +1,42 @@
+require 'digest/md5'
+require 'vagrant/util/retryable'
+
+module VagrantPlugins
+  module ProviderLibvirt
+    module Cap
+      class Mount9P
+        extend Vagrant::Util::Retryable
+
+        def self.mount_9p_shared_folder(machine, folders)
+          folders.each do |_name, opts|
+            # Expand the guest path so we can handle things like "~/vagrant"
+            expanded_guest_path = machine.guest.capability(
+              :shell_expand_guest_path, opts[:guestpath]
+            )
+
+            # Do the actual creating and mounting
+            machine.communicate.sudo("mkdir -p #{expanded_guest_path}")
+
+            # Mount
+            mount_tag = Digest::MD5.new.update(opts[:hostpath]).to_s[0, 31]
+
+            mount_opts = '-o trans=virtio'
+            mount_opts += ",access=#{opts[:owner]}" if opts[:owner]
+            mount_opts += ",version=#{opts[:version]}" if opts[:version]
+            mount_opts += ",#{opts[:mount_opts]}" if opts[:mount_opts]
+
+            mount_command = "mount -t 9p #{mount_opts} '#{mount_tag}' #{expanded_guest_path}"
+            retryable(on: Vagrant::Errors::LinuxMountFailed,
+                      tries: 5,
+                      sleep: 3) do
+              machine.communicate.sudo('modprobe 9p')
+              machine.communicate.sudo('modprobe 9pnet_virtio')
+              machine.communicate.sudo(mount_command,
+                                       error_class: Vagrant::Errors::LinuxMountFailed)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-libvirt/cap/mount_virtiofs.rb
+++ b/lib/vagrant-libvirt/cap/mount_virtiofs.rb
@@ -4,10 +4,10 @@ require 'vagrant/util/retryable'
 module VagrantPlugins
   module ProviderLibvirt
     module Cap
-      class MountP9
+      class MountVirtioFS
         extend Vagrant::Util::Retryable
 
-        def self.mount_p9_shared_folder(machine, folders)
+        def self.mount_virtiofs_shared_folder(machine, folders)
           folders.each do |_name, opts|
             # Expand the guest path so we can handle things like "~/vagrant"
             expanded_guest_path = machine.guest.capability(
@@ -20,17 +20,12 @@ module VagrantPlugins
             # Mount
             mount_tag = Digest::MD5.new.update(opts[:hostpath]).to_s[0, 31]
 
-            mount_opts = '-o trans=virtio'
-            mount_opts += ",access=#{opts[:owner]}" if opts[:owner]
-            mount_opts += ",version=#{opts[:version]}" if opts[:version]
-            mount_opts += ",#{opts[:mount_opts]}" if opts[:mount_opts]
+            mount_opts = "-o #{opts[:mount_opts]}" if opts[:mount_opts]
 
-            mount_command = "mount -t 9p #{mount_opts} '#{mount_tag}' #{expanded_guest_path}"
+            mount_command = "mount -t virtiofs #{mount_opts} '#{mount_tag}' #{expanded_guest_path}"
             retryable(on: Vagrant::Errors::LinuxMountFailed,
                       tries: 5,
                       sleep: 3) do
-              machine.communicate.sudo('modprobe 9p')
-              machine.communicate.sudo('modprobe 9pnet_virtio')
               machine.communicate.sudo(mount_command,
                                        error_class: Vagrant::Errors::LinuxMountFailed)
             end

--- a/lib/vagrant-libvirt/cap/synced_folder_9p.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_9p.rb
@@ -6,10 +6,9 @@ require 'digest/md5'
 require 'vagrant/util/subprocess'
 require 'vagrant/errors'
 require 'vagrant-libvirt/errors'
-# require_relative "helper"
 
 module VagrantPlugins
-  module SyncedFolder9p
+  module SyncedFolder9P
     class SyncedFolder < Vagrant.plugin('2', :synced_folder)
       include Vagrant::Util
       include VagrantPlugins::ProviderLibvirt::Util::ErbTemplate
@@ -69,10 +68,10 @@ module VagrantPlugins
         end
       end
 
-      # TODO: once up, mount folders
+      # once up, mount folders
       def enable(machine, folders, _opts)
         # Go through each folder and mount
-        machine.ui.info('mounting p9 share in guest')
+        machine.ui.info('mounting 9p share in guest')
         # Only mount folders that have a guest path specified.
         mount_folders = {}
         folders.each do |id, opts|
@@ -83,7 +82,7 @@ module VagrantPlugins
         end
         # Mount the actual folder
         machine.guest.capability(
-          :mount_p9_shared_folder, mount_folders
+          :mount_9p_shared_folder, mount_folders
         )
       end
 

--- a/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
@@ -1,0 +1,109 @@
+require 'log4r'
+require 'ostruct'
+require 'nokogiri'
+require 'digest/md5'
+
+require 'vagrant/util/subprocess'
+require 'vagrant/errors'
+require 'vagrant-libvirt/errors'
+
+module VagrantPlugins
+  module SyncedFolderVirtioFS
+    class SyncedFolder < Vagrant.plugin('2', :synced_folder)
+      include Vagrant::Util
+      include VagrantPlugins::ProviderLibvirt::Util::ErbTemplate
+
+      def initialize(*args)
+        super
+        @logger = Log4r::Logger.new('vagrant_libvirt::synced_folders::virtiofs')
+      end
+
+      def usable?(machine, _raise_error = false)
+        # bail now if not using Libvirt since checking version would throw error
+        return false unless machine.provider_name == :libvirt
+
+        # virtiofs support introduced since 6.2.0
+        # version number format is major * 1,000,000 + minor * 1,000 + release
+        libvirt_version = machine.provider.driver.connection.client.libversion
+        libvirt_version >= 6_002_000
+      end
+
+      def prepare(machine, folders, _opts)
+        raise Vagrant::Errors::Error('No Libvirt connection') if machine.provider.driver.connection.nil?
+        @conn = machine.provider.driver.connection.client
+
+        begin
+          # loop through folders
+          folders.each do |id, folder_opts|
+            folder_opts.merge!(target: id,
+                               mount: true,
+                               readonly: nil) { |_k, ov, _nv| ov }
+
+            mount_tag = Digest::MD5.new.update(folder_opts[:hostpath]).to_s[0, 31]
+            folder_opts[:mount_tag] = mount_tag
+
+            machine.ui.info "================\nMachine id: #{machine.id}\nShould be mounting folders\n #{id}, opts: #{folder_opts}"
+
+            #xml = to_xml('filesystem', folder_opts)
+            xml = Nokogiri::XML::Builder.new do |xml|
+              xml.filesystem(type: 'mount', accessmode: 'passthrough') do
+                xml.driver(type: 'virtiofs')
+                xml.source(dir: folder_opts[:hostpath])
+                xml.target(dir: mount_tag)
+                xml.readonly unless folder_opts[:readonly].nil?
+              end
+            end.to_xml(
+              save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION |
+                         Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS |
+                         Nokogiri::XML::Node::SaveOptions::FORMAT
+            )
+            # puts "<<<<< XML:\n #{xml}\n >>>>>"
+            @conn.lookup_domain_by_uuid(machine.id).attach_device(xml, 0)
+          end
+        rescue => e
+          machine.ui.error("could not attach device because: #{e}")
+          raise VagrantPlugins::ProviderLibvirt::Errors::AttachDeviceError,
+                error_message: e.message
+        end
+      end
+
+      # once up, mount folders
+      def enable(machine, folders, _opts)
+        # Go through each folder and mount
+        machine.ui.info('mounting virtiofs share in guest')
+        # Only mount folders that have a guest path specified.
+        mount_folders = {}
+        folders.each do |id, opts|
+          next unless opts[:mount] && opts[:guestpath] && !opts[:guestpath].empty?
+          mount_folders[id] = opts.dup
+        end
+        # Mount the actual folder
+        machine.guest.capability(
+          :mount_virtiofs_shared_folder, mount_folders
+        )
+      end
+
+      def cleanup(machine, _opts)
+        if machine.provider.driver.connection.nil?
+          raise Vagrant::Errors::Error('No Libvirt connection')
+        end
+        @conn = machine.provider.driver.connection.client
+        begin
+          if machine.id && machine.id != ''
+            dom = @conn.lookup_domain_by_uuid(machine.id)
+            Nokogiri::XML(dom.xml_desc).xpath(
+              '/domain/devices/filesystem'
+            ).each do |xml|
+              dom.detach_device(xml.to_s)
+              machine.ui.info 'Cleaned up shared folders'
+            end
+          end
+        rescue => e
+          machine.ui.error("could not detach device because: #{e}")
+          raise VagrantPlugins::ProviderLibvirt::Errors::DetachDeviceError,
+                error_message: e.message
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -30,9 +30,13 @@ module VagrantPlugins
         hook.after Vagrant::Action::Builtin::BoxRemove, Action.remove_libvirt_image
       end
 
-      guest_capability('linux', 'mount_p9_shared_folder') do
-        require_relative 'cap/mount_p9'
-        Cap::MountP9
+      guest_capability('linux', 'mount_9p_shared_folder') do
+        require_relative 'cap/mount_9p'
+        Cap::Mount9P
+      end
+      guest_capability('linux', 'mount_virtiofs_shared_folder') do
+        require_relative 'cap/mount_virtiofs'
+        Cap::MountVirtioFS
       end
 
       provider_capability(:libvirt, :nic_mac_addresses) do
@@ -48,8 +52,12 @@ module VagrantPlugins
       # lower priority than nfs or rsync
       # https://github.com/vagrant-libvirt/vagrant-libvirt/pull/170
       synced_folder('9p', 4) do
-        require_relative 'cap/synced_folder'
-        VagrantPlugins::SyncedFolder9p::SyncedFolder
+        require_relative 'cap/synced_folder_9p'
+        VagrantPlugins::SyncedFolder9P::SyncedFolder
+      end
+      synced_folder('virtiofs', 5) do
+        require_relative 'cap/synced_folder_virtiofs'
+        VagrantPlugins::SyncedFolderVirtioFS::SyncedFolder
       end
 
       # This initializes the internationalization strings.


### PR DESCRIPTION
## Overview

From <https://virtio-fs.gitlab.io/index.html#overview>:

> Virtio-fs is a shared file system that lets virtual machines access a directory tree on the host. Unlike existing approaches, it is designed to offer local file system semantics and performance.

From <https://virtio-fs.gitlab.io/index.html#faq>:

> Existing solutions to this problem, such as virtio-9p, are based on existing network protocols that are not optimized for virtualization use cases. As a result they do not perform as well as local file systems and do not provide the semantics that some applications rely on.

This PR add `virtiofs` support to vagrant-libvirt, which simply clone-and-hack from our existing 9p implementation. It also tidy up and synchronize naming for 9p implementation.

Tested with:

  - Host: Ubuntu 20.10 + Linux 5.10.30 + QEMU 5.0.0 + Libvirt 6.6.0 + Vagrant 2.2.15
  - Guest: Ubuntu 20.04 + Linux 5.4.0

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>

## Testing

Install the pre-build gem from https://github.com/alvistack/vagrant-libvirt-vagrant-libvirt/releases/tag/0.4.2.pre.5:
```
$ curl -skL -m 300 -O https://github.com/alvistack/vagrant-libvirt-vagrant-libvirt/releases/download/0.4.2.pre.5/vagrant-libvirt-0.4.2.pre.5.gem
$ vagrant plugin install ./vagrant-libvirt-0.4.2.pre.5.gem
```

Verify host config:
```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.10
Release:	20.10
Codename:	groovy

$ uname -srmpio
Linux 5.10.30-051030-generic x86_64 x86_64 x86_64 GNU/Linux

$ qemu-system-x86_64 --version
QEMU emulator version 5.0.0 (Debian 1:5.0-5ubuntu9.7)
Copyright (c) 2003-2020 Fabrice Bellard and the QEMU Project developers

$ virsh --version
6.6.0

$ vagrant --version
Vagrant 2.2.15

$ vagrant plugin list
vagrant-libvirt (0.4.2.pre.5, global)
  - Version Constraint: 0.4.2.pre.5
  
$ cat /etc/libvirt/qemu.conf | grep memory_backing_dir
memory_backing_dir = "/dev/shm"  
```

Create a Vagrant file with:
```
Vagrant.configure("2") do |config|
  config.vm.box = "alvistack/ubuntu-20.04"

  config.vm.provider :libvirt do |libvirt|
    libvirt.cpus = 2
    libvirt.disk_bus = "virtio"
    libvirt.disk_driver :cache => "writeback"
    libvirt.driver = "kvm"
    libvirt.memory = 8192
    libvirt.memorybacking :access, :mode => 'shared'
    libvirt.nic_model_type = "virtio"
    libvirt.numa_nodes = [{ :cpus => "0-1", :memory => "8192", :memAccess => "shared" }]
    libvirt.video_type = "virtio"
  end

  config.vm.network :forwarded_port, guest: 8080, host: 8080, host_ip: "0.0.0.0", gateway_ports: true
  config.vm.network :forwarded_port, guest: 8443, host: 8443, host_ip: "0.0.0.0", gateway_ports: true

  config.vm.synced_folder "./", "/vagrant", type: "virtiofs"
end
```

Vagrant up the environment:
```
vagrant up --provider=libvirt
```

Verify the guest config and mount result:
```
$ vagrant ssh
Welcome to Ubuntu 20.04.2 LTS (GNU/Linux 5.4.0-71-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

vagrant@ubuntu:~$ sudo su -

root@ubuntu:~# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.2 LTS
Release:	20.04
Codename:	focal

root@ubuntu:~# uname -srmpio
Linux 5.4.0-71-generic x86_64 x86_64 x86_64 GNU/Linux

root@ubuntu:~# df -h | grep vagrant
70d33537fdc7fdd4783eb977a942ccd  738G  368G  332G  53% /vagrant

root@ubuntu:~# mount | grep vagrant
70d33537fdc7fdd4783eb977a942ccd on /vagrant type virtiofs (rw,relatime)
```

## Benchmark
### 9p
```
root@ubuntu:~# fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test --bs=4k --iodepth=64 --readwrite=randrw --rwmixread=75 --size=4G --filename=/vagrant/testfile
test: (g=0): rw=randrw, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=64
fio-3.16
Starting 1 process
Jobs: 1 (f=1): [m(1)][100.0%][r=100MiB/s,w=32.8MiB/s][r=25.6k,w=8399 IOPS][eta 00m:00s]
test: (groupid=0, jobs=1): err= 0: pid=15396: Fri Apr 16 10:00:28 2021
  read: IOPS=21.2k, BW=83.0MiB/s (87.0MB/s)(3070MiB/36987msec)
   bw (  KiB/s): min=68375, max=106520, per=99.70%, avg=84737.75, stdev=8587.07, samples=73
   iops        : min=17093, max=26630, avg=21184.44, stdev=2146.80, samples=73
  write: IOPS=7101, BW=27.7MiB/s (29.1MB/s)(1026MiB/36987msec); 0 zone resets
   bw (  KiB/s): min=23400, max=35696, per=99.71%, avg=28321.33, stdev=2833.70, samples=73
   iops        : min= 5850, max= 8924, avg=7080.32, stdev=708.42, samples=73
  cpu          : usr=2.77%, sys=15.65%, ctx=1049612, majf=0, minf=7
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=0.1%, >=64=100.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.1%, >=64=0.0%
     issued rwts: total=785920,262656,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=64

Run status group 0 (all jobs):
   READ: bw=83.0MiB/s (87.0MB/s), 83.0MiB/s-83.0MiB/s (87.0MB/s-87.0MB/s), io=3070MiB (3219MB), run=36987-36987msec
  WRITE: bw=27.7MiB/s (29.1MB/s), 27.7MiB/s-27.7MiB/s (29.1MB/s-29.1MB/s), io=1026MiB (1076MB), run=36987-36987msec
  ```
  
### virtiofs (READ +140%, WRITE +130%)
```
root@ubuntu:~# fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test --bs=4k --iodepth=64 --readwrite=randrw --rwmixread=75 --size=4G --filename=/vagrant/testfile
test: (g=0): rw=randrw, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=64
fio-3.16
Starting 1 process
test: Laying out IO file (1 file / 4096MiB)
Jobs: 1 (f=1): [m(1)][100.0%][r=192MiB/s,w=63.0MiB/s][r=49.2k,w=16.4k IOPS][eta 00m:00s]
test: (groupid=0, jobs=1): err= 0: pid=2370: Fri Apr 16 09:56:45 2021
  read: IOPS=50.7k, BW=198MiB/s (208MB/s)(3070MiB/15493msec)
   bw (  KiB/s): min=193720, max=214032, per=100.00%, avg=203105.57, stdev=5510.83, samples=30
   iops        : min=48430, max=53508, avg=50776.43, stdev=1377.78, samples=30
  write: IOPS=16.0k, BW=66.2MiB/s (69.4MB/s)(1026MiB/15493msec); 0 zone resets
   bw (  KiB/s): min=64464, max=72408, per=100.00%, avg=67900.20, stdev=1959.17, samples=30
   iops        : min=16116, max=18102, avg=16975.03, stdev=489.79, samples=30
  cpu          : usr=6.12%, sys=42.66%, ctx=866423, majf=0, minf=9
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=0.1%, >=64=100.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.1%, >=64=0.0%
     issued rwts: total=785920,262656,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=64

Run status group 0 (all jobs):
   READ: bw=198MiB/s (208MB/s), 198MiB/s-198MiB/s (208MB/s-208MB/s), io=3070MiB (3219MB), run=15493-15493msec
  WRITE: bw=66.2MiB/s (69.4MB/s), 66.2MiB/s-66.2MiB/s (69.4MB/s-69.4MB/s), io=1026MiB (1076MB), run=15493-15493msec
  ```