### PR TITLE
Adding SEV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1799,6 +1799,68 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+## SEV
+
+SEV (Secure Encryption Virtualization) is supported by libvirt and by the vagrant-libvirt provider 
+but comes with several requirements.
+
+This mode has only been tested with q35 types of machines, so you'll need an UEFI boot
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.loader = "/usr/share/OVMF/OVMF_CODE.fd"
+    libvirt.nvram = "/path/to/ovmf/OVMF_VARS.fd"
+    libvirt.machine_type = 'pc-q35-focal'
+  end
+end
+```
+
+Read the libvirt documentaiton to understand what OVMF is and how to use it.
+
+Next, you'll want to call the following methods:
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.launchsecurity :type => 'sev', :cbitpos => 47, :reducedPhysBits => 1, :policy => "0x0003"
+    libvirt.memtune :type => "hard_limit", :value => 2500000 # Note here the value in kB (not in Mb)
+  end
+end
+```
+
+Note that the value provided in the memtune hard_limit is in Kb by default. It should be higher than the 
+one given in ```libvirt.memory``` (which is in Mb, by the way) by some amount (again, check out the [https://libvirt.org/kbase/launch_security_sev.html](documentation)) to understand why.
+
+It is also necessary to explicitely define the memballoon for it to accept the iommu flag.
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.memballoon_enabled = true
+    libvirt.memballoon_model = 'virtio'
+    libvirt.memballoon_pci_bus = '0x07'
+    libvirt.memballoon_pci_slot = '0x00'
+  end
+end
+```
+
+And finally, because the iommu flag has to be passed to the networks, you also need to set it explicitely:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :libvirt do |libvirt|
+    # Management network only (the NAT'ed network provided by Vagrant)
+    libvirt.management_network_driver_iommu = true
+  end
+
+  # Example in defining a bridge 
+  config.vm.network :public_network, :dev => "br0", :bridge => "br0", :mode => "bridge", :type => "bridge", :driver_iommu => true # <== Note here the additional flag
+end
+```
+
+Don't forget that you'll need an UEFI base box.
+
+
 ## Libvirt communication channels
 
 For certain functionality to be available within a guest, a private

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -47,6 +47,7 @@ module VagrantPlugins
           @features_hyperv = config.features_hyperv
           @clock_offset = config.clock_offset
           @clock_timers = config.clock_timers
+          @launchsecurity_data = config.launchsecurity_data
           @shares = config.shares
           @cpu_mode = config.cpu_mode
           @cpu_model = config.cpu_model
@@ -62,6 +63,15 @@ module VagrantPlugins
           @nested = config.nested
           @memory_size = config.memory.to_i * 1024
           @memory_backing = config.memory_backing
+          @memtunes = config.memtunes
+
+
+	  @memballoon_enabled = config.memballoon_enabled
+	  @memballoon_model = config.memballoon_model
+	  @memballoon_pci_bus = config.memballoon_pci_bus
+	  @memballoon_pci_slot = config.memballoon_pci_slot
+
+
           @management_network_mac = config.management_network_mac
           @domain_volume_cache = config.volume_cache || 'default'
           @kernel = config.kernel
@@ -257,6 +267,10 @@ module VagrantPlugins
           @memory_backing.each do |backing|
             env[:ui].info(" -- Memory Backing:    #{backing[:name]}: #{backing[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')}")
           end
+
+          @memtunes.each do |memtune|
+            env[:ui].info(" -- Memory tuning:    #{memtune[:type]}: #{memtune[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')}, value: #{memtune[:value]}")
+          end
           unless @shares.nil?
             env[:ui].info(" -- Shares:            #{@shares}")
           end
@@ -301,6 +315,10 @@ module VagrantPlugins
 
           unless @disks.empty?
             env[:ui].info(" -- Disks:         #{_disks_print(@disks)}")
+          end
+
+          if not @launchsecurity_data.nil?
+            env[:ui].info(" -- Launch security: type=#{@launchsecurity_data[:type]}, cbitpos=#{@launchsecurity_data[:cbitpos]}, reducedPhysBits=#{@launchsecurity_data[:reducedPhysBits]}, policy=#{@launchsecurity_data[:policy]}")
           end
 
           @disks.each do |disk|

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -65,7 +65,7 @@ module VagrantPlugins
                 disk_target.parent.delete_element("#{disk_target.parent.xpath}/address")
               end
 	
-	      nvram = REXML::XPath.first(xml_descr, 'os/nvram')
+	            nvram = REXML::XPath.first(xml_descr, '/domain/os/nvram')
               unless nvram.nil?
                 had_nvram = true
               end
@@ -205,7 +205,7 @@ module VagrantPlugins
                    
                    
                   newLaunchSecurity = REXML::XPath.first(xml_descr, '/domain/launchSecurity')
-		  newType = newLaunchSecurity.attributes['type']
+		              newType = newLaunchSecurity.attributes['type']
                   newCbitPos = REXML::XPath.first( newLaunchSecurity, 'cbitpos')
                   newReducedPhysBits = REXML::XPath.first( newLaunchSecurity, 'reducedPhysBits')
                   newPolicy = REXML::XPath.first( newLaunchSecurity, 'policy')
@@ -215,43 +215,27 @@ module VagrantPlugins
                     descr_changed = true
                   end
 
-		  if newCbitPos.text != config.launchsecurity_data[:cbitpos]
+		              if newCbitPos.text != config.launchsecurity_data[:cbitpos]
                     @logger.debug "launchSecurity config changed"
                     descr_changed = true
                   end
 
-		  if newReducedPhysBits.text != config.launchsecurity_data[:reducedPhysBits]
+		              if newReducedPhysBits.text != config.launchsecurity_data[:reducedPhysBits]
                     @logger.debug "launchSecurity config changed"
                     descr_changed = true
-		  end
+		              end
 
-		  if newPolicy.text != config.launchsecurity_data[:policy]
-                     @logger.debug "launchSecurity config changed"
-                     descr_changed = true
-		  end
+		              if newPolicy.text != config.launchsecurity_data[:policy]
+                    @logger.debug "launchSecurity config changed"
+                    descr_changed = true
+		              end
  
 
                   REXML::XPath.each( xml_descr, '/domain/devices/controller') do | controller |
                     driver_node = controller.add_element('driver')
                     driver_node.attributes['iommu'] = 'on'
                   end
-
-#                  newLaunchSecurity.attributes['type'] = config.launchsecurity_data.type
-#                  cbitpos = newLaunchSecurity.add_element('cbitpos')
-#                  cbitpos.text = config.launchsecurity_data.cbitpos
-#                  
-#                  reducedPhysBits = newLaunchSecurity.add_element('reducedPhysBits')
-#                  reducedPhysBits.text = config.launchsecurity_data.reducedPhysBits
-                  
-#                  policy = newLaunchSecurity.add_element('policy')
-#                  policy.text = config.launchsecurity_data.policy
-                  
-#                  unless "'#{newLaunchSecurity}'".eql? "'#{launchSecurity}'"
-#                    descr_changed = true
-#                  end
-
                 end
-
 
               else
                 unless launchSecurity.nil?
@@ -262,10 +246,10 @@ module VagrantPlugins
 
 
 
-                   REXML::XPath.each( xml_descr, '/domain/devices/controller') do | controller |
-                     driver_node = controller.add_element('driver')
-                     driver_node.attributes['iommu'] = 'on'
-                   end
+              REXML::XPath.each( xml_descr, '/domain/devices/controller') do | controller |
+                driver_node = controller.add_element('driver')
+                driver_node.attributes['iommu'] = 'on'
+              end
 
 
               # Graphics
@@ -423,13 +407,13 @@ module VagrantPlugins
               # Apply
               if descr_changed
                 begin
-	          # A domain that has NVRAM must receive a special flag during undefine
+	                # A domain that has NVRAM must receive a special flag during undefine
                   # See this method call: https://libvirt.org/ruby/api/Libvirt/Domain.html#method-i-undefine
                   if had_nvram
-	                libvirt_domain.undefine(4)
+	                  libvirt_domain.undefine(Libvirt::Domain::UNDEFINE_NVRAM)
                   else
-           		libvirt_domain.undefine(4)
-		  end
+                    libvirt_domain.undefine()
+                  end
 
                   new_descr = String.new
                   xml_descr.write new_descr

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -224,7 +224,7 @@ module VagrantPlugins
         @management_network_pci_bus = UNSET_VALUE
         @management_network_domain = UNSET_VALUE
         @management_network_mtu = UNSET_VALUE
-	@management_network_driver_iommu = UNSET_VALUE
+	      @management_network_driver_iommu = UNSET_VALUE
         # System connection information
         @system_uri      = UNSET_VALUE
 
@@ -495,7 +495,8 @@ module VagrantPlugins
         end
         
         opts = config[:options] || {}
-	opts[:unit] = opts[:unit] || "KiB"
+	      opts[:unit] = opts[:unit] || "KiB"
+
         @memtunes = [] if @memtunes == UNSET_VALUE
         @memtunes.push( name: config[:type], value: config[:value], config: opts )
       end
@@ -853,7 +854,7 @@ module VagrantPlugins
         @management_network_domain = nil if @management_network_domain == UNSET_VALUE
         @management_network_mtu = nil if @management_network_mtu == UNSET_VALUE
         @management_network_driver_iommu = false if @management_network_driver_iommu == UNSET_VALUE
-	@system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
+	      @system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
 
         # Domain specific settings.
         @title = '' if @title == UNSET_VALUE

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -69,7 +69,7 @@ module VagrantPlugins
       attr_accessor :management_network_pci_slot
       attr_accessor :management_network_domain
       attr_accessor :management_network_mtu
-
+      attr_accessor :management_network_driver_iommu
       # System connection information
       attr_accessor :system_uri
 
@@ -83,6 +83,7 @@ module VagrantPlugins
       attr_accessor :memory
       attr_accessor :nodeset
       attr_accessor :memory_backing
+      attr_accessor :memtunes
       attr_accessor :channel
       attr_accessor :cpus
       attr_accessor :cpuset
@@ -96,6 +97,7 @@ module VagrantPlugins
       attr_accessor :features_hyperv
       attr_accessor :clock_offset
       attr_accessor :clock_timers
+      attr_accessor :launchsecurity_data
       attr_accessor :numa_nodes
       attr_accessor :loader
       attr_accessor :nvram
@@ -222,7 +224,7 @@ module VagrantPlugins
         @management_network_pci_bus = UNSET_VALUE
         @management_network_domain = UNSET_VALUE
         @management_network_mtu = UNSET_VALUE
-
+	@management_network_driver_iommu = UNSET_VALUE
         # System connection information
         @system_uri      = UNSET_VALUE
 
@@ -233,6 +235,7 @@ module VagrantPlugins
         @memory            = UNSET_VALUE
         @nodeset           = UNSET_VALUE
         @memory_backing    = UNSET_VALUE
+        @memtunes          = UNSET_VALUE
         @cpus              = UNSET_VALUE
         @cpuset            = UNSET_VALUE
         @cpu_mode          = UNSET_VALUE
@@ -245,6 +248,7 @@ module VagrantPlugins
         @features_hyperv   = UNSET_VALUE
         @clock_offset      = UNSET_VALUE
         @clock_timers      = []
+        @launchsecurity_data = UNSET_VALUE
         @numa_nodes        = UNSET_VALUE
         @loader            = UNSET_VALUE
         @nvram             = UNSET_VALUE
@@ -475,6 +479,37 @@ module VagrantPlugins
         @memory_backing = [] if @memory_backing == UNSET_VALUE
         @memory_backing.push(name: option,
                              config: config)
+      end
+
+      def memtune(config={})
+        if config[:type].nil?
+          raise "Missing memtune type"
+        end
+
+        unless ['hard_limit', 'soft_limit', 'swap_hard_limit'].include? config[:type]
+          raise "Memtune type not allowed (hard_limit, soft_limit, swap_hard_limit are allowed)"
+        end
+
+        if config[:value].nil?
+          raise "Missing memtune value"
+        end
+        
+        opts = config[:options] || {}
+	opts[:unit] = opts[:unit] || "KiB"
+        @memtunes = [] if @memtunes == UNSET_VALUE
+        @memtunes.push( name: config[:type], value: config[:value], config: opts )
+      end
+
+      def launchsecurity(options = {})
+        if options[:type].nil?
+          raise "Lauch security type only supports SEV. Expliciately set 'sev' as a type"
+        end
+        @launchsecurity_data = {}
+        @launchsecurity_data[:type] = options[:type]
+        @launchsecurity_data[:cbitpos] = options[:cbitpos] || 47
+        @launchsecurity_data[:reducedPhysBits] = options[:reducedPhysBits] || 1
+        @launchsecurity_data[:policy] = options[:policy] || "0x0003"
+
       end
 
       def input(options = {})
@@ -817,7 +852,8 @@ module VagrantPlugins
         @management_network_pci_slot = nil if @management_network_pci_slot == UNSET_VALUE
         @management_network_domain = nil if @management_network_domain == UNSET_VALUE
         @management_network_mtu = nil if @management_network_mtu == UNSET_VALUE
-        @system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
+        @management_network_driver_iommu = false if @management_network_driver_iommu == UNSET_VALUE
+	@system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
 
         # Domain specific settings.
         @title = '' if @title == UNSET_VALUE
@@ -826,6 +862,7 @@ module VagrantPlugins
         @memory = 512 if @memory == UNSET_VALUE
         @nodeset = nil if @nodeset == UNSET_VALUE
         @memory_backing = [] if @memory_backing == UNSET_VALUE
+        @memtunes = [] if @memtunes == UNSET_VALUE
         @cpus = 1 if @cpus == UNSET_VALUE
         @cpuset = nil if @cpuset == UNSET_VALUE
         @cpu_mode = 'host-model' if @cpu_mode == UNSET_VALUE
@@ -844,6 +881,7 @@ module VagrantPlugins
         @features_hyperv = [] if @features_hyperv == UNSET_VALUE
         @clock_offset = 'utc' if @clock_offset == UNSET_VALUE
         @clock_timers = [] if @clock_timers == UNSET_VALUE
+        @launchsecurity_data = nil if @launchsecurity_data == UNSET_VALUE
         @numa_nodes = @numa_nodes == UNSET_VALUE ? nil : _generate_numa
         @loader = nil if @loader == UNSET_VALUE
         @nvram = nil if @nvram == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -34,7 +34,6 @@
       </numa>
     <% end %>
   </cpu>
-
 <%- if @nodeset -%>
   <numatune>
     <memory nodeset='<%= @nodeset %>'/>
@@ -47,6 +46,14 @@
   <% end %>
   </memoryBacking>
 <% end%>
+
+<% unless @memtunes.empty? %>
+  <memtune>
+  <% @memtunes.each do |memtune| %>
+    <<%= memtune[:name] %> <%= memtune[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')  %>><%= memtune[:value] %></<%= memtune[:name] %>>
+  <% end %>
+  </memtune>
+<% end %>
 <% if @shares %>
   <cputune>
     <shares><%= @shares %></shares>
@@ -194,7 +201,10 @@
 <% end %>
 
 <% @inputs.each do |input| %>
-    <input type='<%= input[:type] %>' bus='<%= input[:bus] %>'/>
+    <input type='<%= input[:type] %>' bus='<%= input[:bus] %>'>
+      <% unless @launchsecurity_data.nil? %><driver iommu='on' /><% end %>
+      <driver iommu='on' />
+    </input>
 <% end %>
 
     <% if !@sound_type.nil? %>
@@ -214,6 +224,8 @@
     <% if @rng[:model] == "random"%>
       <rng model='virtio'>
         <backend model='random'>/dev/random</backend>
+        <% unless @launchsecurity_data.nil? %><driver iommu='on' /><% end %>
+        <driver iommu='on' />
       </rng>
     <% end %>
     <% @pcis.each do |pci| %>
@@ -283,12 +295,16 @@
     <% end -%>
     <% if not @usbctl_dev.empty? %>
     <%# USB Controller -%>
-    <controller type='usb' model='<%= @usbctl_dev[:model] %>' <%= "ports=\"#{@usbctl_dev[:ports]}\" " if @usbctl_dev[:ports] %>/>
+    <controller type='usb' model='<%= @usbctl_dev[:model] %>' <%= "ports=\"#{@usbctl_dev[:ports]}\" " if @usbctl_dev[:ports] %>>
+    <% unless @launchsecurity_data.nil? %><driver iommu='on' /><% end %>
+    <driver iommu='on' />
+    </controller>
     <% end %>
     <% unless @memballoon_enabled.nil? %>
     <% if @memballoon_enabled %>
     <memballoon model='<%= @memballoon_model %>'>
       <address type='pci' domain='0x0000' bus='<%= @memballoon_pci_bus %>' slot='<%= @memballoon_pci_slot %>' function='0x0'/>
+      <% unless @launchsecurity_data.nil? %><driver iommu='on' /><% end %>
     </memballoon>
     <% else %>
     <memballoon model='none'/>
@@ -296,6 +312,13 @@
     <% end %>
   </devices>
 
+  <% unless @launchsecurity_data.nil? %>
+  <launchSecurity type='<%= @launchsecurity_data[:type] %>'>
+    <cbitpos><%= @launchsecurity_data[:cbitpos] %></cbitpos>
+    <reducedPhysBits><%= @launchsecurity_data[:reducedPhysBits] %></reducedPhysBits>
+    <policy><%= @launchsecurity_data[:policy] %></policy>
+  </launchSecurity>
+  <% end %>
   <% if not @qemu_args.empty? or not @qemu_env.empty? %>
   <qemu:commandline>
     <% @qemu_args.each do |arg| %>

--- a/lib/vagrant-libvirt/templates/public_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/public_interface.xml.erb
@@ -11,12 +11,15 @@
   <% end %>
   <model type='<%=@model_type%>'/>
   <% if @driver_name and @driver_queues %>
-    <driver name='<%=@driver_name%>' queues='<%=@driver_queues%>'/>
+    <driver <% if @driver_iommu %> iommu="on" <% end %> name='<%=@driver_name%>' queues='<%=@driver_queues%>'/>
   <% elsif @driver_queues %>
-    <driver queues='<%=@driver_queues%>'/>
+    <driver <% if @driver_iommu %> iommu="on" <% end %> queues='<%=@driver_queues%>'/>
   <% elsif @driver_name %>
-    <driver name='<%=@driver_name%>'/>
+    <driver <% if @driver_iommu %> iommu="on" <% end %> name='<%=@driver_name%>'/>
+  <% elsif @driver_iommu %>
+    <driver iommu='on' />
   <% end %>
+
   <% if @ovs %>
   <virtualport type='openvswitch'>
     <% if @ovs_interfaceid %>

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -32,6 +32,8 @@ module VagrantPlugins
           management_network_pci_slot = env[:machine].provider_config.management_network_pci_slot
           management_network_domain = env[:machine].provider_config.management_network_domain
           management_network_mtu = env[:machine].provider_config.management_network_mtu
+	  management_network_driver_iommu = env[:machine].provider_config.management_network_driver_iommu
+
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -73,7 +75,7 @@ module VagrantPlugins
             }
           end
 
-
+          management_network_options[:driver_iommu] = management_network_driver_iommu
 
           unless management_network_mac.nil?
             management_network_options[:mac] = management_network_mac

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -12,10 +12,10 @@
         <feature name='AAA' policy='required'/>
         <topology sockets='1' cores='3' threads='2'/>
   </cpu>
-
   <numatune>
     <memory nodeset='1-4,^3,6'/>
   </numatune>
+
   <cputune>
     <shares>1024</shares>
   </cputune>
@@ -112,6 +112,7 @@
       </video>
       <rng model='virtio'>
         <backend model='random'>/dev/random</backend>
+        
       </rng>
       <hostdev mode='subsystem' type='pci' managed='yes'>
         <source>
@@ -150,7 +151,9 @@
         <device path='/dev/tpm0'/>
       </backend>
     </tpm>
-    <controller type='usb' model='nec-xhci' ports="4" />
+    <controller type='usb' model='nec-xhci' ports="4" >
+    
+    </controller>
   </devices>
 
   <qemu:commandline>


### PR DESCRIPTION
We are working on supporting SEV virtual machines

Necessary modifications were made relating to 

- Adding ```launchSecurity``` method and tag
- Adding ```memtunes``` method and tag
- Adding iommu drivers in controllers and in interfaces
- New network option ```management_driver_iommu``` was necessary

Known issues:
- Changing the memtunes does not trigger a redifinition of the domain
- The fog-libvirt domain ```undefine``` call fails for devices with a ```nvram``` tag. This is because a specific flag needs to be sent over to libvirt. Upstream PR merging will be necessary before this one is merged.

The minimum Vagrantfile has become a bit more complex

```ruby
ronfig.vm.provider :libvirt do |libvirt|
  libvirt.loader = "/usr/share/OVMF/OVMF_CODE.fd"
  libvirt.nvram = "/path/to/ovmf/OVMF_VARS.fd"
  libvirt.launchsecurity :type => 'sev', :cbitpos => 47, :reducedPhysBits => 1, :policy => "0x0003"
  libvirt.memory = 2000
  libvirt.memtune :type => "hard_limit", :value => 2500000 # Note here the value in kB (not in Mb)
  libvirt.machine_type = 'pc-q35-focal'

  libvirt.management_network_driver_iommu = true
  
  libvirt.memballoon_enabled = true
  libvirt.memballoon_model = 'virtio'
  libvirt.memballoon_pci_bus = '0x07'
  libvirt.memballoon_pci_slot = '0x00'

  # Debugging purposes
  #libvirt.graphics_type = 'vnc'
  #libvirt.graphics_port = '5901'
  #libvirt.graphics_ip = '0.0.0.0'

end
```

Adding a public network also needs an additional option:

```
config.vm.network :public_network, :dev => "br0", :bridge => "br0", :mode => "bridge", :type => "bridge", :driver_iommu => true
```

Sorry for the messy commits. I tried to squash them but it just got worse :D