### PR TITLE
Cpu mode host-passthrough allows topology and features

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -968,6 +968,11 @@ module VagrantPlugins
       def validate(machine)
         errors = _detected_errors
 
+        # technically this shouldn't occur, but ensure that if somehow it does, it gets rejected.
+        if @cpu_mode == 'host-passthrough' && @cpu_model != ''
+          errors << "cannot set cpu_model with cpu_mode of 'host-passthrough'. leave model unset or switch mode."
+        end
+
         # The @uri and @qemu_use_session should not conflict
         uri = _parse_uri(@uri)
         if (uri.scheme.start_with? "qemu") && (uri.path.include? "session")

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -8,29 +8,29 @@
   <cpu mode='<%= @cpu_mode %>'>
 <%- if @cpu_mode != 'host-passthrough' -%>
     <model fallback='<%= @cpu_fallback %>'><% if @cpu_mode == 'custom' %><%= @cpu_model %><% end %></model>
-  <%- if @nested -%>
-    <%- if @cpu_features.select{|x| x[:name] == 'vmx'}.empty? -%>
+<%- end -%>
+<%- if @nested -%>
+  <%- if @cpu_features.select{|x| x[:name] == 'vmx'}.empty? -%>
     <feature policy='optional' name='vmx'/>
-    <%- end -%>
-    <%- if @cpu_features.select{|x| x[:name] == 'svm'}.empty? -%>
+  <%- end -%>
+  <%- if @cpu_features.select{|x| x[:name] == 'svm'}.empty? -%>
     <feature policy='optional' name='svm'/>
-    <%- end -%>
   <%- end -%>
-  <%- @cpu_features.each do |cpu_feature| -%>
+<%- end -%>
+<%- @cpu_features.each do |cpu_feature| -%>
     <feature name='<%= cpu_feature[:name] %>' policy='<%= cpu_feature[:policy] %>'/>
-  <%- end -%>
-  <%- unless @cpu_topology.empty? -%>
+<%- end -%>
+<%- unless @cpu_topology.empty? -%>
     <%# CPU topology -%>
     <topology sockets='<%= @cpu_topology[:sockets] %>' cores='<%= @cpu_topology[:cores] %>' threads='<%= @cpu_topology[:threads] %>'/>
-    <%- end -%>
-  <%- end -%>
-  <%- if @numa_nodes -%>
+<%- end -%>
+<%- if @numa_nodes -%>
     <numa>
-    <%- @numa_nodes.each_with_index do |node, index| -%>
+  <%- @numa_nodes.each_with_index do |node, index| -%>
       <cell id='<%= index %>' cpus='<%= node[:cpus] %>' memory='<%= node[:memory] %>'<% if node.key?(:memAccess) %> memAccess='<%= node[:memAccess] %>'<% end %>/>
-    <%- end -%>
-    </numa>
   <%- end -%>
+    </numa>
+<%- end -%>
   </cpu>
 <%- if @nodeset -%>
   <numatune>

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -628,6 +628,21 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         assert_invalid
       end
     end
+
+    context 'with cpu_mode and cpu_model defined' do
+      it 'should discard model if mode is passthrough' do
+        subject.cpu_mode = 'host-passthrough'
+        subject.cpu_model = 'qemu64'
+        assert_valid
+        expect(subject.cpu_model).to be_empty
+      end
+
+      it 'should allow custom mode with model' do
+        subject.cpu_mode = 'custom'
+        subject.cpu_model = 'qemu64'
+        assert_valid
+      end
+    end
   end
 
   describe '#merge' do

--- a/spec/unit/templates/domain_cpu_mode_passthrough.xml
+++ b/spec/unit/templates/domain_cpu_mode_passthrough.xml
@@ -1,0 +1,39 @@
+<domain type='' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name></name>
+  <title></title>
+  <description></description>
+  <uuid></uuid>
+  <memory></memory>
+  <vcpu>1</vcpu>
+  <cpu mode='host-passthrough'>
+    <feature policy='optional' name='vmx'/>
+    <feature policy='optional' name='svm'/>
+    <topology sockets='1' cores='2' threads='1'/>
+  </cpu>
+  <os>
+    <type>hvm</type>
+    <kernel></kernel>
+    <initrd></initrd>
+    <cmdline></cmdline>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'>
+  </clock>
+  <devices>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+    <input type='mouse' bus='ps2'/>
+    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <video>
+      <model type='cirrus' vram='9216' heads='1'/>
+    </video>
+  </devices>
+</domain>

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -129,15 +129,31 @@ describe 'templates/domain' do
     end
   end
 
-  context 'when custom cpu model enabled' do
-    before do
-      domain.cpu_mode = 'custom'
-      domain.cpu_model = 'SandyBridge'
+  context 'when cpu mode is set' do
+    context 'to host-passthrough' do
+      before do
+        domain.cpu_mode = 'host-passthrough'
+        domain.cpu_model = 'SandyBridge'
+        domain.cputopology :sockets => '1', :cores => '2', :threads => '1'
+        domain.nested = true
+      end
+      let(:test_file) { 'domain_cpu_mode_passthrough.xml' }
+      it 'should allow features and topology and ignore model' do
+        domain.finalize!
+        expect(domain.to_xml('domain')).to eq xml_expected
+      end
     end
-    let(:test_file) { 'domain_custom_cpu_model.xml' }
-    it 'renders template' do
-      domain.finalize!
-      expect(domain.to_xml('domain')).to eq xml_expected
+
+    context 'to custom and model is set' do
+      before do
+        domain.cpu_mode = 'custom'
+        domain.cpu_model = 'SandyBridge'
+      end
+      let(:test_file) { 'domain_custom_cpu_model.xml' }
+      it 'renders template' do
+        domain.finalize!
+        expect(domain.to_xml('domain')).to eq xml_expected
+      end
     end
   end
 


### PR DESCRIPTION
When cpu mode was set to host-passthrough the template would skip
setting all other settings for the cpu, while it appears from the
documentation that it supports use of feature elements, and testing
confirms that it also supports the topology element.

https://libvirt.org/formatdomain.html#cpu-model-and-topology

Fixes: #975
