### PR TITLE
Ensure open3 required and qemu-utils in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt update \
         kmod \
         libvirt-bin \
         openssh-client \
+        qemu-utils \
         rsync \
     && rm -rf /var/lib/apt/lists \
     ;

--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -1,4 +1,5 @@
 require 'log4r'
+require 'open3'
 
 module VagrantPlugins
   module ProviderLibvirt


### PR DESCRIPTION
Depending on load order of libraries as well as version of ruby, need to
require open3 before attempting to reference `Open3`.

There is an additional dependency on qemu-utils to dynamically retrieve
the image information to provide the virtual size and format
automatically. Add this to the docker image to ensure it's available for
users of this distribution format.

Fixes: #1305