### PR TITLE
Basic forward port tests and refactor out @env

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -11,10 +11,8 @@ module VagrantPlugins
         end
 
         def call(env)
-          @env = env
-
           # Get the ports we're forwarding
-          env[:forwarded_ports] = compile_forwarded_ports(env[:machine].config)
+          env[:forwarded_ports] = compile_forwarded_ports(env, env[:machine].config)
 
           # Warn if we're port forwarding to any privileged ports
           env[:forwarded_ports].each do |fp|
@@ -28,49 +26,50 @@ module VagrantPlugins
           # Continue, we need the VM to be booted in order to grab its IP
           @app.call env
 
-          if @env[:forwarded_ports].any?
+          if env[:forwarded_ports].any?
             env[:ui].info I18n.t('vagrant.actions.vm.forward_ports.forwarding')
-            forward_ports
+            forward_ports(env)
           end
         end
 
-        def forward_ports
-          @env[:forwarded_ports].each do |fp|
+        def forward_ports(env)
+          env[:forwarded_ports].each do |fp|
             message_attributes = {
               adapter: fp[:adapter] || 'eth0',
               guest_port: fp[:guest],
               host_port: fp[:host]
             }
 
-            @env[:ui].info(I18n.t(
+            env[:ui].info(I18n.t(
                              'vagrant.actions.vm.forward_ports.forwarding_entry',
                              **message_attributes
             ))
 
-            if fp[:protocol] == 'udp'
-              @env[:ui].warn I18n.t('vagrant_libvirt.warnings.forwarding_udp')
-              next
-            end
-
             ssh_pid = redirect_port(
-              @env[:machine],
+              env,
+              env[:machine],
               fp[:host_ip] || '*',
               fp[:host],
-              fp[:guest_ip] || @env[:machine].provider.ssh_info[:host],
+              fp[:guest_ip] || env[:machine].provider.ssh_info[:host],
               fp[:guest],
               fp[:gateway_ports] || false
             )
-            store_ssh_pid(fp[:host], ssh_pid)
+            store_ssh_pid(env[:machine], fp[:host], ssh_pid)
           end
         end
 
         private
 
-        def compile_forwarded_ports(config)
+        def compile_forwarded_ports(env, config)
           mappings = {}
 
           config.vm.networks.each do |type, options|
             next if options[:disabled]
+
+            if options[:protocol] == 'udp'
+              env[:ui].warn I18n.t('vagrant_libvirt.warnings.forwarding_udp')
+              next
+            end
 
             next unless type == :forwarded_port && options[:id] != 'ssh'
             if options.fetch(:host_ip, '').to_s.strip.empty?
@@ -82,7 +81,7 @@ module VagrantPlugins
           mappings.values
         end
 
-        def redirect_port(machine, host_ip, host_port, guest_ip, guest_port,
+        def redirect_port(env, machine, host_ip, host_port, guest_ip, guest_port,
                           gateway_ports)
           ssh_info = machine.ssh_info
           params = %W(
@@ -114,7 +113,7 @@ module VagrantPlugins
           if host_port <= 1024
             @@lock.synchronize do
               # TODO: add i18n
-              @env[:ui].info 'Requesting sudo for host port(s) <= 1024'
+              env[:ui].info 'Requesting sudo for host port(s) <= 1024'
               r = system('sudo -v')
               if r
                 ssh_cmd << 'sudo ' # add sudo prefix
@@ -125,14 +124,15 @@ module VagrantPlugins
           ssh_cmd << "ssh -n #{options} #{params}"
 
           @logger.debug "Forwarding port with `#{ssh_cmd}`"
-          log_file = ssh_forward_log_file(host_ip, host_port,
-                                          guest_ip, guest_port)
+          log_file = ssh_forward_log_file(
+            env[:machine], host_ip, host_port, guest_ip, guest_port,
+          )
           @logger.info "Logging to #{log_file}"
           spawn(ssh_cmd, [:out, :err] => [log_file, 'w'], :pgroup => true)
         end
 
-        def ssh_forward_log_file(host_ip, host_port, guest_ip, guest_port)
-          log_dir = @env[:machine].data_dir.join('logs')
+        def ssh_forward_log_file(machine, host_ip, host_port, guest_ip, guest_port)
+          log_dir = machine.data_dir.join('logs')
           log_dir.mkdir unless log_dir.directory?
           File.join(
             log_dir,
@@ -141,8 +141,8 @@ module VagrantPlugins
           )
         end
 
-        def store_ssh_pid(host_port, ssh_pid)
-          data_dir = @env[:machine].data_dir.join('pids')
+        def store_ssh_pid(machine, host_port, ssh_pid)
+          data_dir = machine.data_dir.join('pids')
           data_dir.mkdir unless data_dir.directory?
 
           data_dir.join("ssh_#{host_port}.pid").open('w') do |pid_file|
@@ -169,13 +169,12 @@ module VagrantPlugins
         end
 
         def call(env)
-          @env = env
-
-          if ssh_pids.any?
+          pids = ssh_pids(env[:machine])
+          if pids.any?
             env[:ui].info I18n.t(
               'vagrant.actions.vm.clear_forward_ports.deleting'
             )
-            ssh_pids.each do |tag|
+            pids.each do |tag|
               next unless ssh_pid?(tag[:pid])
               @logger.debug "Killing pid #{tag[:pid]}"
               kill_cmd = ''
@@ -191,7 +190,7 @@ module VagrantPlugins
             end
 
             @logger.info 'Removing ssh pid files'
-            remove_ssh_pids
+            remove_ssh_pids(env[:machine])
           else
             @logger.info 'No ssh pids found'
           end
@@ -201,9 +200,9 @@ module VagrantPlugins
 
         protected
 
-        def ssh_pids
-          glob = @env[:machine].data_dir.join('pids').to_s + '/ssh_*.pid'
-          @ssh_pids = Dir[glob].map do |file|
+        def ssh_pids(machine)
+          glob = machine.data_dir.join('pids').to_s + '/ssh_*.pid'
+          ssh_pids = Dir[glob].map do |file|
             {
               pid: File.read(file).strip.chomp,
               port: File.basename(file)['ssh_'.length..-1 * ('.pid'.length + 1)].to_i
@@ -217,8 +216,8 @@ module VagrantPlugins
           `ps -o command= #{pid}`.strip.chomp =~ /ssh/
         end
 
-        def remove_ssh_pids
-          glob = @env[:machine].data_dir.join('pids').to_s + '/ssh_*.pid'
+        def remove_ssh_pids(machine)
+          glob = machine.data_dir.join('pids').to_s + '/ssh_*.pid'
           Dir[glob].each do |file|
             File.delete file
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,5 +31,7 @@ require 'vagrant-libvirt'
 require 'support/environment_helper'
 require 'vagrant-spec/unit'
 
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
+
 RSpec.configure do |spec|
 end

--- a/spec/support/matchers/have_file_content.rb
+++ b/spec/support/matchers/have_file_content.rb
@@ -1,0 +1,63 @@
+require "rspec/expectations/version"
+#
+# Taken from https://github.com/cucumber/aruba/blob/main/lib/aruba/matchers/file/have_file_content.rb
+# with minor modifications
+#
+# @!method have_file_content(content)
+#   This matchers checks if <file> has content. `content` can be a string,
+#   regexp or an RSpec matcher.
+#
+#   @param [String, Regexp, Matcher] content
+#     Specifies the content of the file
+#
+#   @return [Boolean] The result
+#
+#     false:
+#     * if file does not exist
+#     * if file content is not equal string
+#     * if file content does not include regexp
+#     * if file content does not match the content specification
+#
+#     true:
+#     * if file content includes regexp
+#     * if file content is equal string
+#     * if file content matches the content specification
+#
+#   @example Use matcher with string
+#
+#     RSpec.describe do
+#       it { expect(file1).to have_file_content('a') }
+#     end
+#
+#   @example Use matcher with regexp
+#
+#     RSpec.describe do
+#       it { expect(file1).to have_file_content(/a/) }
+#     end
+#
+#   @example Use matcher with an RSpec matcher
+#
+#     RSpec.describe do
+#       it { expect(file1).to have_file_content(a_string_starting_with 'a') }
+#       it { expect(files1).to include a_file_having_content(a_string_starting_with 'a') }
+#     end
+RSpec::Matchers.define :have_file_content do |expected|
+  match do |actual|
+    next false unless File.exists?(actual)
+
+    @actual   = File.read(actual).chomp
+    @expected = if expected.is_a? String
+                  expected.chomp
+                else
+                  expected
+                end
+
+    values_match?(@expected, @actual)
+  end
+
+  diffable if expected.is_a? String
+
+  description { "have file content: #{description_of expected}" }
+end
+
+RSpec::Matchers.alias_matcher :a_file_having_content, :have_file_content

--- a/spec/unit/action/forward_ports_spec.rb
+++ b/spec/unit/action/forward_ports_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+require 'support/sharedcontext'
+require 'support/libvirt_context'
+
+require 'vagrant-libvirt/errors'
+require 'vagrant-libvirt/action/forward_ports'
+
+describe VagrantPlugins::ProviderLibvirt::Action::ForwardPorts do
+  subject { described_class.new(app, env) }
+
+  include_context 'unit'
+
+  let(:machine_config) { double("machine_config") }
+  let(:vm_config) { double("vm_config") }
+
+  before (:each) do
+    allow(machine).to receive(:config).and_return(machine_config)
+    allow(machine_config).to receive(:vm).and_return(vm_config)
+    allow(vm_config).to receive(:networks).and_return([])
+  end
+
+  describe '#call' do
+    context 'with none defined' do
+      it 'should skip calling forward_ports' do
+        expect(subject).to_not receive(:forward_ports)
+        expect(subject.call(env)).to be_nil
+      end
+    end
+
+    context 'with forwarded port defined' do
+      context 'when host port in protected range' do
+        let(:port_options){ {guest: 8080, host: 80} }
+
+        it 'should emit a warning' do
+          expect(vm_config).to receive(:networks).and_return([[:forwarded_port, port_options]])
+          expect(ui).to receive(:warn).with(include("You are trying to forward to privileged ports"))
+          expect(subject).to receive(:forward_ports).and_return(nil)
+
+          expect(subject.call(env)).to be_nil
+        end
+      end
+
+      context 'when guest port in protected range' do
+        let(:port_options){ {guest: 80, host: 8080} }
+
+        it 'should not trigger any warning' do
+          expect(vm_config).to receive(:networks).and_return([[:forwarded_port, port_options]])
+          expect(ui).to_not receive(:warn)
+          expect(subject).to receive(:forward_ports).and_return(nil)
+
+          expect(subject.call(env)).to be_nil
+        end
+      end
+    end
+
+    context 'when udp protocol is selected' do
+      let(:port_options){ {guest: 80, host: 8080, protocol: "udp"} }
+
+      it 'should skip and emit warning' do
+        expect(vm_config).to receive(:networks).and_return([[:forwarded_port, port_options]])
+        expect(ui).to receive(:warn).with("Forwarding UDP ports is not supported. Ignoring.")
+        expect(subject).to_not receive(:forward_ports)
+
+        expect(subject.call(env)).to be_nil
+      end
+    end
+  end
+
+  describe '#forward_ports' do
+    let(:pid_dir){ machine.data_dir.join('pids') }
+
+    before (:each) do
+      allow(env).to receive(:[]).and_call_original
+      allow(machine).to receive(:ssh_info).and_return(
+        {
+          :host => "localhost",
+          :username => "vagrant",
+          :port => 22,
+          :private_key_path => ["/home/test/.ssh/id_rsa"],
+        }
+      )
+    end
+
+    context 'with port to forward' do
+      let(:port_options){ {guest: 80, host: 8080, guest_ip: "192.168.1.121"} }
+
+      it 'should spawn ssh to setup forwarding' do
+        expect(env).to receive(:[]).with(:forwarded_ports).and_return([port_options])
+        expect(ui).to receive(:info).with("#{port_options[:guest]} (guest) => #{port_options[:host]} (host) (adapter eth0)")
+        expect(subject).to receive(:spawn).with(/ssh -n -o User=vagrant -o Port=22.*-L \*:8080:192.168.1.121:80 -N localhost/, anything).and_return(9999)
+
+        expect(subject.forward_ports(env)).to eq([port_options])
+
+        expect(pid_dir.join('ssh_8080.pid')).to have_file_content("9999")
+      end
+    end
+
+    context 'with privileged host port' do
+      let(:port_options){ {guest: 80, host: 80, guest_ip: "192.168.1.121"} }
+
+      it 'should spawn ssh to setup forwarding' do
+        expect(env).to receive(:[]).with(:forwarded_ports).and_return([port_options])
+        expect(ui).to receive(:info).with("#{port_options[:guest]} (guest) => #{port_options[:host]} (host) (adapter eth0)")
+        expect(ui).to receive(:info).with('Requesting sudo for host port(s) <= 1024')
+        expect(subject).to receive(:system).with('sudo -v').and_return(true)
+        expect(subject).to receive(:spawn).with(/sudo ssh -n -o User=vagrant -o Port=22.*-L \*:80:192.168.1.121:80 -N localhost/, anything).and_return(10000)
+
+        expect(subject.forward_ports(env)).to eq([port_options])
+
+        expect(pid_dir.join('ssh_80.pid')).to have_file_content("10000")
+      end
+    end
+  end
+end
+
+describe VagrantPlugins::ProviderLibvirt::Action::ClearForwardedPorts do
+  subject { described_class.new(app, env) }
+
+  include_context 'unit'
+  include_context 'libvirt'
+
+  describe '#call' do
+    context 'no forwarded ports' do
+      it 'should skip checking if pids are running' do
+        expect(subject).to_not receive(:ssh_pid?)
+        expect(logger).to receive(:info).with('No ssh pids found')
+
+        expect(subject.call(env)).to be_nil
+      end
+    end
+
+    context 'multiple forwarded ports' do
+      before do
+        data_dir = machine.data_dir.join('pids')
+        data_dir.mkdir unless data_dir.directory?
+
+        [
+          {:port => '8080', :pid => '10001'},
+          {:port => '8081', :pid => '10002'},
+        ].each do |port_pid|
+          File.write(data_dir.to_s + "/ssh_#{port_pid[:port]}.pid", port_pid[:pid])
+        end
+      end
+      it 'should terminate each of the processes' do
+        expect(logger).to receive(:info).with(no_args) # don't know how to test translations from vagrant
+        expect(subject).to receive(:ssh_pid?).with("10001").and_return(true)
+        expect(subject).to receive(:ssh_pid?).with("10002").and_return(true)
+        expect(logger).to receive(:debug).with(/Killing pid/).twice()
+        expect(logger).to receive(:info).with('Removing ssh pid files')
+        expect(subject).to receive(:system).with("kill 10001")
+        expect(subject).to receive(:system).with("kill 10002")
+
+        expect(subject.call(env)).to be_nil
+
+        expect(Dir.entries(machine.data_dir.join('pids'))).to eq(['.', '..'])
+      end
+    end
+  end
+end

--- a/spec/unit/action/forward_ports_spec.rb
+++ b/spec/unit/action/forward_ports_spec.rb
@@ -152,7 +152,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::ClearForwardedPorts do
 
         expect(subject.call(env)).to be_nil
 
-        expect(Dir.entries(machine.data_dir.join('pids'))).to eq(['.', '..'])
+        expect(Dir.entries(machine.data_dir.join('pids'))).to match_array(['.', '..'])
       end
     end
   end


### PR DESCRIPTION
Adds some basic unit spec tests to validate the main behaviours around
the port forwarding to allow for subsequent behaviour changes.

Additionally removes the dependency on the instance variable @env for
internal functions to allow testing some of the internal functions
without needing to inject an instance variable that is not set on
initialization.

Includes a file contents matcher lifted from the cucumber/aruba project
on github, with some minor modifications instead of including the entire
gem.
