### PR TITLE
Make simplecov a source development dependency only

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,8 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    env:
+      VAGRANT_LIBVIRT_REQUIRE_SIMPLECOV: "true"
     continue-on-error: ${{ matrix.allow_fail }}
     strategy:
       fail-fast: false

--- a/Gemfile
+++ b/Gemfile
@@ -37,11 +37,9 @@ group :development do
     gem 'rexml'
   end
 
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
-    gem 'mime-types', '< 3.4.0'
-  end
-
   gem 'pry'
+  gem 'simplecov'
+  gem 'simplecov-lcov'
 end
 
 group :plugins do

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -23,8 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-core", ">= 3.5"
   s.add_development_dependency "rspec-expectations", ">= 3.5"
   s.add_development_dependency "rspec-mocks", ">= 3.5"
-  s.add_development_dependency "simplecov"
-  s.add_development_dependency "simplecov-lcov"
 
   s.add_runtime_dependency 'fog-libvirt', '>= 0.6.0'
   s.add_runtime_dependency 'fog-core', '~> 2.1'


### PR DESCRIPTION
Remove the need for downstream packaging to either require or patch
out simplecov from existing files by making it an optional development
dependency.
