### PR TITLE
Bugfix Additional Disks Storage File Ownership

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -198,7 +198,7 @@ module VagrantPlugins
                 path: disk[:absolute_path],
                 capacity: disk[:size],
                 owner: storage_uid(env),
-                group: storage_uid(env),
+                group: storage_gid(env),
                 #:allocation => ?,
                 pool_name: disk_pool_name
               )


### PR DESCRIPTION
For additional disk image created by
`lib/vagrant-libvirt/action/create_domain.rb`, it is now incorrectly
hard-coded with `group: storage_uid(env)`, so even QEMU process is
running with `root:libvirt` but file is still owned by `root:root`

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>