### PR TITLE
Ensure state is fully removed for destroy

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -179,6 +179,7 @@ module VagrantPlugins
               # Try to remove stale volumes anyway
               b2.use SetNameOfDomain
               b2.use RemoveStaleVolume if env[:machine].config.vm.box
+              b2.use CleanMachineFolder, quiet: true
               b2.use MessageNotCreated unless env[:result]
 
               next
@@ -191,6 +192,7 @@ module VagrantPlugins
                 b3.use PruneNFSExports
                 b3.use DestroyDomain
                 b3.use DestroyNetworks
+                b3.use CleanMachineFolder
               else
                 b3.use MessageWillNotDestroy
               end
@@ -324,6 +326,7 @@ module VagrantPlugins
       autoload :CreateDomainVolume, action_root.join('create_domain_volume')
       autoload :CreateNetworkInterfaces, action_root.join('create_network_interfaces')
       autoload :CreateNetworks, action_root.join('create_networks')
+      autoload :CleanMachineFolder, action_root.join('clean_machine_folder')
       autoload :DestroyDomain, action_root.join('destroy_domain')
       autoload :DestroyNetworks, action_root.join('destroy_networks')
       autoload :ForwardPorts, action_root.join('forward_ports')

--- a/lib/vagrant-libvirt/action/clean_machine_folder.rb
+++ b/lib/vagrant-libvirt/action/clean_machine_folder.rb
@@ -1,0 +1,28 @@
+require 'log4r'
+
+module VagrantPlugins
+  module ProviderLibvirt
+    module Action
+      class CleanMachineFolder
+
+        def initialize(app, env, options=nil)
+          @logger = Log4r::Logger.new('vagrant_libvirt::action::create_domain')
+          @app = app
+          @ui = env[:ui]
+          @quiet = (options || {}).fetch(:quiet, false)
+        end
+
+        def call(env)
+          machine_folder = env[:machine].data_dir
+
+          @ui.info("Deleting the machine folder") unless @quiet
+
+          @logger.debug("Recursively removing: #{machine_folder}")
+          FileUtils.rm_rf(machine_folder, :secure => true)
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/action/clean_machine_folder_spec.rb
+++ b/spec/unit/action/clean_machine_folder_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'support/sharedcontext'
+
+require 'vagrant-libvirt/action/clean_machine_folder'
+
+describe VagrantPlugins::ProviderLibvirt::Action::CleanMachineFolder do
+  subject { described_class.new(app, env) }
+
+  include_context 'unit'
+
+  describe '#call' do
+    context 'with default options' do
+      it 'should verbosely remove the folder' do
+        expect(ui).to receive(:info).with('Deleting the machine folder')
+        expect(FileUtils).to receive(:rm_rf).with(machine.data_dir, {:secure => true})
+
+        expect(subject.call(env)).to be_nil
+      end
+    end
+
+    context 'when the data dir doesn\'t exist' do
+      before do
+        Dir.mktmpdir do |d|
+          # returns a temporary directory that has been already deleted when running
+          expect(machine).to receive(:data_dir).and_return(d.to_s).exactly(2).times
+        end
+      end
+
+      it 'should remove the folder' do
+        expect(ui).to receive(:info).with('Deleting the machine folder')
+        expect(FileUtils).to receive(:rm_rf).with(machine.data_dir, {:secure => true})
+
+        expect(subject.call(env)).to be_nil
+      end
+    end
+
+    context 'with quiet option enabled' do
+      subject { described_class.new(app, env, {:quiet => true}) }
+
+      it 'should quietly remove the folder' do
+        expect(ui).to_not receive(:info).with('Deleting the machine folder')
+        expect(FileUtils).to receive(:rm_rf).with(machine.data_dir, {:secure => true})
+
+        expect(subject.call(env)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Completely remove state after a destroy, and ensure removal of a
non-existing domain also scrubs the machine folder clean.

Closes: #1132
