### PR TITLE
Allow the connection.client.libversion call

### DIFF
--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -27,6 +27,8 @@ describe VagrantPlugins::ProviderLibvirt::Action do
     allow(logger).to receive(:info)
     allow(logger).to receive(:debug)
     allow(logger).to receive(:error)
+
+    allow(connection.client).to receive(:libversion).and_return(6_002_000)
   end
 
   def allow_action_env_result(action, *responses)


### PR DESCRIPTION
When the tests are executed and rsync is not installed on the machine executing the tests, then vagrant-libvirt will automatically fallback to virtiofs or 9p. Both of these perform the following call to check the libvirt version:
```Ruby
libvirt_version = machine.provider.driver.connection.client.libversion
```
However, this mock was not setup and thus those tests would fail.

This fixes https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1415