### PR TITLE
Double the UDPSocket in cases where there's no network

### DIFF
--- a/spec/unit/action/prepare_nfs_settings_spec.rb
+++ b/spec/unit/action/prepare_nfs_settings_spec.rb
@@ -32,10 +32,14 @@ describe VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings do
         EOF
       end
       let(:socket) { double('socket') }
+      let(:udp_socket) { double('udp_socket') }
 
       before do
         allow(::TCPSocket).to receive(:new).and_return(socket)
         allow(socket).to receive(:close)
+
+        allow(::UDPSocket).to receive(:open).and_return(udp_socket)
+        allow(udp_socket).to receive(:connect)
       end
 
       it 'should retrieve the guest IP address' do


### PR DESCRIPTION
In PrepareNFSSettings.read_host_ip we use a UDPSocket to connect to the host in
question. However, this fails completely if the system executing the tests has
no network adapters enable, like builders in OBS or Koji. If we double the calls
to this, then we no longer face that issue.