### PR TITLE
add support for boot 'network' from a vagrant public_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,6 +1389,24 @@ Name of network "foreman_managed" is key for define boot order
       end
 ```
 
+An example VM that is PXE booted from the `br1` device (which must already be configured in the host machine), and if that fails, is booted from the disk:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.define :pxeclient do |pxeclient|
+    pxeclient.vm.network :public_network,
+      dev: 'br1',
+      auto_config: false
+    pxeclient.vm.provider :libvirt do |domain|
+      boot_network = {'dev' => 'br1'}
+      domain.storage :file, :size => '100G'
+      domain.boot boot_network
+      domain.boot 'hd'
+    end
+  end
+end
+```
+
 ## SSH Access To VM
 
 vagrant-libvirt supports vagrant's [standard ssh

--- a/lib/vagrant-libvirt/action/set_boot_order.rb
+++ b/lib/vagrant-libvirt/action/set_boot_order.rb
@@ -86,9 +86,13 @@ module VagrantPlugins
 
         def search_network(nets, xml)
           str = '/domain/devices/interface'
-          str += "[(@type='network' or @type='udp' or @type='bridge')"
+          str += "[(@type='network' or @type='udp' or @type='bridge' or @type='direct')"
           unless nets.empty?
-            str += " and source[@network='#{nets.first['network']}']"
+            net = nets.first
+            network = net['network']
+            dev = net['dev']
+            str += " and source[@network='#{network}']" if network
+            str += " and source[@dev='#{dev}']" if dev
           end
           str += ']'
           @logger.debug(str)


### PR DESCRIPTION
when we use a `public_network` in vagrant, this is how libvirt domain xml looks like (notice that the interface type is 'direct'):

```xml
    <interface type="direct">
      <mac address="08:00:27:00:00:01"/>
      <source dev="br-rpi" mode="bridge"/>
      <model type="virtio"/>
      <boot order="2"/> <!-- this boot xml node will be inserted with this commit -->
      <address type="pci" domain="0x0000" bus="0x00" slot="0x05" function="0x0"/>
    </interface>
```

closes https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1002