### PR TITLE
Retrieve IP Address of management interface using qemu-guest-agent commands #1341

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,23 @@ DHCP server. dnsmasq writes lease information in the `/var/lib/libvirt/dnsmasq`
 directory. Vagrant-libvirt looks for the MAC address in this file and extracts
 the corresponding IP address.
 
+It is also possible to use the Qemu Agent to extract the management interface
+configuration from the booted virtual machine. This is helpful in libvirt
+environments where no local dnsmasq is used for automatic address assigment,
+but external dhcp services via bridged libvirt networks.
+
+Prerequisite is to enable the qemu agent channel via ([Libvirt communication
+channels](#libvirt-communication-channels)) and the virtual machine image must
+have the agent pre-installed before deploy. The agent will start automatically
+if it detects an attached channel during boot.
+
+* `qemu_use_agent` - false by default, if set to true, attempt to extract configured
+  ip address via qemu agent.
+
+To use the management network interface with an external dhcp service you need
+to setup a bridged host network manually and define it via
+`management_network_name` in your Vagrantfile.
+
 ## Additional Disks
 
 You can create and attach additional disks to a VM via `libvirt.storage :file`.

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -162,7 +162,7 @@ module VagrantPlugins
             if @interface_network[:created]
               # Just check for mismatch error here - if name and ip from
               # config match together.
-              if @options[:network_name] != @interface_network[:name]
+              if @options[:network_name] != @interface_network[:name] and @qemu_use_agent = false
                 raise Errors::NetworkNameAndAddressMismatch,
                       ip_address:   @options[:ip],
                       network_name: @options[:network_name]

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
 
         def configured_networks(env, logger)
           qemu_use_session = env[:machine].provider_config.qemu_use_session
+          qemu_use_agent = env[:machine].provider_config.qemu_use_agent
           management_network_device = env[:machine].provider_config.management_network_device
           management_network_name = env[:machine].provider_config.management_network_name
           management_network_address = env[:machine].provider_config.management_network_address

--- a/tests/qemu_agent/Vagrantfile
+++ b/tests/qemu_agent/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# frozen_string_literal: true
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/debian10"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
+    libvirt.qemu_use_agent = true
+  end
+end

--- a/tests/runtests.bats
+++ b/tests/runtests.bats
@@ -119,6 +119,17 @@ cleanup() {
   cleanup
 }
 
+@test "bring up and use qemu agent for connectivity" {
+  export VAGRANT_CWD=tests/qemu_agent
+  cleanup
+  run ${VAGRANT_CMD} up ${VAGRANT_OPT}
+  echo "${output}"
+  echo "status = ${status}"
+  [ "$status" -eq 0 ]
+  echo "${output}"
+  cleanup
+}
+
 @test "ip is reachable with private network" {
   export VAGRANT_CWD=tests/private_network
   cleanup


### PR DESCRIPTION
See issue #1341 for detailed explanation.

Following setup:

 * host system with debian 11 running, with bridge for network interface configured. Network interface is connected to home router wit dhcp enabled.

```
  brctl addbr br0
  brctl addif br0 enp0s31f6 
  ifconfig br0 up
  ifconfig enp0s31f6 up
```

As a test, dhclient -vv br0 assigns ip address via dhcp from home network router.

Now create virtual machine with following definition:

```
Vagrant.configure("2") do |config|    
 # config.vagrant.plugins = "vagrant-libvirt"     
  config.vm.box = "generic/debian11"     
  config.vm.provider "libvirt" do |libvirt|    
    libvirt.qemu_use_agent = true
    libvirt.channel :type => 'unix', :target_name => 'org.qemu.guest_agent.0', :target_type => 'virtio'
    # attach management network to existing bridge
    libvirt.management_network_device = "br0"
  end
end
```

vagrant up:

```
bundle exec vagrant up --debug
[..]
DEBUG driver: Unable to receive IP via qemu agent: [Call to virDomainQemuAgentCommand failed: Guest agent is not responding: QEMU guest agent is not connected]
 INFO driver: Get IP via qemu agent
DEBUG driver: Unable to receive IP via qemu agent: [Call to virDomainQemuAgentCommand failed: Guest agent is not responding: QEMU guest agent is not connected]
 INFO driver: Get IP via qemu agent
DEBUG driver: Got Response from qemu agent
DEBUG driver: {"return":[{"name":"lo","ip-addresses":[{"ip-address-type":"ipv4","ip-address":"127.0.0.1","prefix":8}],"statistics":{"tx-packets":160,"tx-errs":0,"rx-bytes":13920,"rx-dropped":0,"rx-packets":160,"rx-errs":0,"tx-bytes":13920,"tx-dropped":0},"hardware-address":"00:00:00:00:00:00"},{"name":"eth0","hardware-address":"52:54:00:fd:ab:49"}]}
[..]
DEBUG driver: Got Response from qemu agent
DEBUG driver: {"return":[{"name":"lo","ip-addresses":[{"ip-address-type":"ipv4","ip-address":"127.0.0.1","prefix":8}],"statistics":{"tx-packets":160,"tx-errs":0,"rx-bytes":13920,"rx-dropped":0,"rx-packets":160,"rx-errs":0,"tx-bytes":13920,"tx-dropped":0},"hardware-address":"00:00:00:00:00:00"},{"name":"eth0","ip-addresses":[{"ip-address-type":"ipv4","ip-address":"192.168.178.167","prefix":24}],"statistics":{"tx-packets":4,"tx-errs":0,"rx-bytes":5268,"rx-dropped":15,"rx-packets":46,"rx-errs":0,"tx-bytes":832,"tx-dropped":0},"hardware-address":"52:54:00:fd:ab:49"}]}
DEBUG driver: Found mathing interface: [eth0]
DEBUG driver: Return IP: [192.168.178.167]
[..]
```
spinned up virtual machine was assigned ip 192.168.178.167 on management interface from external router and is fully provisioned and reachable:

```
bundle exec vagrant ssh -c "ip addr"

2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 52:54:00:fd:ab:49 brd ff:ff:ff:ff:ff:ff
    altname enp0s6
    altname ens6
    inet 192.168.178.167/24 brd 192.168.178.255 scope global dynamic eth0
       valid_lft 863870sec preferred_lft 863870sec
Connection to 192.168.178.167 closed.

```
