### PR TITLE
Fixed handling of nil volumes

### DIFF
--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -32,6 +32,8 @@ module VagrantPlugins
           )
           domain = env[:machine].provider.driver.connection.servers.get(env[:machine].id.to_s)
           root_disk = domain.volumes.select do |x|
+            !x.nil?
+          end.select do |x|
             x.name == libvirt_domain.name + '.img'
           end.first
           raise Errors::NoDomainVolume if root_disk.nil?

--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -32,9 +32,7 @@ module VagrantPlugins
           )
           domain = env[:machine].provider.driver.connection.servers.get(env[:machine].id.to_s)
           root_disk = domain.volumes.select do |x|
-            !x.nil?
-          end.select do |x|
-            x.name == libvirt_domain.name + '.img'
+            !x.nil? && x.name == libvirt_domain.name + '.img'
           end.first
           raise Errors::NoDomainVolume if root_disk.nil?
 


### PR DESCRIPTION
With up to date vagrant-libvirt from git, running `vagrant package default` results with this error, on my setup:

```
==> default: Packaging domain...
Traceback (most recent call last):
        24: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/bin/vagrant:231:in `<main>'
        23: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/environment.rb:290:in `cli'
        22: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/cli.rb:67:in `execute'
        21: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/plugins/commands/package/command.rb:49:in `execute'
        20: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/plugins/commands/package/command.rb:81:in `package_target'
        19: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/plugin/v2/command.rb:232:in `with_target_vms'
        18: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/plugin/v2/command.rb:232:in `each'
        17: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/plugin/v2/command.rb:243:in `block in with_target_vms'
        16: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/plugins/commands/package/command.rb:83:in `block in package_target'
        15: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/plugins/commands/package/command.rb:94:in `package_vm'
        14: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/machine.rb:201:in `action'
        13: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/machine.rb:201:in `call'
        12: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/environment.rb:614:in `lock'
        11: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/machine.rb:215:in `block in action'
        10: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/machine.rb:246:in `action_raw'
         9: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/action/runner.rb:89:in `run'
         8: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/util/busy.rb:19:in `busy'
         7: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/action/runner.rb:89:in `block in run'
         6: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/action/builder.rb:149:in `call'
         5: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/action/warden.rb:48:in `call'
         4: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
         3: from /opt/vagrant/embedded/gems/2.2.18/gems/vagrant-2.2.18/lib/vagrant/action/warden.rb:48:in `call'
         2: from /home/odeda/Documents/Projects/vgtest/.vagrant.d/gems/2.7.4/gems/vagrant-libvirt-0.5.3/lib/vagrant-libvirt/action/package_domain.rb:25:in `call'
         1: from /home/odeda/Documents/Projects/vgtest/.vagrant.d/gems/2.7.4/gems/vagrant-libvirt-0.5.3/lib/vagrant-libvirt/action/package_domain.rb:25:in `select'
/home/odeda/Documents/Projects/vgtest/.vagrant.d/gems/2.7.4/gems/vagrant-libvirt-0.5.3/lib/vagrant-libvirt/action/package_domain.rb:26:in `block in call': undefined method `name' for nil:NilClass (NoMethodError)
```

Please see attached domain XML below:
[virsh.txt](https://github.com/vagrant-libvirt/vagrant-libvirt/files/7006407/virsh.txt)
