### PR TITLE
Fix variable in entrypoint.sh when determining user based on Vagrantfile ownership

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ esac
 # from the current working directory anyway
 vagrantfile="${VAGRANT_VAGRANTFILE:-Vagrantfile}"
 path="$(pwd)"
-while [[ "$path" != "" && ! -e "$path/$1" ]]
+while [[ "$path" != "" && ! -e "$path/$vagrantfile" ]]
 do
     path=${path%/*}
 done


### PR DESCRIPTION
In the entrypoint.sh script, the "$1" variable was used incorrectly when determining default user based on the ownership of the vagrantfile (or parents). The "$vagrantfile" variable should have been used instead, as it was just set.

Signed-off-by: SG <13872653+mmguero@users.noreply.github.com>