### PR TITLE
Make destroy network locale independent

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_networks.rb
+++ b/lib/vagrant-libvirt/action/destroy_networks.rb
@@ -47,7 +47,7 @@ module VagrantPlugins
               )
             rescue Libvirt::RetrieveError => e
               # this network is already destroyed, so move on
-              if e.message =~ /Network not found/
+              if e.libvirt_code == ProviderLibvirt::Util::ErrorCodes::VIR_ERR_NO_NETWORK
                 @logger.info 'It is already undefined'
                 next
               # some other error occured, so raise it again


### PR DESCRIPTION
My machine uses French locales. 

When I try to run a `vagrant destroy -f mymachine`, the 'Network not found' error is raised because my error message is in French.

The comparison is then `if 'Réseau non trouvé' == 'Network not found'` as 'Network not found' is hardcoded which obviously fails everytime.

I could switch to an english locale but as it is a quick fix and may be used by others, I chose to switch from message comparison to libvirt_code comparison as eveything was already there, making it work with any locale.