### PR TITLE
Use qemu-img json output and compute virtual size #1308

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -266,7 +266,7 @@ module VagrantPlugins
           end
           env[:ui].info(" -- Storage pool:      #{@storage_pool_name}")
           @domain_volumes.each do |volume|
-            env[:ui].info(" -- Image(#{volume[:device]}):     #{volume[:path]}, #{volume[:virtual_size]}G")
+            env[:ui].info(" -- Image(#{volume[:device]}):     #{volume[:path]}, #{volume[:virtual_size].to_GB}G")
           end
 
           if not @disk_driver_opts.empty?

--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -39,7 +39,7 @@ module VagrantPlugins
             @backing_file = box_volume.path
 
             # Virtual size of image. Take value worked out by HandleBoxImage
-            @capacity = env[:box_volumes][index][:virtual_size] # G
+            @capacity = env[:box_volumes][index][:virtual_size].to_B # Byte
 
             # Create new volume from xml template. Fog currently doesn't support
             # volume snapshots directly.
@@ -47,7 +47,7 @@ module VagrantPlugins
               xml = Nokogiri::XML::Builder.new do |xml|
                 xml.volume do
                   xml.name(@name)
-                  xml.capacity(@capacity, unit: 'G')
+                  xml.capacity(@capacity, unit: 'B')
                   xml.target do
                     xml.format(type: 'qcow2')
                     xml.permissions do

--- a/lib/vagrant-libvirt/util/byte_number.rb
+++ b/lib/vagrant-libvirt/util/byte_number.rb
@@ -1,0 +1,71 @@
+class ByteNumber < Numeric
+    def initialize(int)
+        @int = int
+    end
+
+    def to_s
+        @int.to_s
+    end
+
+    def to_i
+        @int
+    end
+
+    def to_f
+        @int.to_f
+    end
+
+    def to_B
+        to_i
+    end
+
+    def to_KB
+        _compute_unit_to_n_kilo(1)
+    end
+
+    def to_MB
+        _compute_unit_to_n_kilo(2)
+    end
+
+    def to_GB
+        _compute_unit_to_n_kilo(3)
+    end
+
+    def coerce(other)
+        to_i.coerce(other)
+    end
+
+    def <=>(other)
+        to_i <=> other
+    end
+
+    def +(other)
+        to_i + other
+    end
+
+    def -(other)
+        to_i - other
+    end
+
+    def *(other)
+        to_i * other
+    end
+
+    def /(other)
+        to_i / other
+    end
+
+    def pow(n)
+        self.class.new(to_i ** n)
+    end
+
+    def self.from_GB(value)
+        self.new(value*(1024**3))
+    end
+
+    private
+    def _compute_unit_to_n_kilo(n=0)
+        (to_f/(1024 ** n)).ceil
+    end
+end
+  

--- a/spec/unit/action/create_domain_volume_spec.rb
+++ b/spec/unit/action/create_domain_volume_spec.rb
@@ -3,6 +3,8 @@ require 'support/sharedcontext'
 require 'support/libvirt_context'
 
 require 'vagrant-libvirt/action/destroy_domain'
+require 'vagrant-libvirt/util/byte_number'
+
 
 describe VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume do
   subject { described_class.new(app, env) }
@@ -38,7 +40,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume do
         env[:box_volumes] = [
           {
             :name=>"test_vagrant_box_image_1.1.1_0.img",
-            :virtual_size=>5
+            :virtual_size=>ByteNumber.new(5368709120)
           }
         ]
       end
@@ -65,15 +67,15 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume do
         env[:box_volumes] = [
           {
             :name=>"test_vagrant_box_image_1.1.1_0.img",
-            :virtual_size=>5
+            :virtual_size=>ByteNumber.new(5368709120)
           },
           {
             :name=>"test_vagrant_box_image_1.1.1_1.img",
-            :virtual_size=>10
+            :virtual_size=>ByteNumber.new(10737423360)
           },
           {
             :name=>"test_vagrant_box_image_1.1.1_2.img",
-            :virtual_size=>20
+            :virtual_size=>ByteNumber.new(21474836480)
           }
         ]
       end

--- a/spec/unit/action/create_domain_volume_spec/one_disk_in_storage.xml
+++ b/spec/unit/action/create_domain_volume_spec/one_disk_in_storage.xml
@@ -1,6 +1,6 @@
 <volume>
   <name>test.img</name>
-  <capacity unit="G">5</capacity>
+  <capacity unit="B">5368709120</capacity>
   <target>
     <format type="qcow2"></format>
     <permissions>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_0.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_0.xml
@@ -1,6 +1,6 @@
 <volume>
   <name>test.img</name>
-  <capacity unit="G">5</capacity>
+  <capacity unit="B">5368709120</capacity>
   <target>
     <format type="qcow2"></format>
     <permissions>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_1.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_1.xml
@@ -1,6 +1,6 @@
 <volume>
   <name>test_1.img</name>
-  <capacity unit="G">10</capacity>
+  <capacity unit="B">10737423360</capacity>
   <target>
     <format type="qcow2"></format>
     <permissions>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_2.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_2.xml
@@ -1,6 +1,6 @@
 <volume>
   <name>test_2.img</name>
-  <capacity unit="G">20</capacity>
+  <capacity unit="B">21474836480</capacity>
   <target>
     <format type="qcow2"></format>
     <permissions>

--- a/spec/unit/util/byte_number_spec.rb
+++ b/spec/unit/util/byte_number_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+require 'vagrant-libvirt/util/byte_number'
+
+
+describe ByteNumber do
+  describe '#ByteNumber to Gigrabyte' do
+    it 'should return bigger size' do
+      expect( ByteNumber.new("10737423360").to_GB).to eq(11)
+      expect( ByteNumber.new("737423360").to_GB).to eq(1)
+      expect( ByteNumber.new("110737423360").to_GB).to eq(104)
+    end
+  end
+
+  describe '#ByteNumber from Gigrabyte' do
+    it 'should convert' do
+      expect( ByteNumber.from_GB(5).to_i).to eq(5368709120)
+    end
+  end
+
+  describe '#ByteNumber pow' do
+    it 'should be work like interger' do
+      expect( ByteNumber.new(5).pow(5).to_i).to eq(5**5)
+    end
+  end
+end

--- a/tests/runtests.bats
+++ b/tests/runtests.bats
@@ -1,7 +1,7 @@
 SCRIPT_DIR="$( cd "$BATS_TEST_DIRNAME" &> /dev/null && pwd )"
 export PATH=$(dirname ${SCRIPT_DIR})/bin:${PATH}
 
-VAGRANT_CMD=vagrant
+VAGRANT_CMD="vagrant"
 VAGRANT_OPT="--provider=libvirt"
 
 TEMPDIR=


### PR DESCRIPTION
Hi,

this merge request fix the bug #1308 

I use the json output of `qemu-img info` for read virtual size of disk.
I create new `ByteNumber` for convert the virtual size to gygabyte, byte and megabyte.
Now, the unit of virtual size is byte and not gigabyte.