### PR TITLE
Handle nil volumes when cd-rom attached

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -70,7 +70,7 @@ module VagrantPlugins
 
             # remove root storage
             root_disk = domain.volumes.select do |x|
-              x.name == libvirt_domain.name + '.img'
+              x.name == libvirt_domain.name + '.img' if x
             end.first
             root_disk.destroy if root_disk
           end

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -85,7 +85,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
 
         it 'uses explicit removal of disks' do
           allow(libvirt_domain).to receive(:name).and_return('test')
-          allow(domain).to receive(:volumes).and_return([root_disk])
+          allow(domain).to receive(:volumes).and_return([root_disk, nil])
 
           expect(domain).to_not receive(:destroy).with(destroy_volumes: true)
           expect(root_disk).to receive(:destroy)  # root disk remove


### PR DESCRIPTION
When a cd-rom is attached as an additional storage, listing the volumes
can include a nil element. Make sure to check that the element is valid
before attempting to access the attribute.

Update the test to better match the observed behaviour.

Fixes: #1209, #1262
