### PR TITLE
Handle extraction of keyfile from uri

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 require 'vagrant'
 
 class Numeric
@@ -1019,6 +1021,10 @@ module VagrantPlugins
         @host = uri.host
         @port = uri.port
         @username = uri.user
+        if uri.query
+          params = CGI.parse(uri.query)
+          @id_ssh_key_file = params['keyfile'].first if params.has_key?('keyfile')
+        end
 
         finalize_id_ssh_key_file
       end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -394,7 +394,6 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         [
           {:uri => 'qemu+ssh://remote/system?keyfile=/some/path/to/keyfile'},
           "ssh 'remote' -i '/some/path/to/keyfile' -W %h:%p",
-          {:allow_failure => "keyfile not yet inferred from uri"},
         ],
 
         # provide custom template


### PR DESCRIPTION
If the keyfile is specified as part of the URI provided, extract it and
set the appropriate option so that it can be provided to the proxy
command subsequently.
