### PR TITLE
Basic packaging tests and restructure action

### DIFF
--- a/spec/support/temporary_dir.rb
+++ b/spec/support/temporary_dir.rb
@@ -1,0 +1,10 @@
+shared_context 'temporary_dir' do
+  around do |example|
+    Dir.mktmpdir("rspec-") do |dir|
+      @temp_dir = dir
+      example.run
+    end
+  end
+
+  attr_reader :temp_dir
+end

--- a/spec/unit/action/package_domain_spec.rb
+++ b/spec/unit/action/package_domain_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+require 'support/sharedcontext'
+
+require 'vagrant-libvirt/action/clean_machine_folder'
+
+describe VagrantPlugins::ProviderLibvirt::Action::PackageDomain do
+  subject { described_class.new(app, env) }
+
+  include_context 'unit'
+  include_context 'libvirt'
+  include_context 'temporary_dir'
+
+  let(:libvirt_client) { double('libvirt_client') }
+  let(:libvirt_domain) { double('libvirt_domain') }
+  let(:servers) { double('servers') }
+  let(:volumes) { double('volumes') }
+
+  describe '#call' do
+    before do
+      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
+        .to receive(:connection).and_return(connection)
+      allow(connection).to receive(:client).and_return(libvirt_client)
+      allow(libvirt_client).to receive(:lookup_domain_by_uuid).and_return(libvirt_domain)
+
+      allow(connection).to receive(:servers).and_return(servers)
+      allow(servers).to receive(:get).and_return(domain)
+
+      allow(connection).to receive(:volumes).and_return(volumes)
+
+      allow(logger).to receive(:info)
+
+      env["package.directory"] = temp_dir
+    end
+
+    context 'with defaults' do
+      let(:root_disk) { double('libvirt_domain_disk') }
+      before do
+        allow(root_disk).to receive(:name).and_return('default_domain.img')
+        allow(domain).to receive(:volumes).and_return([root_disk])
+        allow(libvirt_domain).to receive(:name).and_return('default_domain')
+        allow(subject).to receive(:download_image).and_return(true)
+      end
+
+      it 'should succeed' do
+        expect(ui).to receive(:info).with('Packaging domain...')
+        expect(ui).to receive(:info).with(/Downloading default_domain.img to .*\/box.img/)
+        expect(ui).to receive(:info).with('Image has backing image, copying image and rebasing ...')
+        expect(subject).to receive(:`).with(/qemu-img info .*\/box.img | grep 'backing file:' | cut -d ':' -f2/).and_return("some image")
+        expect(subject).to receive(:`).with(/qemu-img rebase -p -b "" .*\/box.img/)
+        expect(subject).to receive(:`).with(/virt-sysprep --no-logfile --operations .* -a .*\/box.img .*/)
+        expect(subject).to receive(:`).with(/virt-sparsify --in-place .*\/box.img/)
+        expect(subject).to receive(:`).with(/qemu-img info --output=json .*\/box.img/).and_return(
+          { 'virtual-size': 5*1024*1024*1024 }.to_json
+        )
+
+        expect(subject.call(env)).to be_nil
+        expect(File.exist?(File.join(temp_dir, 'metadata.json'))).to eq(true)
+        expect(File.exist?(File.join(temp_dir, 'Vagrantfile'))).to eq(true)
+      end
+    end
+  end
+
+  describe '#vagrantfile_content' do
+    context 'with defaults' do
+      it 'should output expected content' do
+        expect(subject.vagrantfile_content(env)).to eq(
+          <<-EOF.unindent
+          Vagrant.configure("2") do |config|
+            config.vm.provider :libvirt do |libvirt|
+              libvirt.driver = "kvm"
+            end
+
+          end
+          EOF
+        )
+      end
+    end
+
+    context 'with custom user vagrantfile' do
+      before do
+        env["package.vagrantfile"] = "_Vagrantfile"
+      end
+      it 'should output Vagrantfile containing reference' do
+        expect(subject.vagrantfile_content(env)).to eq(
+          <<-EOF.unindent
+          Vagrant.configure("2") do |config|
+            config.vm.provider :libvirt do |libvirt|
+              libvirt.driver = "kvm"
+            end
+
+            # Load include vagrant file if it exists after the auto-generated
+            # so it can override any of the settings
+            include_vagrantfile = File.expand_path("../include/_Vagrantfile", __FILE__)
+            load include_vagrantfile if File.exist?(include_vagrantfile)
+
+          end
+          EOF
+        )
+      end
+    end
+  end
+end

--- a/tests/package_complex_example/Vagrantfile
+++ b/tests/package_complex_example/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/debian10"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.driver = "qemu"
+    libvirt.cpus = 2
+    libvirt.memory = 2048
+  end
+
+  # note by default packaging the resulting machine will bundle the generated
+  # ssh key with the resulting box, to disable this behaviour need to
+  # uncomment the following line.
+  #config.ssh.insert_key = false
+end

--- a/tests/package_complex_example/Vagrantfile.testbox
+++ b/tests/package_complex_example/Vagrantfile.testbox
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "test-package-complex-example"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.driver = "qemu"
+    libvirt.cpus = 2
+    libvirt.memory = 2048
+  end
+end

--- a/tests/package_complex_example/scripts/sysprep.sh
+++ b/tests/package_complex_example/scripts/sysprep.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -eux
+
+# consider purging any packages you don't need here
+
+echo "autoremoving packages and cleaning apt data"
+apt-get -y autoremove;
+apt-get -y clean;
+
+# repeat what machine-ids does in sysprep as this script needs to run via customize
+# which has a bug resulting in the machine-ids being regenerated
+
+if [ -f /etc/machine-id ]
+then
+    truncate --size=0 /etc/machine-id
+fi
+
+if [ -f /var/lib/dbus/machine-id ]
+then
+    truncate --size=0 /run/machine-id
+fi
+
+echo "remove /var/cache"
+find /var/cache -type f -exec rm -rf {} \;
+
+echo "force a new random seed to be generated"
+rm -f /var/lib/systemd/random-seed
+
+# for debian based systems ensure host keys regenerated on boot
+if [ -e /usr/sbin/dpkg-reconfigure ]
+then
+    printf "@reboot root command bash -c 'export PATH=$PATH:/usr/sbin ; export DEBIAN_FRONTEND=noninteractive ; export DEBCONF_NONINTERACTIVE_SEEN=true ; /usr/sbin/dpkg-reconfigure openssh-server &>/dev/null ; /bin/systemctl restart ssh.service ; rm --force /etc/cron.d/keys'\n" > /etc/cron.d/keys
+fi

--- a/tests/package_simple/Vagrantfile.testbox
+++ b/tests/package_simple/Vagrantfile.testbox
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "infernix/tinycore"
+  config.vm.box = "test-package-simple-domain"
   config.ssh.shell = "/bin/sh"
   config.ssh.insert_key = false
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/tests/runtests.bats
+++ b/tests/runtests.bats
@@ -142,19 +142,61 @@ cleanup() {
   echo "${output}"
   echo "status = ${status}"
   [ "$status" -eq 0 ]
-  run ${VAGRANT_CMD} halt
-  echo "${output}"
-  echo "status = ${status}"
-  [ "$status" -eq 0 ]
+  rm -f package.box
   run ${VAGRANT_CMD} package
   echo "${output}"
   echo "status = ${status}"
   [ "$status" -eq 0 ]
-  run ${VAGRANT_CMD} box add package.box --name test-package-simple-domain
+  run ${VAGRANT_CMD} destroy -f
   echo "${output}"
   echo "status = ${status}"
   [ "$status" -eq 0 ]
-  run ${VAGRANT_CMD} box remove test-package-simple-domain
+  run ${VAGRANT_CMD} box add --force package.box --name test-package-simple-domain
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  VAGRANT_VAGRANTFILE=Vagrantfile.testbox run ${VAGRANT_CMD} up ${VAGRANT_OPT}
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  run ${VAGRANT_CMD} box remove --force test-package-simple-domain
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  rm -f package.box
+
+  cleanup
+}
+
+@test "package complex example" {
+  export VAGRANT_CWD=tests/package_complex_example
+  # this will allow the host keys to be removed, and part of the sysprep script
+  # adds a step to trigger the regeneration.
+  export VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS='defaults,-ssh-userdir,customize'
+  export VAGRANT_LIBVIRT_VIRT_SYSPREP_OPTIONS="--run $(pwd)/tests/package_complex_example/scripts/sysprep.sh"
+  cleanup
+  run ${VAGRANT_CMD} up ${VAGRANT_OPT}
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  rm -f package.box
+  run ${VAGRANT_CMD} package
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  run ${VAGRANT_CMD} destroy -f
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  run ${VAGRANT_CMD} box add --force package.box --name test-package-complex-example
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  VAGRANT_VAGRANTFILE=Vagrantfile.testbox run ${VAGRANT_CMD} up ${VAGRANT_OPT}
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  run ${VAGRANT_CMD} box remove --force test-package-complex-example
   echo "${output}"
   echo "status = ${status}"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Restructure action to remove custom handling around packaging of the
box and instead use more of the built-in provided actions instead.

Includes some packaging tests to cover both simple where the public
key is retained (can't modify the tinycore VM without more complex
provisioning steps), and a more complex one that utilizes a script
and supports triggering regenerating the hosts on subsequent boots.

The use of the upstream packaging helpers means that when the
default insecure ssh key has been replaced, the packaging process
will automatically include the generated key.

Fixes: #759
Fixes: #765
Fixes: #1013
Fixes: #994