### PR TITLE
Fix destroying/undefining domains with NVRAM

### DIFF
--- a/lib/vagrant-libvirt/util.rb
+++ b/lib/vagrant-libvirt/util.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       autoload :NetworkUtil, 'vagrant-libvirt/util/network_util'
       autoload :StorageUtil, 'vagrant-libvirt/util/storage_util'
       autoload :ErrorCodes, 'vagrant-libvirt/util/error_codes'
+      autoload :DomainFlags, 'vagrant-libvirt/util/domain_flags'
       autoload :Ui, 'vagrant-libvirt/util/ui'
     end
   end

--- a/lib/vagrant-libvirt/util/domain_flags.rb
+++ b/lib/vagrant-libvirt/util/domain_flags.rb
@@ -1,0 +1,15 @@
+ # Ripped from https://libvirt.org/html/libvirt-libvirt-domain.html#types
+module VagrantPlugins
+  module ProviderLibvirt
+    module Util
+      module DomainFlags
+        # virDomainUndefineFlagsValues
+        VIR_DOMAIN_UNDEFINE_MANAGED_SAVE = 1 # Also remove any managed save
+        VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA = 2 # If last use of domain, then also remove any snapshot metadata
+        VIR_DOMAIN_UNDEFINE_NVRAM = 4 # Also remove any nvram file
+        VIR_DOMAIN_UNDEFINE_KEEP_NVRAM = 8 # Keep nvram file
+        VIR_DOMAIN_UNDEFINE_CHECKPOINTS_METADATA = 16 # If last use of domain, then also remove any checkpoint metadata Future undefine control flags should come here.
+      end
+    end
+  end
+end

--- a/spec/unit/action/start_domain_spec/existing_added_nvram.xml
+++ b/spec/unit/action/start_domain_spec/existing_added_nvram.xml
@@ -1,0 +1,62 @@
+<domain type='qemu'>
+  <name>vagrant-libvirt_default</name>
+  <uuid>881a931b-0110-4d10-81aa-47a1a19f5726</uuid>
+  <description>Source: /home/test/vagrant-libvirt/Vagrantfile</description>
+  <memory unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <boot dev='hd'/>
+  <nvram>/path/to/nvram/file</nvram></os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu check='partial' mode='host-model'/>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk device='disk' type='file'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/vagrant-libvirt_default.img'/>
+      <target bus='virtio' dev='vda'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x03' type='pci'/>
+    </disk>
+    <controller index='0' model='piix3-uhci' type='usb'>
+      <address bus='0x00' domain='0x0000' function='0x2' slot='0x01' type='pci'/>
+    </controller>
+    <controller index='0' model='pci-root' type='pci'/>
+    <interface type='network'>
+      <mac address='52:54:00:7d:14:0e'/>
+      <source network='vagrant-libvirt'/>
+      <model type='virtio'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x05' type='pci'/>
+    </interface>
+    <serial type='pty'>
+      <target port='0' type='isa-serial'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target port='0' type='serial'/>
+    </console>
+    <input bus='ps2' type='mouse'/>
+    <input bus='ps2' type='keyboard'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'>
+      <listen address='127.0.0.1' type='address'/>
+    </graphics>
+    <audio id='1' type='none'/>
+    <video>
+      <model heads='1' primary='yes' type='cirrus' vram='16384'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x02' type='pci'/>
+    </video>
+    <memballoon model='virtio'>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x04' type='pci'/>
+    </memballoon>
+  </devices>
+</domain>

--- a/spec/unit/action/start_domain_spec/nvram_domain.xml
+++ b/spec/unit/action/start_domain_spec/nvram_domain.xml
@@ -1,0 +1,63 @@
+<domain type='qemu'>
+  <name>vagrant-libvirt_default</name>
+  <uuid>881a931b-0110-4d10-81aa-47a1a19f5726</uuid>
+  <description>Source: /home/test/vagrant-libvirt/Vagrantfile</description>
+  <memory unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <boot dev='hd'/>
+    <nvram>/path/to/nvram/file</nvram>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu mode='host-model' check='partial'/>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/vagrant-libvirt_default.img'/>
+      <target dev='vda' bus='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </disk>
+    <controller type='usb' index='0' model='piix3-uhci'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <interface type='network'>
+      <mac address='52:54:00:7d:14:0e'/>
+      <source network='vagrant-libvirt'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'>
+      <listen type='address' address='127.0.0.1'/>
+    </graphics>
+    <audio id='1' type='none'/>
+    <video>
+      <model type='cirrus' vram='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </memballoon>
+  </devices>
+</domain>

