### PR TITLE
Since Ruby 3.0 `rexml` needs to be required

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fog-libvirt', '>= 0.6.0'
   s.add_runtime_dependency 'fog-core', '~> 2.1'
+  s.add_runtime_dependency 'rexml'
 
   # Make sure to allow use of the same version as Vagrant by being less specific
   s.add_runtime_dependency 'nokogiri', '~> 1.6'


### PR DESCRIPTION
as it's no longer a default gem.