### PR TITLE
Switch back to read-only system connection

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -61,7 +61,7 @@ module VagrantPlugins
 
         config = @machine.provider_config
 
-        @system_connection = Libvirt::open(config.system_uri)
+        @system_connection = Libvirt::open_read_only(config.system_uri)
         @system_connection
       end
 

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -80,15 +80,15 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
     # system_uri should be 'qemu+ssh://user@remote1/system'
     # and not 'qemu:///system'.
     it 'should configure a separate connection per machine' do
-      expect(Libvirt).to receive(:open).with('qemu:///system').and_return(system_connection1)
-      expect(Libvirt).to receive(:open).with('qemu:///system').and_return(system_connection2)
+      expect(Libvirt).to receive(:open_read_only).with('qemu:///system').and_return(system_connection1)
+      expect(Libvirt).to receive(:open_read_only).with('qemu:///system').and_return(system_connection2)
 
       expect(machine.provider.driver.system_connection).to eq(system_connection1)
       expect(machine2.provider.driver.system_connection).to eq(system_connection2)
     end
 
     it 'should configure the connection once' do
-      expect(Libvirt).to receive(:open).with('qemu:///system').and_return(system_connection1)
+      expect(Libvirt).to receive(:open_read_only).with('qemu:///system').and_return(system_connection1)
 
       expect(machine.provider.driver.system_connection).to eq(system_connection1)
       expect(machine.provider.driver.system_connection).to eq(system_connection1)


### PR DESCRIPTION
With the rework to use the default connection to retrieve the domain to 
allow running of the qemu agent, no longer necessary to use a read 
write system connection, and can revert to a read-only connection that 
requires less privileges.

This should remove an occurrence of polkit requesting a password when 
bringing a VM up using a session connection.