### PR TITLE
Output XML elements to debug logs

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -400,9 +400,14 @@ module VagrantPlugins
           # Create Libvirt domain.
           # Is there a way to tell fog to create new domain with already
           # existing volume? Use domain creation from template..
+          xml = to_xml('domain')
+          @logger.debug {
+            "Creating Domain with XML:\n#{xml}"
+          }
+
           begin
             server = env[:machine].provider.driver.connection.servers.create(
-              xml: to_xml('domain')
+              xml: xml
             )
           rescue Fog::Errors::Error => e
             raise Errors::FogCreateServerError, error_message: e.message

--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -78,6 +78,9 @@ module VagrantPlugins
               else
                   pool_name = config.storage_pool_name
               end
+              @logger.debug {
+                "Creating Volume with XML:\n#{xml}"
+              }
               @logger.debug "Using pool #{pool_name} for base box snapshot"
               domain_volume = env[:machine].provider.driver.connection.volumes.create(
                 xml: xml,

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -159,6 +159,9 @@ module VagrantPlugins
                     else
                       to_xml(template_name)
                     end
+              @logger.debug {
+                "Attaching Network Device with XML:\n#{xml}"
+              }
               domain.attach_device(xml)
             rescue => e
               raise Errors::AttachDeviceError,

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -337,8 +337,12 @@ module VagrantPlugins
           @network_domain_name = @options[:domain_name]
 
           begin
+            xml = to_xml('private_network')
+            @logger.debug {
+              "Creating private network with XML:\n#{xml}"
+            }
             @interface_network[:libvirt_network] = \
-              @libvirt_client.define_network_xml(to_xml('private_network'))
+              @libvirt_client.define_network_xml(xml)
             @logger.debug 'created network'
           rescue => e
             raise Errors::CreateNetworkError, error_message: e.message

--- a/lib/vagrant-libvirt/action/handle_storage_pool.rb
+++ b/lib/vagrant-libvirt/action/handle_storage_pool.rb
@@ -44,8 +44,12 @@ module VagrantPlugins
               @storage_pool_path = storage_pool_path(env)
               @storage_pool_uid = storage_uid(env)
               @storage_pool_gid = storage_gid(env)
+              xml = to_xml('default_storage_pool')
+              @logger.debug {
+                "Creating Storage Pool with XML:\n#{xml}"
+              }
               libvirt_pool = env[:machine].provider.driver.connection.client.define_storage_pool_xml(
-                to_xml('default_storage_pool')
+                xml
               )
               libvirt_pool.build
               libvirt_pool.create

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -352,6 +352,9 @@ module VagrantPlugins
             end
             # Autostart with host if enabled in Vagrantfile
             libvirt_domain.autostart = config.autostart
+            @logger.debug {
+              "Starting Domain with XML:\n#{libvirt_domain.xml_desc}"
+            }
             # Actually start the domain
             domain.start
           rescue Fog::Errors::Error, Errors::VagrantLibvirtError => e

--- a/lib/vagrant-libvirt/cap/synced_folder_9p.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_9p.rb
@@ -47,7 +47,6 @@ module VagrantPlugins
 
             machine.ui.info "================\nMachine id: #{machine.id}\nShould be mounting folders\n #{id}, opts: #{folder_opts}"
 
-            #xml = to_xml('filesystem', folder_opts)
             xml = Nokogiri::XML::Builder.new do |xml|
               xml.filesystem(type: 'mount', accessmode: folder_opts[:accessmode]) do
                 xml.driver(type: 'path', wrpolicy: 'immediate')
@@ -60,7 +59,9 @@ module VagrantPlugins
                          Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS |
                          Nokogiri::XML::Node::SaveOptions::FORMAT
             )
-            # puts "<<<<< XML:\n #{xml}\n >>>>>"
+            @logger.debug {
+              "Attaching Synced Folder device with XML:\n#{xml}"
+            }
             @conn.lookup_domain_by_uuid(machine.id).attach_device(xml, 0)
           end
         rescue => e

--- a/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
@@ -46,7 +46,6 @@ module VagrantPlugins
 
             machine.ui.info "================\nMachine id: #{machine.id}\nShould be mounting folders\n #{id}, opts: #{folder_opts}"
 
-            #xml = to_xml('filesystem', folder_opts)
             xml = Nokogiri::XML::Builder.new do |xml|
               xml.filesystem(type: 'mount', accessmode: 'passthrough') do
                 xml.driver(type: 'virtiofs')
@@ -59,7 +58,9 @@ module VagrantPlugins
                          Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS |
                          Nokogiri::XML::Node::SaveOptions::FORMAT
             )
-            # puts "<<<<< XML:\n #{xml}\n >>>>>"
+            @logger.debug {
+              "Attaching Synced Folder device with XML:\n#{xml}"
+            }
             @conn.lookup_domain_by_uuid(machine.id).attach_device(xml, 0)
           end
         rescue => e

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -31,6 +31,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
       allow(connection).to receive(:volumes).and_return(volumes)
 
       allow(logger).to receive(:info)
+      allow(logger).to receive(:debug)
 
       env[:domain_name] = "vagrant-test_default"
 

--- a/spec/unit/action/create_domain_volume_spec.rb
+++ b/spec/unit/action/create_domain_volume_spec.rb
@@ -34,6 +34,8 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume do
       allow(all).to receive(:first).and_return(box_volume)
       allow(box_volume).to receive(:id).and_return(nil)
       env[:domain_name] = 'test'
+
+      allow(logger).to receive(:debug)
     end
 
     context 'when one disk' do

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -30,6 +30,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
       allow(connection).to receive(:servers).and_return(servers)
       allow(servers).to receive(:get).and_return(domain)
 
+      allow(logger).to receive(:debug)
       expect(logger).to receive(:info)
       expect(ui).to_not receive(:error)
     end
@@ -46,7 +47,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
 
       it 'should execute without changing' do
         allow(libvirt_domain).to receive(:undefine)
-        expect(logger).to_not receive(:debug)
         expect(libvirt_domain).to receive(:autostart=)
         expect(domain).to receive(:start)
 
@@ -118,7 +118,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
         end
 
         it 'should execute without changing' do
-          expect(logger).to_not receive(:debug)
           expect(libvirt_domain).to receive(:autostart=)
           expect(domain).to receive(:start)
 
@@ -138,7 +137,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
         end
 
         it 'should execute without changing' do
-          expect(logger).to_not receive(:debug)
           expect(libvirt_domain).to receive(:autostart=)
           expect(domain).to receive(:start)
 


### PR DESCRIPTION
Because libvirt may handle updating the XML of components differently
across different versions and user environments, add the generated
contents to the debug log to assist in understanding what is happening
for different users.
