### PR TITLE
Derive system URI from default URI

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -840,7 +840,6 @@ module VagrantPlugins
         @management_network_pci_slot = nil if @management_network_pci_slot == UNSET_VALUE
         @management_network_domain = nil if @management_network_domain == UNSET_VALUE
         @management_network_mtu = nil if @management_network_mtu == UNSET_VALUE
-        @system_uri      = 'qemu:///system' if @system_uri == UNSET_VALUE
 
         # Domain specific settings.
         @title = '' if @title == UNSET_VALUE
@@ -1065,6 +1064,10 @@ module VagrantPlugins
       def finalize_from_uri
         # Parse uri to extract individual components
         uri = _parse_uri(@uri)
+
+        system_uri = uri.dup
+        system_uri.path = '/system'
+        @system_uri = system_uri.to_s if @system_uri == UNSET_VALUE
 
         # only set @connect_via_ssh if not explicitly to avoid overriding
         # and allow an error to occur if the @uri and @connect_via_ssh disagree

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -80,15 +80,15 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
     # system_uri should be 'qemu+ssh://user@remote1/system'
     # and not 'qemu:///system'.
     it 'should configure a separate connection per machine' do
-      expect(Libvirt).to receive(:open_read_only).with('qemu:///system').and_return(system_connection1)
-      expect(Libvirt).to receive(:open_read_only).with('qemu:///system').and_return(system_connection2)
+      expect(Libvirt).to receive(:open_read_only).with('qemu+ssh://user@remote1/system').and_return(system_connection1)
+      expect(Libvirt).to receive(:open_read_only).with('qemu+ssh://vms@remote2/system').and_return(system_connection2)
 
       expect(machine.provider.driver.system_connection).to eq(system_connection1)
       expect(machine2.provider.driver.system_connection).to eq(system_connection2)
     end
 
     it 'should configure the connection once' do
-      expect(Libvirt).to receive(:open_read_only).with('qemu:///system').and_return(system_connection1)
+      expect(Libvirt).to receive(:open_read_only).with('qemu+ssh://user@remote1/system').and_return(system_connection1)
 
       expect(machine.provider.driver.system_connection).to eq(system_connection1)
       expect(machine.provider.driver.system_connection).to eq(system_connection1)


### PR DESCRIPTION
To facilitate using session on a remote instance, ensure the system_uri
configuration attribute is by default derived from the default uri
provided or constructed based on other settings, so that it contains any
host and transport settings.
