### PR TITLE
Dockerfile: vagrant 2.2.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG VAGRANT_VERSION=2.2.18
+ARG VAGRANT_VERSION=2.2.19
 
 
 FROM ubuntu:bionic as base


### PR DESCRIPTION
https://github.com/hashicorp/vagrant/blob/main/CHANGELOG.md#2219-november-5-2021 was released recently; looks like a simple version bump