### PR TITLE
Revert auto_config change in #1249

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -194,7 +194,7 @@ module VagrantPlugins
               # It's used for provisioning and it has to be available during provisioning,
               # ifdown command is not acceptable here.
               next if slot_number.zero?
-              next if !options[:auto_config]
+              next if options[:auto_config] === false
               @logger.debug "Configuring interface slot_number #{slot_number} options #{options}"
 
               network = {


### PR DESCRIPTION
The #1249 introduce a change of behaviour on auto_config to skip if it
was any kind of false, where as the correct behaviour is to only skip if
explicitly set to false.
