### PR TITLE
Disable removal of host keys by default

### DIFF
--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -50,7 +50,7 @@ module VagrantPlugins
           # remove hw association with interface
           # working for centos with lvs default disks
           options = ENV.fetch('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPTIONS', '')
-          operations = ENV.fetch('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS', 'defaults,-ssh-userdir,-customize')
+          operations = ENV.fetch('VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS', 'defaults,-ssh-userdir,-ssh-hostkeys,-customize')
           `virt-sysprep --no-logfile --operations #{operations} -a #{@tmp_img} #{options}`
           `virt-sparsify --in-place #{@tmp_img}`
           # add any user provided file


### PR DESCRIPTION
Testing has shown that most boxes do not have the hosts keys removed as
it is non trivial to get them to regenerate on subsequent bring up.
Additionally vagrant uses `StrictHostKeyChecking=no` to ignore the host
keys so relying on them to provide any kind of security or identity of a
VM is pointless.

In the few cases where it is possible to have keys regenerate it should
be managed by how the box is cleaned up, and otherwise forced by a
provision script on first boot of the VM.

A number of people have tried to fixed this previously and I failed to
understand then that they were correct. Have attributed co authorship of
this to all of the PRs authors that attempted to fix this over the
years.

While it is possible to have a script executed via sysprep modify the
boot of the machine to ensure the keys are regenerated on the next boot,
this should either be built-in to occur automatically, and there by
assume the responsibility for ensuring host keys are replaced for each
VM packaged by vagrant-libvirt, or should default to the same behaviour
that appears to be common for many debian based boxes and simply not
attempt to remove the host keys. If removal is useful, it may be
re-enabled as needed. See #851 for a script that can be used to have
openssh-server reconfigured to trigger regenerating the keys.

Co-Authored-By: Guillaume Penaud <gpenaud@xilopix.com>
Co-Authored-By: Zak B. Elep <zakame@zakame.net>
Related: #759
Related: #873
Related: #955
Related: #994
