### PR TITLE
Synchronize Snapshot Disks Storage File Permission

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -53,6 +53,7 @@ module VagrantPlugins
                     xml.permissions do
                       xml.owner storage_uid(env)
                       xml.group storage_gid(env)
+                      xml.mode '0744'
                       xml.label 'virt_image_t'
                     end
                   end
@@ -62,6 +63,7 @@ module VagrantPlugins
                     xml.permissions do
                       xml.owner storage_uid(env)
                       xml.group storage_gid(env)
+                      xml.mode '0744'
                       xml.label 'virt_image_t'
                     end
                   end

--- a/spec/unit/action/create_domain_volume_spec/one_disk_in_storage.xml
+++ b/spec/unit/action/create_domain_volume_spec/one_disk_in_storage.xml
@@ -6,6 +6,7 @@
     <permissions>
       <owner>0</owner>
       <group>0</group>
+      <mode>0744</mode>
       <label>virt_image_t</label>
     </permissions>
   </target>
@@ -15,6 +16,7 @@
     <permissions>
       <owner>0</owner>
       <group>0</group>
+      <mode>0744</mode>
       <label>virt_image_t</label>
     </permissions>
   </backingStore>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_0.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_0.xml
@@ -6,6 +6,7 @@
     <permissions>
       <owner>0</owner>
       <group>0</group>
+      <mode>0744</mode>
       <label>virt_image_t</label>
     </permissions>
   </target>
@@ -15,6 +16,7 @@
     <permissions>
       <owner>0</owner>
       <group>0</group>
+      <mode>0744</mode>
       <label>virt_image_t</label>
     </permissions>
   </backingStore>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_1.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_1.xml
@@ -6,6 +6,7 @@
     <permissions>
       <owner>0</owner>
       <group>0</group>
+      <mode>0744</mode>
       <label>virt_image_t</label>
     </permissions>
   </target>
@@ -15,6 +16,7 @@
     <permissions>
       <owner>0</owner>
       <group>0</group>
+      <mode>0744</mode>
       <label>virt_image_t</label>
     </permissions>
   </backingStore>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_2.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_2.xml
@@ -6,6 +6,7 @@
     <permissions>
       <owner>0</owner>
       <group>0</group>
+      <mode>0744</mode>
       <label>virt_image_t</label>
     </permissions>
   </target>
@@ -15,6 +16,7 @@
     <permissions>
       <owner>0</owner>
       <group>0</group>
+      <mode>0744</mode>
       <label>virt_image_t</label>
     </permissions>
   </backingStore>


### PR DESCRIPTION
From <https://github.com/fog/fog-libvirt/blob/39ead72/lib/fog/libvirt/models/compute/templates/volume.xml.erb> storage files are created with permission `<mode>0744</mode>`; BTW, we are missing corresponding parameters from `lib/vagrant-libvirt/action/create_domain_volume.rb`, therefore file created with permission `0600`.

Fixes #1275

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>
