### PR TITLE
Rework shutdown domain to avoid trailing action

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -143,19 +143,17 @@ module VagrantPlugins
             b2.use Call, IsRunning do |env2, b3|
               next unless env2[:result]
 
-              b3.use Call, Message, "Attempting nice shutdowns..." do |_, b4|
-                # ShutdownDomain will perform the domain shutdown on the out calls
-                # so it runs after the remaining actions in the same action builder.
-                b4.use ShutdownDomain, :shutoff, :running
-                b4.use GracefulHalt, :shutoff, :running
+              b3.use StartShutdownTimer
+              b3.use Call, GracefulHalt, :shutoff, :running do |env3, b4|
+                if !env3[:result]
+                  b4.use Call, ShutdownDomain, :shutoff, :running do |env4, b5|
+                    if !env4[:result]
+                       b5.use HaltDomain
+                    end
+                  end
+                end
               end
 
-              # Only force halt if previous actions insufficient.
-              b3.use Call, IsRunning do |env3, b4|
-                next unless env3[:result]
-
-                b4.use HaltDomain
-              end
             end
           end
         end
@@ -360,6 +358,7 @@ module VagrantPlugins
       autoload :ForwardPorts, action_root.join('forward_ports')
       autoload :ClearForwardedPorts, action_root.join('forward_ports')
       autoload :HaltDomain, action_root.join('halt_domain')
+      autoload :StartShutdownTimer, action_root.join('shutdown_domain')
       autoload :ShutdownDomain, action_root.join('shutdown_domain')
       autoload :HandleBoxImage, action_root.join('handle_box_image')
       autoload :HandleStoragePool, action_root.join('handle_storage_pool')

--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -9,6 +9,10 @@ module VagrantPlugins
         error_namespace('vagrant_libvirt.errors')
       end
 
+      class CallChainError < VagrantLibvirtError
+        error_key(:call_chain_error)
+      end
+
       # package not supported
       class PackageNotSupported < VagrantLibvirtError
         error_key(:package_not_supported)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -62,6 +62,7 @@ en:
         Forwarding UDP ports is not supported. Ignoring.
 
     errors:
+      call_chain_error: Invalid action chain, must ensure that '%{require_action}' is called prior to calling '%{current_action}'
       package_not_supported: No support for package with Libvirt. Create box manually.
       fog_error: |-
         There was an error talking to Libvirt. The error message is shown


### PR DESCRIPTION
Using the trailing action for ShutdownDomain results in it being
executed as part of the start up sequence in the reload action.

This appears to happen because the halt action is not executed in
isolation from the start action that is scheduled afterwards and
consequently the chaining behaviour spans both instead of being treated
as the combination of two distinct actions that should complete.

While this fixes the issue, it is important that subsequently call such
actions can be done without allowing the out part of the middleware
behaviour to be applied to subsequent actions.

Partial-Fix: #1376
