### PR TITLE
Handle VM not accessible during reboot

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -137,7 +137,17 @@ module VagrantPlugins
         # TODO: terminated no longer appears to be a valid fog state, remove?
         return :not_created if domain.nil? || domain.state.to_sym == :terminated
 
-        domain.state.tr('-', '_').to_sym
+        state = domain.state.tr('-', '_').to_sym
+        if state == :running
+          begin
+            get_domain_ipaddress(machine, domain)
+          rescue Fog::Errors::TimeoutError => e
+            @logger.debug("Machine #{machine.id} running but no IP address available: #{e}.")
+            return :inaccessible
+          end
+        end
+
+        return state
       end
 
       private

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -12,14 +12,18 @@ describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
   include_context 'unit'
   include_context 'libvirt'
 
+  let(:driver) { double('driver') }
   let(:libvirt_domain) { double('libvirt_domain') }
   let(:libvirt_client) { double('libvirt_client') }
   let(:servers) { double('servers') }
 
+  before do
+    allow(machine.provider).to receive('driver').and_return(driver)
+    allow(driver).to receive(:connection).and_return(connection)
+  end
+
   describe '#call' do
     before do
-      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
-        .to receive(:connection).and_return(connection)
       allow(connection).to receive(:client).and_return(libvirt_client)
       allow(libvirt_client).to receive(:lookup_domain_by_uuid)
         .and_return(libvirt_domain)


### PR DESCRIPTION
To support commands requesting a reboot of a VM after execution, the
query of ssh_info needs to avoid triggering an error when the IP address
is not yet retrievable as this indicates the VM would not be reachable.

Wrap the returning of the state in the driver to distinguish between the
following states:
- :running - indicates the machine is available
- :inaccessible - the machine is running but not yet available to
  connect

This is based on the behaviour from the virtualbox provider.

Includes some rudimentary tests to exercise the driver state code.

Closes: #1366