### PR TITLE
Add aliases for devices

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -251,6 +251,7 @@ module VagrantPlugins
                           udp_tunnel={}, pci_bus, pci_slot)
           Nokogiri::XML::Builder.new do |xml|
             xml.interface(type: type || 'network') do
+              xml.alias(name: "ua-net-#{iface_number}")
               xml.source(source_options) do
                 xml.local(udp_tunnel) if type == 'udp'
               end

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -113,8 +113,9 @@
     <% if @emulator_path %>
     <emulator><%= @emulator_path %></emulator>
     <% end %>
-<% @domain_volumes.each do |volume| -%>
+<% @domain_volumes.each_with_index do |volume, index| -%>
     <disk type='file' device='disk'>
+      <alias name='ua-box-volume-<%= index -%>'/>
       <driver name='qemu' type='qcow2' <%=
         @disk_driver_opts.empty? ? "cache='#{volume[:cache]}'" :
             @disk_driver_opts.reject { |k,v| v.nil? }
@@ -126,8 +127,9 @@
     </disk>
 <% end -%>
 <%# additional disks -%>
-<% @disks.each do |d| -%>
+<% @disks.each_with_index do |d, index| -%>
     <disk type='file' device='disk'>
+      <alias name='ua-disk-volume-<%= index -%>'/>
       <driver name='qemu' type='<%= d[:type] %>' <%=
         d.select { |k,_| [:cache, :io, :copy_on_read, :discard, :detect_zeroes].include? k }
          .reject { |k,v| v.nil? }

--- a/lib/vagrant-libvirt/templates/public_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/public_interface.xml.erb
@@ -1,4 +1,5 @@
 <interface type='<%= @type %>'<% if @trust_guest_rx_filters %> trustGuestRxFilters='yes'<% end %>>
+  <alias name='ua-net-<%= @iface_number %>'/>
   <% if @mac %>
   <mac address='<%= @mac %>'/>
   <% end %>

--- a/spec/unit/action/create_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/create_domain_spec/additional_disks_domain.xml
@@ -27,11 +27,13 @@
   </clock>
   <devices>
     <disk type='file' device='disk'>
+      <alias name='ua-box-volume-0'/>
       <driver name='qemu' type='qcow2' cache='default'/>
       <source file='/var/lib/libvirt/images/vagrant-test_default.img'/>
       <target dev='vda' bus='virtio'/>
     </disk>
     <disk type='file' device='disk'>
+      <alias name='ua-disk-volume-0'/>
       <driver name='qemu' type='qcow2' cache='default'/>
       <source file='/var/lib/libvirt/images/vagrant-test_default-vdb.qcow2'/>
       <target dev='vdb' bus='virtio'/>

--- a/spec/unit/action/create_domain_spec/default_domain.xml
+++ b/spec/unit/action/create_domain_spec/default_domain.xml
@@ -27,6 +27,7 @@
   </clock>
   <devices>
     <disk type='file' device='disk'>
+      <alias name='ua-box-volume-0'/>
       <driver name='qemu' type='qcow2' cache='default'/>
       <source file='/var/lib/libvirt/images/vagrant-test_default.img'/>
       <target dev='vda' bus='virtio'/>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -44,21 +44,25 @@
   <devices>
     <emulator>/usr/bin/kvm-spice</emulator>
     <disk type='file' device='disk'>
+      <alias name='ua-box-volume-0'/>
       <driver name='qemu' type='qcow2' cache='unsafe' io='threads' copy_on_read='on' discard='unmap' detect_zeroes='on'/>
       <source file='/var/lib/libvirt/images/test.qcow2'/>
       <target dev='vda' bus='ide'/>
     </disk>
     <disk type='file' device='disk'>
+      <alias name='ua-box-volume-1'/>
       <driver name='qemu' type='qcow2' cache='unsafe' io='threads' copy_on_read='on' discard='unmap' detect_zeroes='on'/>
       <source file='/var/lib/libvirt/images/test2.qcow2'/>
       <target dev='vdb' bus='ide'/>
     </disk>
     <disk type='file' device='disk'>
+      <alias name='ua-disk-volume-0'/>
       <driver name='qemu' type='qcow2' cache='default'/>
       <source file='/var/lib/libvirt/images/test-disk1.qcow2'/>
       <target dev='vdb' bus='virtio'/>
     </disk>
     <disk type='file' device='disk'>
+      <alias name='ua-disk-volume-1'/>
       <driver name='qemu' type='qcow2' cache='default' io='threads' copy_on_read='on' discard='unmap' detect_zeroes='on'/>
       <source file='/var/lib/libvirt/images/test-disk2.qcow2'/>
       <target dev='vdc' bus='virtio'/>


### PR DESCRIPTION
It is more reliable to identify disk and network devices by use of
aliases, in addition to being able to establish in the absence of
information the purpose of such devices.

There is a possibility that in some cases this will also resolve issues
where the same device attach issued twice with the same details will
fail due to the second request not appearing to be honoured.

Additionally when destroying domains, may not have the relevant details
on how many disks are provided by the box, for those that support
multiple disks. Being able to traverse the domain XML and destroy the
appropriate volumes based on aliases names will remove the need to have
predictable device identifiers during the destroy and allow for an
improved resolver.

Relates: #1342
