### PR TITLE
Enable frozen string across project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in vagrant-libvirt.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #require 'rubygems'
 #require 'bundler/setup'
 require 'bundler/gem_tasks'

--- a/example_box/Vagrantfile
+++ b/example_box/Vagrantfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 

--- a/lib/vagrant-libvirt.rb
+++ b/lib/vagrant-libvirt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'vagrant/action/builder'
 require 'log4r'
 

--- a/lib/vagrant-libvirt/action/clean_machine_folder.rb
+++ b/lib/vagrant-libvirt/action/clean_machine_folder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'vagrant/util/network_ip'
 require 'vagrant/util/scoped_hash_override'
@@ -128,10 +130,10 @@ module VagrantPlugins
             end
 
             message = "Creating network interface eth#{@iface_number}"
-            message << " connected to network #{@network_name}."
+            message += " connected to network #{@network_name}."
             if @mac
               @mac = @mac.scan(/(\h{2})/).join(':')
-              message << " Using MAC address: #{@mac}"
+              message += " Using MAC address: #{@mac}"
             end
             @logger.info(message)
 

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'vagrant/util/network_ip'
 require 'vagrant/util/scoped_hash_override'
@@ -312,8 +314,7 @@ module VagrantPlugins
 
           if @options[:dhcp_enabled]
             # Find out DHCP addresses pool range.
-            network_address = "#{@interface_network[:network_address]}/"
-            network_address << (@interface_network[:netmask]).to_s
+            network_address = "#{@interface_network[:network_address]}/#{(@interface_network[:netmask]).to_s}"
             net = @interface_network[:network_address] ? IPAddr.new(network_address) : nil
 
             # First is address of network, second is gateway (by default).
@@ -345,10 +346,9 @@ module VagrantPlugins
 
           created_networks_file = env[:machine].data_dir + 'created_networks'
 
-          message = 'Saving information about created network '
-          message << "#{@interface_network[:name]}, "
-          message << "UUID=#{@interface_network[:libvirt_network].uuid} "
-          message << "to file #{created_networks_file}."
+          message = 'Saving information about created network ' \
+            "#{@interface_network[:name]}, UUID=#{@interface_network[:libvirt_network].uuid} " \
+            "to file #{created_networks_file}."
           @logger.info(message)
 
           File.open(created_networks_file, 'a') do |file|

--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/destroy_networks.rb
+++ b/lib/vagrant-libvirt/action/destroy_networks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'nokogiri'
 

--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action
@@ -104,7 +106,7 @@ module VagrantPlugins
             IdentitiesOnly=#{ssh_info[:keys_only] ? 'yes' : 'no'}
           ) + ssh_info[:private_key_path].map do |pk|
                 "IdentityFile='\"#{pk}\"'"
-              end).map { |s| s.prepend('-o ') }.join(' ')
+              end).map { |s| "-o #{s}" }.join(' ')
 
           options += " -o ProxyCommand=\"#{ssh_info[:proxy_command]}\"" if machine.provider_config.proxy_command
 
@@ -116,12 +118,12 @@ module VagrantPlugins
               env[:ui].info 'Requesting sudo for host port(s) <= 1024'
               r = system('sudo -v')
               if r
-                ssh_cmd << 'sudo ' # add sudo prefix
+                ssh_cmd += 'sudo ' # add sudo prefix
               end
             end
           end
 
