### PR TITLE
Exclude LIBVIRT_DEFAULT_URI from impacting tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,5 +33,11 @@ require 'vagrant-spec/unit'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
-RSpec.configure do |spec|
+RSpec.configure do |config|
+  # ensure that setting of LIBVIRT_DEFAULT_URI in the environment is not picked
+  # up directly by tests, instead they must set as needed. Some build envs will
+  # may have it set to 'qemu:///session'.
+  config.before(:suite) do
+    ENV.delete('LIBVIRT_DEFAULT_URI')
+  end
 end


### PR DESCRIPTION
Some build environments may have this environment variable set to a
different default value than is expected by the tests. Have rspec delete
it from the environment before starting the test run to ensure that only
the tests that explicitly set it or other config values need expect
different behaviour.

Closes: #1255
