### PR TITLE
Pin dependency to allow tests to run on older version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ group :development do
     gem 'rexml'
   end
 
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
+    gem 'mime-types', '< 3.4.0'
+  end
+
   gem 'pry'
 end
 


### PR DESCRIPTION
Upstream transitive dependency has dropped support for older rubies
without updating the minimum ruby version required.

Pin the max version of the dependency for older rubies to allow the
tests to run until the upstream project resolves.