-          ssh_cmd << "ssh -n #{options} #{params}"
+          ssh_cmd += "ssh -n #{options} #{params}"
 
           @logger.debug "Forwarding port with `#{ssh_cmd}`"
           log_file = ssh_forward_log_file(
@@ -180,10 +182,10 @@ module VagrantPlugins
               kill_cmd = ''
 
               if tag[:port] <= 1024
-                kill_cmd << 'sudo ' # add sudo prefix
+                kill_cmd += 'sudo ' # add sudo prefix
               end
 
-              kill_cmd << "kill #{tag[:pid]}"
+              kill_cmd += "kill #{tag[:pid]}"
               @@lock.synchronize do
                 system(kill_cmd)
               end

--- a/lib/vagrant-libvirt/action/halt_domain.rb
+++ b/lib/vagrant-libvirt/action/halt_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'open3'
 require 'json'
@@ -179,8 +181,7 @@ module VagrantPlugins
             raise Vagrant::Errors::BoxNotFound, name: env[:machine].box.name
           end
           box_image_size = File.size(box_image_file) # B
-          message = "Creating volume #{box_volume[:name]}"
-          message << " in storage pool #{config.storage_pool_name}."
+          message = "Creating volume #{box_volume[:name]} in storage pool #{config.storage_pool_name}."
           @logger.info(message)
           begin
             fog_volume = env[:machine].provider.driver.connection.volumes.create(

--- a/lib/vagrant-libvirt/action/handle_storage_pool.rb
+++ b/lib/vagrant-libvirt/action/handle_storage_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/is_created.rb
+++ b/lib/vagrant-libvirt/action/is_created.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/is_running.rb
+++ b/lib/vagrant-libvirt/action/is_running.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/is_suspended.rb
+++ b/lib/vagrant-libvirt/action/is_suspended.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/message_already_created.rb
+++ b/lib/vagrant-libvirt/action/message_already_created.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/message_not_created.rb
+++ b/lib/vagrant-libvirt/action/message_not_created.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/message_not_running.rb
+++ b/lib/vagrant-libvirt/action/message_not_running.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/message_not_suspended.rb
+++ b/lib/vagrant-libvirt/action/message_not_suspended.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/message_will_not_destroy.rb
+++ b/lib/vagrant-libvirt/action/message_will_not_destroy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'log4r'
 

--- a/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-libvirt/action/prepare_nfs_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 require 'socket'
 require 'timeout'

--- a/lib/vagrant-libvirt/action/prepare_nfs_valid_ids.rb
+++ b/lib/vagrant-libvirt/action/prepare_nfs_valid_ids.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/prune_nfs_exports.rb
+++ b/lib/vagrant-libvirt/action/prune_nfs_exports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'vagrant-libvirt/util/nfs'
 require 'yaml'
 

--- a/lib/vagrant-libvirt/action/read_mac_addresses.rb
+++ b/lib/vagrant-libvirt/action/read_mac_addresses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/remove_libvirt_image.rb
+++ b/lib/vagrant-libvirt/action/remove_libvirt_image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/remove_stale_volume.rb
+++ b/lib/vagrant-libvirt/action/remove_stale_volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 # require 'log4r/yamlconfigurator'
 

--- a/lib/vagrant-libvirt/action/resume_domain.rb
+++ b/lib/vagrant-libvirt/action/resume_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/set_boot_order.rb
+++ b/lib/vagrant-libvirt/action/set_boot_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'nokogiri'
 

--- a/lib/vagrant-libvirt/action/set_name_of_domain.rb
+++ b/lib/vagrant-libvirt/action/set_name_of_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 module VagrantPlugins
   module ProviderLibvirt
@@ -46,7 +48,7 @@ module VagrantPlugins
               env[:root_path].basename.to_s.dup.concat('_')
             elsif config.default_prefix.empty?
               # don't have any prefix, not even "_"
-              ''
+              String.new
             else
               config.default_prefix.to_s.dup
             end

--- a/lib/vagrant-libvirt/action/share_folders.rb
+++ b/lib/vagrant-libvirt/action/share_folders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 require 'log4r'

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'rexml/document'
 
@@ -165,7 +167,7 @@ module VagrantPlugins
 
               # clock timers - because timers can be added/removed, just rebuild and then compare
               if !config.clock_timers.empty? || clock.has_elements?
-                oldclock = ''
+                oldclock = String.new
                 formatter.write(REXML::XPath.first(xml_descr, '/domain/clock'), oldclock)
                 clock.delete_element('//timer')
                 config.clock_timers.each do |clock_timer|
@@ -175,7 +177,7 @@ module VagrantPlugins
                   end
                 end
 
-                newclock = ''
+                newclock = String.new
                 formatter.write(clock, newclock)
                 unless newclock.eql? oldclock
                   @logger.debug "clock timers config changed"
@@ -337,22 +339,22 @@ module VagrantPlugins
               if descr_changed
                 begin
                   libvirt_domain.undefine
-                  new_descr = ''
+                  new_descr = String.new
                   xml_descr.write new_descr
-                  server = env[:machine].provider.driver.connection.servers.create(xml: new_descr)
+                  env[:machine].provider.driver.connection.servers.create(xml: new_descr)
                 rescue Fog::Errors::Error => e
-                  server = env[:machine].provider.driver.connection.servers.create(xml: descr)
+                  env[:machine].provider.driver.connection.servers.create(xml: descr)
                   raise Errors::FogCreateServerError, error_message: e.message
                 end
               end
-            rescue => e
+            rescue Errors::VagrantLibvirtError => e
               env[:ui].error("Error when updating domain settings: #{e.message}")
             end
             # Autostart with host if enabled in Vagrantfile
             libvirt_domain.autostart = config.autostart
             # Actually start the domain
             domain.start
-          rescue => e
+          rescue Fog::Errors::Error, Errors::VagrantLibvirtError => e
             raise Errors::FogError, message: e.message
           end
 

--- a/lib/vagrant-libvirt/action/suspend_domain.rb
+++ b/lib/vagrant-libvirt/action/suspend_domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/action/wait_till_up.rb
+++ b/lib/vagrant-libvirt/action/wait_till_up.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'vagrant-libvirt/errors'
 require 'vagrant-libvirt/util/timer'

--- a/lib/vagrant-libvirt/cap/mount_9p.rb
+++ b/lib/vagrant-libvirt/cap/mount_9p.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/md5'
 require 'vagrant/util/retryable'
 

--- a/lib/vagrant-libvirt/cap/mount_virtiofs.rb
+++ b/lib/vagrant-libvirt/cap/mount_virtiofs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/md5'
 require 'vagrant/util/retryable'
 

--- a/lib/vagrant-libvirt/cap/nic_mac_addresses.rb
+++ b/lib/vagrant-libvirt/cap/nic_mac_addresses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Cap

--- a/lib/vagrant-libvirt/cap/public_address.rb
+++ b/lib/vagrant-libvirt/cap/public_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Cap

--- a/lib/vagrant-libvirt/cap/synced_folder_9p.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_9p.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'ostruct'
 require 'nokogiri'

--- a/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'log4r'
 require 'ostruct'
 require 'nokogiri'

--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fog/libvirt'
 require 'libvirt'
 require 'log4r'

--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'vagrant'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'vagrant'
 rescue LoadError

--- a/lib/vagrant-libvirt/provider.rb
+++ b/lib/vagrant-libvirt/provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'vagrant'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/util.rb
+++ b/lib/vagrant-libvirt/util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Util

--- a/lib/vagrant-libvirt/util/collection.rb
+++ b/lib/vagrant-libvirt/util/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Util

--- a/lib/vagrant-libvirt/util/erb_template.rb
+++ b/lib/vagrant-libvirt/util/erb_template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Util

--- a/lib/vagrant-libvirt/util/error_codes.rb
+++ b/lib/vagrant-libvirt/util/error_codes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Ripped from http://libvirt.org/html/libvirt-virterror.html#virErrorNumber.
 module VagrantPlugins
   module ProviderLibvirt

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ipaddr'
 require 'nokogiri'
 require 'vagrant/util/network_ip'

--- a/lib/vagrant-libvirt/util/nfs.rb
+++ b/lib/vagrant-libvirt/util/nfs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Util

--- a/lib/vagrant-libvirt/util/storage_util.rb
+++ b/lib/vagrant-libvirt/util/storage_util.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module VagrantPlugins
   module ProviderLibvirt

--- a/lib/vagrant-libvirt/util/timer.rb
+++ b/lib/vagrant-libvirt/util/timer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VagrantPlugins
   module ProviderLibvirt
     module Util

--- a/lib/vagrant-libvirt/util/ui.rb
+++ b/lib/vagrant-libvirt/util/ui.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module VagrantPlugins
   module ProviderLibvirt

--- a/lib/vagrant-libvirt/version.rb
+++ b/lib/vagrant-libvirt/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 require 'tmpdir'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 require 'simplecov-lcov'
 

--- a/spec/support/binding_proc.rb
+++ b/spec/support/binding_proc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # A simple extension of the Proc class that supports setting a custom binding
 # and evaluates everything in the Proc using the new binding.

--- a/spec/support/environment_helper.rb
+++ b/spec/support/environment_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 require 'pathname'
 

--- a/spec/support/libvirt_context.rb
+++ b/spec/support/libvirt_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fog/libvirt'
 
 shared_context 'libvirt' do

--- a/spec/support/matchers/have_file_content.rb
+++ b/spec/support/matchers/have_file_content.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec/expectations/version"
 #
 # Taken from https://github.com/cucumber/aruba/blob/main/lib/aruba/matchers/file/have_file_content.rb

--- a/spec/support/sharedcontext.rb
+++ b/spec/support/sharedcontext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 shared_context 'unit' do

--- a/spec/support/temporary_dir.rb
+++ b/spec/support/temporary_dir.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_context 'temporary_dir' do
   around do |example|
     Dir.mktmpdir("rspec-") do |dir|

--- a/spec/unit/action/clean_machine_folder_spec.rb
+++ b/spec/unit/action/clean_machine_folder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/sharedcontext'
 

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/sharedcontext'
 require 'support/libvirt_context'

--- a/spec/unit/action/create_domain_volume_spec.rb
+++ b/spec/unit/action/create_domain_volume_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/sharedcontext'
 require 'support/libvirt_context'

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/sharedcontext'
 require 'support/libvirt_context'

--- a/spec/unit/action/forward_ports_spec.rb
+++ b/spec/unit/action/forward_ports_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/sharedcontext'
 require 'support/libvirt_context'

--- a/spec/unit/action/halt_domain_spec.rb
+++ b/spec/unit/action/halt_domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/sharedcontext'
 require 'support/libvirt_context'

--- a/spec/unit/action/handle_box_image_spec.rb
+++ b/spec/unit/action/handle_box_image_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'json'
 require 'support/sharedcontext'
@@ -77,7 +79,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
           ]
         }
         allow(env[:machine]).to receive_message_chain("box.directory.join") do |arg|
