### PR TITLE
Provide Vagrantfile path in description by default

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -33,7 +33,8 @@ module VagrantPlugins
           # Gather some info about domain
           @name = env[:domain_name]
           @title = config.title
-          @description = config.description
+          vagrantfile = File.join(env[:root_path], (env[:vagrantfile_name] || "Vagrantfile"))
+          @description = !config.description.empty? ? config.description : "Source: #{vagrantfile}"
           @uuid = config.uuid
           @cpus = config.cpus.to_i
           @cpuset = config.cpuset

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -15,7 +15,8 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
   let(:servers) { double('servers') }
   let(:volumes) { double('volumes') }
 
-  let(:storage_pool_xml) { File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), test_file)) }
+  let(:domain_xml) { File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), domain_xml_file)) }
+  let(:storage_pool_xml) { File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), storage_pool_xml_file)) }
   let(:libvirt_storage_pool) { double('storage_pool') }
 
   describe '#call' do
@@ -44,12 +45,13 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
 
     context 'connection => qemu:///system' do
       context 'default pool' do
-        let(:test_file) { 'default_system_storage_pool.xml' }
+        let(:domain_xml_file) { 'default_domain.xml' }
+        let(:storage_pool_xml_file) { 'default_system_storage_pool.xml' }
 
         it 'should execute correctly' do
           expect(libvirt_client).to receive(:lookup_storage_pool_by_name).and_return(libvirt_storage_pool)
           expect(libvirt_storage_pool).to receive(:xml_desc).and_return(storage_pool_xml)
-          expect(servers).to receive(:create).and_return(machine)
+          expect(servers).to receive(:create).with(xml: domain_xml).and_return(machine)
           expect(volumes).to_not receive(:create) # additional disks only
 
           expect(subject.call(env)).to be_nil
@@ -78,6 +80,8 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
           end
 
           context 'volume create succeeded' do
+            let(:domain_xml_file) { 'additional_disks_domain.xml' }
+
             it 'should complete' do
               expect(libvirt_client).to receive(:lookup_storage_pool_by_name).and_return(libvirt_storage_pool)
               expect(libvirt_storage_pool).to receive(:xml_desc).and_return(storage_pool_xml)
@@ -89,7 +93,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
                   :pool_name   => "default",
                 )
               )
-              expect(servers).to receive(:create).and_return(machine)
+              expect(servers).to receive(:create).with(xml: domain_xml).and_return(machine)
 
               expect(subject.call(env)).to be_nil
             end
@@ -119,7 +123,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
       end
 
       context 'default pool' do
-        let(:test_file) { 'default_user_storage_pool.xml' }
+        let(:storage_pool_xml_file) { 'default_user_storage_pool.xml' }
 
         it 'should execute correctly' do
           expect(libvirt_client).to receive(:lookup_storage_pool_by_name).and_return(libvirt_storage_pool)

--- a/spec/unit/action/create_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/create_domain_spec/additional_disks_domain.xml
@@ -1,0 +1,54 @@
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name>vagrant-test_default</name>
+  <title></title>
+  <description>Source: /rootpath/Vagrantfile</description>
+  <uuid></uuid>
+  <memory>524288</memory>
+  <vcpu>1</vcpu>
+
+
+  <cpu mode='host-model'>
+      <model fallback='allow'></model>
+  </cpu>
+
+
+  <os>
+        <type>hvm</type>
+    <kernel></kernel>
+    <initrd></initrd>
+    <cmdline></cmdline>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'>
+  </clock>
+  <devices>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='default'/>
+      <source file='/var/lib/libvirt/images/vagrant-test_default-vdb.qcow2'/>
+      <target dev='vdb' bus='virtio'/>
+    </disk>
+
+
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+
+
+    <input type='mouse' bus='ps2'/>
+
+      <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'  />
+      <video>
+        <model type='cirrus' vram='9216' heads='1'/>
+      </video>
+
+
+  </devices>
+
+</domain>

--- a/spec/unit/action/create_domain_spec/default_domain.xml
+++ b/spec/unit/action/create_domain_spec/default_domain.xml
@@ -1,0 +1,49 @@
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name>vagrant-test_default</name>
+  <title></title>
+  <description>Source: /rootpath/Vagrantfile</description>
+  <uuid></uuid>
+  <memory>524288</memory>
+  <vcpu>1</vcpu>
+
+
+  <cpu mode='host-model'>
+      <model fallback='allow'></model>
+  </cpu>
+
+
+  <os>
+        <type>hvm</type>
+    <kernel></kernel>
+    <initrd></initrd>
+    <cmdline></cmdline>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'>
+  </clock>
+  <devices>
+
+
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+
+
+    <input type='mouse' bus='ps2'/>
+
+      <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'  />
+      <video>
+        <model type='cirrus' vram='9216' heads='1'/>
+      </video>
+
+
+  </devices>
+
+</domain>


### PR DESCRIPTION
Ensure the source Vagrantfile appears in the virtual machine description
to help people using virsh/virt-manager subsequently to understand where
machines have come from.

Fixes: #496
