### PR TITLE
Ensure ssh_run and ssh actions match vagrant

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -233,14 +233,12 @@ module VagrantPlugins
           b.use ConfigValidate
           b.use Call, IsCreated do |env, b2|
             unless env[:result]
-              b2.use MessageNotCreated
-              next
+              raise Vagrant::Errors::VMNotCreatedError
             end
 
             b2.use Call, IsRunning do |env2, b3|
               unless env2[:result]
-                b3.use MessageNotRunning
-                next
+                raise Vagrant::Errors::VMNotRunningError
               end
 
               b3.use SSHExec
@@ -330,14 +328,12 @@ module VagrantPlugins
           b.use ConfigValidate
           b.use Call, IsCreated do |env, b2|
             unless env[:result]
-              b2.use MessageNotCreated
-              next
+              raise Vagrant::Errors::VMNotCreatedError
             end
 
             b2.use Call, IsRunning do |env2, b3|
               unless env2[:result]
-                b3.use MessageNotRunning
-                next
+                raise Vagrant::Errors::VMNotRunningError
               end
 
               b3.use SSHRun

--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -93,4 +93,82 @@ describe VagrantPlugins::ProviderLibvirt::Action do
       end
     end
   end
+
+  describe '#action_ssh' do
+    context 'when not created' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, false)
+      end
+
+      it 'should cause an error' do
+        expect{ machine.action(:ssh, ssh_opts: {})}.to raise_error(Vagrant::Errors::VMNotCreatedError)
+      end
+    end
+
+    context 'when created' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+      end
+
+      context 'when not running' do
+        before do
+          allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, false)
+        end
+
+        it 'should cause an error' do
+          expect{ machine.action(:ssh, ssh_opts: {})}.to raise_error(Vagrant::Errors::VMNotRunningError)
+        end
+      end
+
+      context 'when running' do
+        before do
+          allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, true)
+        end
+
+        it 'should call SSHExec' do
+          expect_any_instance_of(Vagrant::Action::Builtin::SSHExec).to receive(:call).and_return(0)
+          expect(machine.action(:ssh, ssh_opts: {})).to match(hash_including({:action_name => :machine_action_ssh}))
+        end
+      end
+    end
+  end
+
+  describe '#action_ssh_run' do
+    context 'when not created' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, false)
+      end
+
+      it 'should cause an error' do
+        expect{ machine.action(:ssh_run, ssh_opts: {})}.to raise_error(Vagrant::Errors::VMNotCreatedError)
+      end
+    end
+
+    context 'when created' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+      end
+
+      context 'when not running' do
+        before do
+          allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, false)
+        end
+
+        it 'should cause an error' do
+          expect{ machine.action(:ssh_run, ssh_opts: {})}.to raise_error(Vagrant::Errors::VMNotRunningError)
+        end
+      end
+
+      context 'when running' do
+        before do
+          allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, true)
+        end
+
+        it 'should call SSHRun' do
+          expect_any_instance_of(Vagrant::Action::Builtin::SSHRun).to receive(:call).and_return(0)
+          expect(machine.action(:ssh_run, ssh_opts: {})).to match(hash_including({:action_name => :machine_action_ssh_run}))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Vagrant expects that providers raise specific errors if the machines are
not available. Update to match the built-in providers.

Closes: #1376