-          '/test/'.concat(arg.to_s)
+          '/test/' + arg.to_s
         end
       end
 
@@ -197,7 +199,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
           ],
         ]}
         allow(env[:machine]).to receive_message_chain("box.directory.join") do |arg|
-          '/test/'.concat(arg.to_s)
+          '/test/' + arg.to_s
         end
         allow(status).to receive(:success?).and_return(true)
         allow(Open3).to receive(:capture3).with('qemu-img', 'info', '--output=json', '/test/box.img').and_return([
@@ -334,7 +336,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
           ]
         }
         allow(env[:machine]).to receive_message_chain("box.directory.join") do |arg|
-          '/test/'.concat(arg.to_s)
+          '/test/' + arg.to_s
         end
       end
 
@@ -354,7 +356,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
         allow(env[:machine]).to receive_message_chain("box.version") { '1.1.1' }
         allow(env[:machine]).to receive_message_chain("box.metadata") { box_metadata }
         allow(env[:machine]).to receive_message_chain("box.directory.join") do |arg|
-          '/test/'.concat(arg.to_s)
+          '/test/' + arg.to_s
         end
         allow(status).to receive(:success?).and_return(true)
         allow(Open3).to receive(:capture3).with('qemu-img', 'info', "--output=json", '/test/box.img').and_return([

--- a/spec/unit/action/package_domain_spec.rb
+++ b/spec/unit/action/package_domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/sharedcontext'
 

--- a/spec/unit/action/set_name_of_domain_spec.rb
+++ b/spec/unit/action/set_name_of_domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain do

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'support/sharedcontext'
 require 'support/libvirt_context'

--- a/spec/unit/action/wait_till_up_spec.rb
+++ b/spec/unit/action/wait_till_up_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'vagrant-libvirt/action/wait_till_up'
 require 'vagrant-libvirt/errors'
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'support/binding_proc'
 
 require 'spec_helper'

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'support/sharedcontext'
 
 require 'vagrant-libvirt/config'

--- a/spec/unit/util/byte_number_spec.rb
+++ b/spec/unit/util/byte_number_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'vagrant-libvirt/util/byte_number'

--- a/tests/cpus/Vagrantfile
+++ b/tests/cpus/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore"

--- a/tests/default_prefix/Vagrantfile
+++ b/tests/default_prefix/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore"

--- a/tests/memory/Vagrantfile
+++ b/tests/memory/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore"

--- a/tests/package_complex_example/Vagrantfile
+++ b/tests/package_complex_example/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/debian10"

--- a/tests/package_simple/Vagrantfile
+++ b/tests/package_simple/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore"

--- a/tests/private_network/Vagrantfile
+++ b/tests/private_network/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   # private network doesnt work with tinycore, use

--- a/tests/second_disk/Vagrantfile
+++ b/tests/second_disk/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore"

--- a/tests/simple/Vagrantfile
+++ b/tests/simple/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore"

--- a/tests/simple_provision_shell/Vagrantfile
+++ b/tests/simple_provision_shell/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore"

--- a/tests/two_disks/Vagrantfile
+++ b/tests/two_disks/Vagrantfile
@@ -1,5 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+#
+# frozen_string_literal: true
 
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore-two-disks"

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 require File.expand_path('../lib/vagrant-libvirt/version', __FILE__)
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Turn on frozen string support in all files by using a comment to avoid
enabling across dependencies where it may not work.

Fixes: #1177
