### PR TITLE
Enable forward ssh-port to host

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ can help a lot :-)
 * [No box and PXE boot](#no-box-and-pxe-boot)
 * [SSH Access To VM](#ssh-access-to-vm)
 * [Forwarded Ports](#forwarded-ports)
+  * [Forwarding the ssh-port](#forwarding-the-ssh-port)
 * [Synced Folders](#synced-folders)
 * [QEMU Session Support](#qemu-session-support)
 * [Customized Graphics](#customized-graphics)
@@ -1415,6 +1416,24 @@ Default is `eth0`.
 **Externally Accessible Port Forward**
 
 `config.vm.network :forwarded_port, guest: 80, host: 2000, host_ip: "0.0.0.0"`
+
+### Forwarding the ssh-port
+
+By default vagrant-libvirt now allows the standard ssh-port to be forwarded to
+the localhost to allow for consistent provisioning steps/ports used when
+defining across multiple providers.
+
+Previously by default libvirt skipped the forwarding of the ssh-port because
+you can access the machine directly. To return to this behaviour set the
+option `forward_ssh_port` to `false` in the Vagrantfile.
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    # Disable forwarding of forwarded_port with id 'ssh'.
+    libvirt.forward_ssh_port = false
+  end
+```
 
 ## Synced Folders
 

--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -71,7 +71,7 @@ module VagrantPlugins
               next
             end
 
-            next unless type == :forwarded_port && options[:id] != 'ssh'
+            next if type != :forwarded_port || ( options[:id] == 'ssh' && !env[:machine].provider_config.forward_ssh_port )
             if options.fetch(:host_ip, '').to_s.strip.empty?
               options.delete(:host_ip)
             end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -39,6 +39,9 @@ module VagrantPlugins
 
       attr_accessor :proxy_command
 
+      # Forward port with id 'ssh'
+      attr_accessor :forward_ssh_port
+
       # Libvirt storage pool name, where box image and instance snapshots will
       # be stored.
       attr_accessor :storage_pool_name
@@ -196,6 +199,7 @@ module VagrantPlugins
         @id_ssh_key_file   = UNSET_VALUE
         @socket            = UNSET_VALUE
         @proxy_command     = UNSET_VALUE
+        @forward_ssh_port  = UNSET_VALUE # forward port with id 'ssh'
         @storage_pool_name = UNSET_VALUE
         @snapshot_pool_name = UNSET_VALUE
         @random_hostname   = UNSET_VALUE
@@ -783,6 +787,9 @@ module VagrantPlugins
 
         finalize_from_uri
         finalize_proxy_command
+
+        # forward port with id 'ssh'
+        @forward_ssh_port = true if @forward_ssh_port == UNSET_VALUE
 
         @storage_pool_name = 'default' if @storage_pool_name == UNSET_VALUE
         @snapshot_pool_name = @storage_pool_name if @snapshot_pool_name == UNSET_VALUE


### PR DESCRIPTION
Provides an option to disable the forwarding in case it causes issues.
However based on original PRs adding the forwarded behaviour, it does
not appear to be intentional to exclude it permanently.

Closes: #1011
Closes: #1012
