### PR TITLE
Support dev setting vagrant-spec version from env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,10 @@ group :development do
     vagrant_gem_version = Gem::Version.new('2.2.8')
   end
 
-  if vagrant_gem_version <= Gem::Version.new('2.2.7')
+  vagrant_spec_verison = ENV['VAGRANT_SPEC_VERSION']
+  if !vagrant_spec_verison.nil? && !vagrant_spec_verison.empty?
+    gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :ref => vagrant_spec_verison
+  elsif vagrant_gem_version <= Gem::Version.new('2.2.7')
     gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :ref => '161128f2216cee8edb7bcd30da18bd4dea86f98a'
   else
     gem 'vagrant-spec', :github => 'hashicorp/vagrant-spec', :branch => "main"


### PR DESCRIPTION
Allow control of the reference or version of vagrant-spec to be used
from the dev environment where it is necessary to test with older
versions of the plugin which may depend on different versions of
dependencies compared to vagrant-spec.

In this case the latest vagrant-spec has rolled forward the rspec core
version to 3.10, which works with the latest vagrant-libvirt. However
previous versions of vagrant-libvirt require 3.5, which was the previous
minor version pinned.

Adding the option of VAGRANT_SPEC_VERSION that can be set as an
environment variable should help control this explicitly when needed in
the future the same as how VAGRANT_VERSION is handled.
