### PR TITLE
Revert "Fix coveralls reporting (#1272)"

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -119,7 +119,7 @@ jobs:
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - uses: actions/upload-artifact@v2
       with:
-        name: lcov.info
+        name: lcov.info-${{ matrix.vagrant }}-${{ matrix.ruby }}
         path: ./vagrant-libvirt/coverage/lcov.info
     - name: Coveralls Parallel
       uses: coverallsapp/github-action@master

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,19 +47,20 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        path: vagrant-libvirt
     - name: Clone vagrant for ruby 3.0 support
       if: ${{ matrix.ruby == '3.0.0' }}
       uses: actions/checkout@v2
       with:
         repository: hashicorp/vagrant
-        path: .deps/vagrant
+        path: vagrant
         ref: f7973f00edb9438d0b36085f210c80af71cfe5c5
     - name: Clone ruby-libvirt for ruby 3.0 support
       if: ${{ matrix.ruby == '3.0.0' }}
       uses: actions/checkout@v2
       with:
         repository: libvirt/libvirt-ruby
-        path: .deps/libvirt-ruby
+        path: libvirt-ruby
         ref: 43444be184e4d877c5ce110ee5475c952d7590f7
     - name: Set up libvirt
       run: |
@@ -67,7 +68,7 @@ jobs:
         sudo apt-get install libvirt-dev
     - uses: actions/cache@v2
       with:
-        path: vendor/bundle
+        path: vagrant-libvirt/vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
@@ -79,45 +80,54 @@ jobs:
       run: |
         gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
         gem update bundler --conservative
+      working-directory: vagrant-libvirt
     - name: Handle additional ruby 3.0 setup
       if: ${{ matrix.ruby == '3.0.0' }}
       run: |
         # ensure vagrant gemspec allows ruby 3.0
-        pushd .deps/vagrant/
+        pushd ../vagrant/
         # ensure main branch exists
         git checkout -b main
         sed -i -e 's@s.required_ruby_version.*=.*@s.required_ruby_version     = "~> 3.0"@' vagrant.gemspec
         popd
 
-        bundle config local.vagrant ${PWD}/.deps/vagrant/
+        bundle config local.vagrant ${PWD}/../vagrant/
 
         # build gem of latest bindings that contain fix for ruby include path
-        pushd .deps/libvirt-ruby
+        pushd ../libvirt-ruby
         rake gem
         popd
 
         mkdir -p vendor/bundle/ruby/3.0.0/cache/
-        cp .deps/libvirt-ruby/pkg/ruby-libvirt-*.gem vendor/bundle/ruby/3.0.0/cache/
+        cp ../libvirt-ruby/pkg/ruby-libvirt-*.gem vendor/bundle/ruby/3.0.0/cache/
         # need the following to allow the local provided gem to be used instead of the
         # one from rubygems
         bundle config set --local disable_checksum_validation true
+      working-directory: vagrant-libvirt
     - name: Run bundler using cached path
       run: |
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
+      working-directory: vagrant-libvirt
       env:
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - name: Run tests
       run: |
         bundle exec rspec --color --format documentation
+      working-directory: vagrant-libvirt
       env:
         VAGRANT_VERSION: ${{ matrix.vagrant }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: lcov.info
+        path: ./vagrant-libvirt/coverage/lcov.info
     - name: Coveralls Parallel
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.github_token }}
         parallel: true
-        path-to-lcov: ./coverage/lcov.info
+        path-to-lcov: ./vagrant-libvirt/coverage/lcov.info
+
 
   finish:
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ Vagrantfile
 !example_box/Vagrantfile
 .vagrant
 *.swp
-.deps
 
 # don't commit the generated version
 lib/vagrant-libvirt/version


### PR DESCRIPTION
This reverts commit 6f608c54bfb373a1bf5d970abe4e10d7ed392d7c.

This should demo that there is an issue with coveralls action and
uploading coverage from projects placed in a sub-directory.
