### PR TITLE
Retrieve disk format and virtual size directly

### DIFF
--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -38,6 +38,10 @@ module VagrantPlugins
       end
 
       # Box exceptions
+      class BadBoxImage < VagrantLibvirtError
+        error_key(:bad_box_image)
+      end
+
       class NoBoxVolume < VagrantLibvirtError
         error_key(:no_box_volume)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -72,6 +72,10 @@ en:
       no_storage_pool: |-
         No usable storage pool found! Please check if storage pool is
         created and available.
+      bad_box_image: |-
+        Received error when query the box image details from '%{image}'.
+        Stdout: %{out}
+        Stderr: %{err}
       no_box_volume: |-
         Volume for box image is missing in storage pools. Try to run vagrant
         again, or check if storage volume is accessible.

--- a/tools/create_box_with_two_disks.sh
+++ b/tools/create_box_with_two_disks.sh
@@ -17,15 +17,12 @@ then
     cat > "${NEW_PATH}/${BOX_VERSION}/libvirt/metadata.json" <<EOF
 {
   "provider": "libvirt",
-  "format": "qcow2",
   "disks" : [
-      {
-          "virtual_size": 2
-      },
-      {
+    {
+    },
+    {
           "path":"disk2.qcow2",
-          "virtual_size":10
-      }
+    }
   ]
 }
 EOF


### PR DESCRIPTION
When uploading disks to libvirt storage it is unnecessary to require
that the virtual size or the format be provided as these can be
retrieved by calling qemu-img on the box files to retrieve the required
information.

Update the handle box image support to separate the handling of the two
different formats and remove the need to specify the additional settings
in the case of the V2 format for multi disk boxes.
