### PR TITLE
Fix missing vagrant user on docker based Installation(#1191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,13 @@ docker run -it --rm \
 It's possible to define an alias in `~/.bashrc`, for example:
 ```bash
 alias vagrant='
-  mkdir -p ~/.vagrant.d/{boxes,data,tmp}; \
+  VAGRANT_HOME=~/.vagrant.d
+  mkdir -p $VAGRANT_HOME/{boxes,data,tmp}; \
   docker run -it --rm \
     -e LIBVIRT_DEFAULT_URI \
     -v /var/run/libvirt/:/var/run/libvirt/ \
-    -v ~/.vagrant.d:/.vagrant.d \
-    -v $(pwd):$(pwd) \
+    -v $VAGRANT_HOME:/.vagrant.d \
+    -v $(realpath "$(pwd)"):$(pwd) \
     -w $(pwd) \
     --network host \
     vagrantlibvirt/vagrant-libvirt:latest \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,33 +40,27 @@ then
     echo "WARNING! Running as root, if this breaks, you get to keep both pieces"
 fi
 
-
 export USER=vagrant
 export GROUP=users
 export HOME=/home/${USER}
 
 echo "Starting with UID: ${USER_UID}, GID: ${USER_GID}"
-if [[ "${USER_GID}" != "0" ]]
-then
-    if getent group ${GROUP} > /dev/null
-    then
-        GROUPCMD=groupmod
-    else
-        GROUPCMD=groupadd
-    fi
-    ${GROUPCMD} -g ${USER_GID} ${GROUP} >/dev/null || exit 3
-fi
 
-if [[ "${USER_UID}" != "0" ]]
+if getent group ${GROUP} > /dev/null
 then
-    if getent passwd ${USER} > /dev/null
-    then
-        USERCMD=usermod
-    else
-        USERCMD=useradd
-    fi
-    ${USERCMD} --shell /bin/bash -u ${USER_UID} -g ${USER_GID} -o -c "" -m ${USER} >/dev/null 2>&1 || exit 3
+    GROUPCMD=groupmod
+else
+    GROUPCMD=groupadd
 fi
+${GROUPCMD} -o -g ${USER_GID} ${GROUP} >/dev/null || exit 3
+
+if getent passwd ${USER} > /dev/null
+then
+    USERCMD=usermod
+else
+    USERCMD=useradd
+fi
+${USERCMD} --shell /bin/bash -u ${USER_UID} -g ${USER_GID} -o -c "" -m ${USER} >/dev/null 2>&1 || exit 3
 
 # make sure the directories can be written to by vagrant otherwise will
 # get a start up error


### PR DESCRIPTION
1.fix issue #1191
2.add symbolic link support on Docker based Installation doc

When run as root, vagrant user inside container will not be created, so we get #1191 error.