### PR TITLE
fix(action): fix typo in change domain disk_bus

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -58,7 +58,7 @@ module VagrantPlugins
               # disk_bus
               REXML::XPath.each(xml_descr, '/domain/devices/disk[@device="disk"]/target[@dev="vda"]') do |disk_target|
                 next unless disk_target.attributes['bus'] != config.disk_bus
-                @logger.debug "domain disk bus updated from '#{disk_target.attributes['bus']}' to '#{bus}'"
+                @logger.debug "domain disk bus updated from '#{disk_target.attributes['bus']}' to '#{config.disk_bus}'"
                 descr_changed = true
                 disk_target.attributes['bus'] = config.disk_bus
                 disk_target.parent.delete_element("#{disk_target.parent.xpath}/address")


### PR DESCRIPTION
Steps to reproduce:
* Create domain with default options
* Change domain `disk_bus` to `scsi`
* Reload domain with `vagrant reload`

Expected results:
* Domain changed its `disk_bus` to `scsi`:
  * updated `bus` attribute in XML to `scsi` and controller model to `virtio-scsi`
  * domain successfully booted with `/dev/sda`

Real results:
* Error on updating domain:
```
==> compute01: Halting domain...
==> compute01: Starting domain.
==> compute01: Error when updating domain settings: undefined local variable or method `bus' for #<VagrantPlugins::ProviderLibvirt::Action::StartDomain:0x000000000370cc88>
==> compute01: Waiting for domain to get an IP address...
==> compute01: Waiting for machine to boot. This may take a few minutes...
```