### PR TITLE
Allow usage of public/private networks as management networks

### DIFF
--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -92,8 +92,14 @@ module VagrantPlugins
             management_network_options[:slot] = management_network_pci_slot
           end
 
-          if (env[:machine].config.vm.box &&
-              !env[:machine].provider_config.mgmt_attach)
+          # if there is a box and management network is disabled
+          # need qemu agent enabled and at least one network that can be accessed
+          if (
+            env[:machine].config.vm.box &&
+            !env[:machine].provider_config.mgmt_attach &&
+            !env[:machine].provider_config.qemu_use_agent &&
+            !env[:machine].config.vm.networks.any? { |type, _| ["private_network", "public_network"].include?(type.to_s) }
+          )
             raise Errors::ManagementNetworkRequired
           end
 

--- a/tests/qemu_agent/Vagrantfile
+++ b/tests/qemu_agent/Vagrantfile
@@ -6,7 +6,9 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/debian10"
   config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.network "private_network", type: "dhcp"
   config.vm.provider :libvirt do |libvirt|
     libvirt.qemu_use_agent = true
+    libvirt.mgmt_attach = false
   end
 end


### PR DESCRIPTION
Allow usage of public/private networks in place of the management network.

This requires that the qemu_use_agent is enabled and at least one network
is defined in the Vagrantfile that is either private or public.

The restriction that qemu_use_agent need be enabled may be removed
subsequently for networks using a static IP address, 

Fixes: #1204
Fixes: #1124
Fixes: #1057