### PR TITLE
Regression unit test for frozen string literal fix

### DIFF
--- a/lib/vagrant-libvirt/util/nfs.rb
+++ b/lib/vagrant-libvirt/util/nfs.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'vagrant/action/builtin/mixin_synced_folders'
+
 module VagrantPlugins
   module ProviderLibvirt
     module Util

--- a/spec/support/sharedcontext.rb
+++ b/spec/support/sharedcontext.rb
@@ -36,6 +36,6 @@ shared_context 'unit' do
 
   before (:each) do
     allow(machine).to receive(:guest).and_return(guest)
-    allow(machine).to receive(:communicator).and_return(communicator)
+    allow(machine).to receive(:communicate).and_return(communicator)
   end
 end

--- a/spec/unit/action/prepare_nfs_settings_spec.rb
+++ b/spec/unit/action/prepare_nfs_settings_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/sharedcontext'
+
+require 'vagrant-libvirt/action/prepare_nfs_settings'
+
+
+describe VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings do
+  subject { described_class.new(app, env) }
+
+  include_context 'unit'
+
+  describe '#call' do
+    context 'when enabled' do
+      let(:vagrantfile) do
+        <<-EOF
+        Vagrant.configure('2') do |config|
+          config.vm.box = "vagrant-libvirt/test"
+          config.vm.define :test
+          config.vm.synced_folder ".", "/vagrant", type: "nfs"
+          config.vm.provider :libvirt do |libvirt|
+            #{vagrantfile_providerconfig}
+          end
+        end
+        EOF
+      end
+      let(:socket) { double('socket') }
+
+      before do
+        allow(::TCPSocket).to receive(:new).and_return(socket)
+        allow(socket).to receive(:close)
+      end
+
+      it 'should retrieve the guest IP address' do
+        times_called = 0
+        expect(::TCPSocket).to receive(:new) do
+          # force reaching later code
+          times_called += 1
+          times_called < 2 ? raise("StandardError") : socket
+        end
+        expect(machine).to receive(:ssh_info).and_return({:host => '192.168.1.2'})
+        expect(communicator).to receive(:execute).and_yield(:stdout, "192.168.1.2\n192.168.2.2")
+
+        expect(subject.call(env)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/action/prepare_nfs_settings_spec.rb
+++ b/spec/unit/action/prepare_nfs_settings_spec.rb
@@ -12,6 +12,12 @@ describe VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings do
   include_context 'unit'
 
   describe '#call' do
+    before do
+      # avoid requiring nfsd installed to run tests
+      allow(machine.env.host).to receive(:capability?).with(:nfs_installed).and_return(true)
+      allow(machine.env.host).to receive(:capability).with(:nfs_installed).and_return(true)
+    end
+
     context 'when enabled' do
       let(:vagrantfile) do
         <<-EOF

--- a/spec/unit/action/wait_till_up_spec.rb
+++ b/spec/unit/action/wait_till_up_spec.rb
@@ -62,7 +62,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::WaitTillUp do
           expect(app).to_not receive(:call)
           expect(ui).to receive(:info).with('Waiting for domain to get an IP address...')
           expect(ui).to_not receive(:info).with('Waiting for SSH to become available...')
-          expect(env[:machine].communicate).to_not receive(:ready?)
           expect {subject.call(env) }.to raise_error(::Fog::Errors::TimeoutError)
         end
       end


### PR DESCRIPTION
Add a unit test for the prepare nfs settings action to act as a
regression test for the recent fix to avoiding modifying a frozen string
literal.

As part of this fix how the communicator is returned via a call to a
machine for testing purposes and remove an obsolete expect from the
wait till up tests as the code that would result in the communicator
being called has been removed.
