### PR TITLE
Unrestrict rspec-* version to >= 3.5 to sync with vagrant

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.version       = VagrantPlugins::ProviderLibvirt.get_version
 
-  s.add_development_dependency "rspec-core", "~> 3.5"
-  s.add_development_dependency "rspec-expectations", "~> 3.5"
-  s.add_development_dependency "rspec-mocks", "~> 3.5"
+  s.add_development_dependency "rspec-core", ">= 3.5"
+  s.add_development_dependency "rspec-expectations", ">= 3.5"
+  s.add_development_dependency "rspec-mocks", ">= 3.5"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "simplecov-lcov"
 


### PR DESCRIPTION
Vagrant recently bumped its minimum rspec version to 3.10. This brings the version in sync with vagrant so that we do not require two different versions of the same gem.