### PR TITLE
Refactor create domain tests

### DIFF
--- a/spec/support/sharedcontext.rb
+++ b/spec/support/sharedcontext.rb
@@ -9,6 +9,7 @@ shared_context 'unit' do
   let(:vagrantfile) do
     <<-EOF
     Vagrant.configure('2') do |config|
+      config.vm.box = "vagrant-libvirt/test"
       config.vm.define :test
       config.vm.provider :libvirt do |libvirt|
         #{vagrantfile_providerconfig}

--- a/spec/unit/action/create_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/create_domain_spec/additional_disks_domain.xml
@@ -28,6 +28,11 @@
   <devices>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='default'/>
+      <source file='/var/lib/libvirt/images/vagrant-test_default.img'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='default'/>
       <source file='/var/lib/libvirt/images/vagrant-test_default-vdb.qcow2'/>
       <target dev='vdb' bus='virtio'/>
     </disk>

--- a/spec/unit/action/create_domain_spec/default_domain.xml
+++ b/spec/unit/action/create_domain_spec/default_domain.xml
@@ -26,6 +26,11 @@
   <clock offset='utc'>
   </clock>
   <devices>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='default'/>
+      <source file='/var/lib/libvirt/images/vagrant-test_default.img'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
 
 
     <serial type='pty'>


### PR DESCRIPTION
Adjust create domain tests to exercise both with a box defined and
undefined. Switch the default vagrantfile definition to have a box
defined as it is the expected behaviour.
