### PR TITLE
Allow rspec to float on minor releases

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.version       = VagrantPlugins::ProviderLibvirt.get_version
 
-  s.add_development_dependency "rspec-core", "~> 3.5.0"
-  s.add_development_dependency "rspec-expectations", "~> 3.5.0"
-  s.add_development_dependency "rspec-mocks", "~> 3.5.0"
+  s.add_development_dependency "rspec-core", "~> 3.5"
+  s.add_development_dependency "rspec-expectations", "~> 3.5"
+  s.add_development_dependency "rspec-mocks", "~> 3.5"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "simplecov-lcov"
 


### PR DESCRIPTION
To ensure the tests can be run across multiple vagrant releases, must
allow newer rspec minor releases. As these are for development, it
should be alright to allow a wider range.
