### PR TITLE
Avoid blanking username if set by user

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -1018,10 +1018,12 @@ module VagrantPlugins
           end
         end
 
-        # Extract host and username values from uri if provided, otherwise nil
+        # Extract host values from uri if provided, otherwise nil
         @host = uri.host
         @port = uri.port
-        @username = uri.user
+        # only override username if there is a value provided
+        @username = nil if @username == UNSET_VALUE
+        @username = uri.user if uri.user
         if uri.query
           params = CGI.parse(uri.query)
           @id_ssh_key_file = params['keyfile'].first if params.has_key?('keyfile')

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -192,14 +192,14 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         ],
         [ # when username explicitly set without ssh
           {:username => 'my_user' },
-          {:uri => 'qemu:///system'},
+          {:uri => 'qemu:///system', :username => 'my_user'},
           {
             :env => {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
           }
         ],
         [ # when username explicitly set with host but without ssh
           {:username => 'my_user', :host => 'remote'},
-          {:uri => 'qemu://remote/system'},
+          {:uri => 'qemu://remote/system', :username => 'my_user'},
           {
             :env => {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
           }


### PR DESCRIPTION
While the username may not be used unless the connection is via ssh,
should avoid forcing to nil by accident when re-parsing from the uri.
