### PR TITLE
Ensure sessions trigger a listing of the network devices

### DIFF
--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -30,6 +30,15 @@ module VagrantPlugins
 
         def call(env)
           if env[:machine].provider_config.qemu_use_session
+            # Get a list of all (active and inactive) Libvirt networks. This
+            # triggers a side effect to ensure networking is fully available
+            # for VMs using sessions. It is likely that this should be done
+            # to determine the correct virtual device for the management
+            # network for sessions instead of assuming the default of virbr0.
+            @available_networks = libvirt_networks(
+              env[:machine].provider.driver.system_connection
+            )
+
             @app.call(env)
             return
           end


### PR DESCRIPTION
List network devices to trigger a side effect to ensure the
qemu-bridge-helper will run correctly for users of the modular daemons.

It is likely that this should be done for sessions to support resolving
the correct virtual bridge device anyway, however that is more involved
and maybe superseded by not needing a network interface should qemu
agent be able to act as a communicator. Or to perform port forwarding
using qemuargs to allow SSH access directly in.

Fixes: #1258
