### PR TITLE
Validate partial mocks

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,10 +44,6 @@ RSpec.configure do |config|
   end
 
   config.mock_with :rspec do |mocks|
-    # This option should be set when all dependencies are being loaded
-    # before a spec run, as is the case in a typical spec helper. It will
-    # cause any verifying double instantiation for a class that does not
-    # exist to raise, protecting against incorrectly spelt names.
-    mocks.verify_doubled_constant_names = true
+    mocks.verify_partial_doubles = true
   end
 end

--- a/spec/support/libvirt_context.rb
+++ b/spec/support/libvirt_context.rb
@@ -10,9 +10,9 @@ shared_context 'libvirt' do
   let(:libvirt_context) { true                      }
   let(:id)              { 'dummy-vagrant_dummy'     }
   let(:connection)      { double('connection') }
-  let(:domain)          { instance_double('::Fog::Libvirt::Compute::Server') }
-  let(:libvirt_client)  { instance_double('::Libvirt::Connect') }
-  let(:libvirt_domain)  { instance_double('::Libvirt::Domain') }
+  let(:domain)          { instance_double(::Fog::Libvirt::Compute::Server) }
+  let(:libvirt_client)  { instance_double(::Libvirt::Connect) }
+  let(:libvirt_domain)  { instance_double(::Libvirt::Domain) }
   let(:logger)          { double('logger') }
 
   def connection_result(options = {})

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -155,7 +155,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
               end
 
               context 'with box metadata' do
-                let(:box) { instance_double('::Vagrant::Box') }
+                let(:box) { instance_double(::Vagrant::Box) }
                 before do
                   allow(env[:machine]).to receive(:box).and_return(box)
                   allow(box).to receive(:metadata).and_return(Hash[

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -607,7 +607,9 @@ describe VagrantPlugins::ProviderLibvirt::Config do
 
     context 'with mac defined' do
       let (:vm) { double('vm') }
-      before { expect(machine.config).to receive(:vm).and_return(vm) }
+      before do
+        machine.config.instance_variable_get("@keys")[:vm] = vm
+      end
 
       it 'is valid with valid mac' do
         expect(vm).to receive(:networks).and_return([[:public, { mac: 'aa:bb:cc:dd:ee:ff' }]])

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -177,7 +177,7 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
       end
 
       context 'when qemu_use_session is enabled' do
-        let(:networks) { [instance_double('::Fog::Libvirt::Compute::Real')] }
+        let(:networks) { [instance_double(::Fog::Libvirt::Compute::Real)] }
         let(:dhcp_leases) {
           {
             "iface"      =>"virbr0",


### PR DESCRIPTION
Switch to using explicit references to objects to be partially mocked
and remove the need to resolve the string constants as this will catch
more instances of calls to invalid or missing methods.

Rework how the vm is added to the machine for one of the tests as it is
not a method and instead is provided via internal state being exposed
with a helper.
