### PR TITLE
Vagrant up expects machine data_dir to exist afterwards

### DIFF
--- a/lib/vagrant-libvirt/action/clean_machine_folder.rb
+++ b/lib/vagrant-libvirt/action/clean_machine_folder.rb
@@ -19,6 +19,8 @@ module VagrantPlugins
 
           @logger.debug("Recursively removing: #{machine_folder}")
           FileUtils.rm_rf(machine_folder, :secure => true)
+          # need to recreate to prevent exception during a cancelled up
+          FileUtils.mkdir_p(machine_folder)
 
           @app.call(env)
         end

--- a/spec/unit/action/clean_machine_folder_spec.rb
+++ b/spec/unit/action/clean_machine_folder_spec.rb
@@ -9,12 +9,18 @@ describe VagrantPlugins::ProviderLibvirt::Action::CleanMachineFolder do
   include_context 'unit'
 
   describe '#call' do
+    before do
+      FileUtils.touch(File.join(machine.data_dir, "box.meta"))
+    end
+
     context 'with default options' do
       it 'should verbosely remove the folder' do
         expect(ui).to receive(:info).with('Deleting the machine folder')
-        expect(FileUtils).to receive(:rm_rf).with(machine.data_dir, {:secure => true})
 
         expect(subject.call(env)).to be_nil
+
+        expect(File.exists?(machine.data_dir)).to eq(true)
+        expect(Dir.entries(machine.data_dir)).to match_array([".", ".."])
       end
     end
 
@@ -22,15 +28,17 @@ describe VagrantPlugins::ProviderLibvirt::Action::CleanMachineFolder do
       before do
         Dir.mktmpdir do |d|
           # returns a temporary directory that has been already deleted when running
-          expect(machine).to receive(:data_dir).and_return(d.to_s).exactly(2).times
+          expect(machine).to receive(:data_dir).and_return(d.to_s).exactly(3).times
         end
       end
 
       it 'should remove the folder' do
         expect(ui).to receive(:info).with('Deleting the machine folder')
-        expect(FileUtils).to receive(:rm_rf).with(machine.data_dir, {:secure => true})
 
         expect(subject.call(env)).to be_nil
+
+        expect(File.exists?(machine.data_dir)).to eq(true)
+        expect(Dir.entries(machine.data_dir)).to match_array([".", ".."])
       end
     end
 
@@ -39,9 +47,11 @@ describe VagrantPlugins::ProviderLibvirt::Action::CleanMachineFolder do
 
       it 'should quietly remove the folder' do
         expect(ui).to_not receive(:info).with('Deleting the machine folder')
-        expect(FileUtils).to receive(:rm_rf).with(machine.data_dir, {:secure => true})
 
         expect(subject.call(env)).to be_nil
+
+        expect(File.exists?(machine.data_dir)).to eq(true)
+        expect(Dir.entries(machine.data_dir)).to match_array([".", ".."])
       end
     end
   end


### PR DESCRIPTION
Ensure the machine data_dir is recreated after removal because vagrant
up expects the directory to exist even if there has been an exception
and the machine has been deleted subsequently.

Remove expects that check for arguments vs keywords as ruby 3.0 has
changed the separation and currently cannot upgrade the rspec-mocks to
handle until vagrant-spec updates.