--- a/spec/unit/action/start_domain_spec/nvram_domain_other_setting.xml
+++ b/spec/unit/action/start_domain_spec/nvram_domain_other_setting.xml
@@ -1,0 +1,63 @@
+<domain type='qemu'>
+  <name>vagrant-libvirt_default</name>
+  <uuid>881a931b-0110-4d10-81aa-47a1a19f5726</uuid>
+  <description>Source: /home/test/vagrant-libvirt/Vagrantfile</description>
+  <memory unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>4</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <boot dev='hd'/>
+    <nvram>/path/to/nvram/file</nvram>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu check='partial' mode='host-model'/>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk device='disk' type='file'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/vagrant-libvirt_default.img'/>
+      <target bus='virtio' dev='vda'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x03' type='pci'/>
+    </disk>
+    <controller index='0' model='piix3-uhci' type='usb'>
+      <address bus='0x00' domain='0x0000' function='0x2' slot='0x01' type='pci'/>
+    </controller>
+    <controller index='0' model='pci-root' type='pci'/>
+    <interface type='network'>
+      <mac address='52:54:00:7d:14:0e'/>
+      <source network='vagrant-libvirt'/>
+      <model type='virtio'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x05' type='pci'/>
+    </interface>
+    <serial type='pty'>
+      <target port='0' type='isa-serial'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target port='0' type='serial'/>
+    </console>
+    <input bus='ps2' type='mouse'/>
+    <input bus='ps2' type='keyboard'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'>
+      <listen address='127.0.0.1' type='address'/>
+    </graphics>
+    <audio id='1' type='none'/>
+    <video>
+      <model heads='1' primary='yes' type='cirrus' vram='16384'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x02' type='pci'/>
+    </video>
+    <memballoon model='virtio'>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x04' type='pci'/>
+    </memballoon>
+  </devices>
+</domain>

--- a/spec/unit/action/start_domain_spec/nvram_domain_removed.xml
+++ b/spec/unit/action/start_domain_spec/nvram_domain_removed.xml
@@ -1,0 +1,63 @@
+<domain type='qemu'>
+  <name>vagrant-libvirt_default</name>
+  <uuid>881a931b-0110-4d10-81aa-47a1a19f5726</uuid>
+  <description>Source: /home/test/vagrant-libvirt/Vagrantfile</description>
+  <memory unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <boot dev='hd'/>
+    
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu check='partial' mode='host-model'/>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk device='disk' type='file'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/vagrant-libvirt_default.img'/>
+      <target bus='virtio' dev='vda'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x03' type='pci'/>
+    </disk>
+    <controller index='0' model='piix3-uhci' type='usb'>
+      <address bus='0x00' domain='0x0000' function='0x2' slot='0x01' type='pci'/>
+    </controller>
+    <controller index='0' model='pci-root' type='pci'/>
+    <interface type='network'>
+      <mac address='52:54:00:7d:14:0e'/>
+      <source network='vagrant-libvirt'/>
+      <model type='virtio'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x05' type='pci'/>
+    </interface>
+    <serial type='pty'>
+      <target port='0' type='isa-serial'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target port='0' type='serial'/>
+    </console>
+    <input bus='ps2' type='mouse'/>
+    <input bus='ps2' type='keyboard'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'>
+      <listen address='127.0.0.1' type='address'/>
+    </graphics>
+    <audio id='1' type='none'/>
+    <video>
+      <model heads='1' primary='yes' type='cirrus' vram='16384'/>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x02' type='pci'/>
+    </video>
+    <memballoon model='virtio'>
+      <address bus='0x00' domain='0x0000' function='0x0' slot='0x04' type='pci'/>
+    </memballoon>
+  </devices>
+</domain>


### PR DESCRIPTION
Fixes #1027.

This patch depends on upstream PR [fog-libvirt#102](https://github.com/fog/fog-libvirt/pull/102). So if and when that PR becomes part of a release, this PR would need to bump the fog-libvirt dependency to that new version. Would that be acceptable to merge? Otherwise I won't bother and just leave this patch laying around for anyone else who needs it.

Both patches are currently applied in our testing environment and so far everything is working as intended.