### PR TITLE
Reduce patching for distro default session use

### DIFF
--- a/spec/unit/action/create_domain_volume_spec.rb
+++ b/spec/unit/action/create_domain_volume_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'support/sharedcontext'
 require 'support/libvirt_context'
 
+require 'fog/libvirt/models/compute/volume'
+
 require 'vagrant-libvirt/action/destroy_domain'
 require 'vagrant-libvirt/util/byte_number'
 
@@ -14,11 +16,9 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume do
   include_context 'unit'
   include_context 'libvirt'
 
-  let(:libvirt_domain) { double('libvirt_domain') }
-  let(:libvirt_client) { double('libvirt_client') }
   let(:volumes) { double('volumes') }
   let(:all) { double('all') }
-  let(:box_volume) { double('box_volume') }
+  let(:box_volume) { instance_double(::Fog::Libvirt::Compute::Volume) }
 
   def read_test_file(name)
     File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), name))
@@ -34,6 +34,8 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume do
       allow(all).to receive(:first).and_return(box_volume)
       allow(box_volume).to receive(:id).and_return(nil)
       env[:domain_name] = 'test'
+
+      allow(machine.provider_config).to receive(:qemu_use_session).and_return(false)
 
       allow(logger).to receive(:debug)
     end

--- a/spec/unit/action/wait_till_up_spec.rb
+++ b/spec/unit/action/wait_till_up_spec.rb
@@ -24,6 +24,8 @@ describe VagrantPlugins::ProviderLibvirt::Action::WaitTillUp do
       allow(driver).to receive(:state).and_return(:running)
       # return some information for domain when needed
       allow(domain).to receive(:mac).and_return('9C:D5:53:F1:5A:E7')
+
+      allow(machine.provider_config).to receive(:qemu_use_session).and_return(false)
     end
 
     context 'when machine does not exist' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -318,8 +318,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
             end
           end
 
-          outputs.transform_values! { |v| v.is_a?(Regexp) ? a_string_matching(v) : v }
-          expect(got).to match(outputs)
+          expect(got).to match(outputs.inject({}) { |h, (k, v)| h[k] = v.is_a?(Regexp) ? a_string_matching(v) : v; h })
         end
       end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -171,55 +171,55 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         # ignore LIBVIRT_DEFAULT_URI due to explicit settings
         [ # when uri explicitly set
           {:uri => 'qemu:///system'},
-          {:uri => 'qemu:///system'},
+          {:uri => %r{qemu:///(system|session)}},
           {
-            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu:///custom'},
           }
         ],
         [ # when host explicitly set
           {:host => 'remote'},
-          {:uri => 'qemu://remote/system'},
+          {:uri => %r{qemu://remote/(system|session)}},
           {
-            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu:///custom'},
           }
         ],
         [ # when connect_via_ssh explicitly set
           {:connect_via_ssh => true},
-          {:uri => 'qemu+ssh://localhost/system?no_verify=1'},
+          {:uri => %r{qemu\+ssh://localhost/(system|session)\?no_verify=1}},
           {
-            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu:///custom'},
           }
         ],
         [ # when username explicitly set without ssh
           {:username => 'my_user' },
-          {:uri => 'qemu:///system', :username => 'my_user'},
+          {:uri => %r{qemu:///(system|session)}, :username => 'my_user'},
           {
-            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu:///custom'},
           }
         ],
         [ # when username explicitly set with host but without ssh
           {:username => 'my_user', :host => 'remote'},
-          {:uri => 'qemu://remote/system', :username => 'my_user'},
+          {:uri => %r{qemu://remote/(system|session)}, :username => 'my_user'},
           {
-            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu:///custom'},
           }
         ],
         [ # when password explicitly set
           {:password => 'some_password'},
-          {:uri => 'qemu:///system', :password => 'some_password'},
+          {:uri => %r{qemu:///(system|session)}, :password => 'some_password'},
           {
-            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu://session'},
+            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu:///custom'},
           }
         ],
 
         # driver settings
         [ # set to kvm only
           {:driver => 'kvm'},
-          {:uri => "qemu:///system"},
+          {:uri => %r{qemu:///(system|session)}},
         ],
         [ # set to qemu only
           {:driver => 'qemu'},
-          {:uri => "qemu:///system"},
+          {:uri => %r{qemu:///(system|session)}},
         ],
         [ # set to qemu with session enabled
           {:driver => 'qemu', :qemu_use_session => true},
@@ -241,29 +241,29 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         # connect_via_ssh settings
         [ # enabled
           {:connect_via_ssh => true},
-          {:uri => "qemu+ssh://localhost/system?no_verify=1"},
+          {:uri => %r{qemu\+ssh://localhost/(system|session)\?no_verify=1}},
         ],
         [ # enabled with user
           {:connect_via_ssh => true, :username => 'my_user'},
-          {:uri => "qemu+ssh://my_user@localhost/system?no_verify=1"},
+          {:uri => %r{qemu\+ssh://my_user@localhost/(system|session)\?no_verify=1}},
         ],
         [ # enabled with host
           {:connect_via_ssh => true, :host => 'remote_server'},
-          {:uri => "qemu+ssh://remote_server/system?no_verify=1"},
+          {:uri => %r{qemu\+ssh://remote_server/(system|session)\?no_verify=1}},
         ],
 
         # id_ssh_key_file behaviour
         [ # set should take given value
           {:connect_via_ssh => true, :id_ssh_key_file => '/path/to/keyfile'},
-          {:uri => 'qemu+ssh://localhost/system?no_verify=1&keyfile=/path/to/keyfile', :connect_via_ssh => true},
+          {:uri => %r{qemu\+ssh://localhost/(system|session)\?no_verify=1&keyfile=/path/to/keyfile}, :connect_via_ssh => true},
         ],
         [ # set should infer use of ssh
           {:id_ssh_key_file => '/path/to/keyfile'},
-          {:uri => 'qemu+ssh://localhost/system?no_verify=1&keyfile=/path/to/keyfile', :connect_via_ssh => true},
+          {:uri => %r{qemu\+ssh://localhost/(system|session)\?no_verify=1&keyfile=/path/to/keyfile}, :connect_via_ssh => true},
         ],
         [ # connect_via_ssh should enable default but ignore due to not existing
           {:connect_via_ssh => true},
-          {:uri => 'qemu+ssh://localhost/system?no_verify=1', :id_ssh_key_file => nil},
+          {:uri => %r{qemu\+ssh://localhost/(system|session)\?no_verify=1}, :id_ssh_key_file => nil},
           {
             :setup => ProcWithBinding.new {
               expect(File).to receive(:file?).with("/home/tests/.ssh/id_rsa").and_return(false)
@@ -272,7 +272,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         ],
         [ # connect_via_ssh should enable default and include due to existing
           {:connect_via_ssh => true},
-          {:uri => 'qemu+ssh://localhost/system?no_verify=1&keyfile=/home/tests/.ssh/id_rsa', :id_ssh_key_file => '/home/tests/.ssh/id_rsa'},
+          {:uri => %r{qemu\+ssh://localhost/(system|session)\?no_verify=1&keyfile=/home/tests/\.ssh/id_rsa}, :id_ssh_key_file => '/home/tests/.ssh/id_rsa'},
           {
             :setup => ProcWithBinding.new {
               expect(File).to receive(:file?).with("/home/tests/.ssh/id_rsa").and_return(true)
@@ -283,7 +283,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         # socket behaviour
         [ # set
           {:socket => '/var/run/libvirt/libvirt-sock'},
-          {:uri => "qemu:///system?socket=/var/run/libvirt/libvirt-sock"},
+          {:uri => %r{qemu:///(system|session)\?socket=/var/run/libvirt/libvirt-sock}},
         ],
       ].each do |inputs, outputs, options|
         opts = {}
@@ -317,7 +317,9 @@ describe VagrantPlugins::ProviderLibvirt::Config do
               hash["#{name.to_s[1..-1]}".to_sym] =subject.instance_variable_get(name)
             end
           end
-          expect(got).to eq(outputs)
+
+          outputs.transform_values! { |v| v.is_a?(Regexp) ? a_string_matching(v) : v }
+          expect(got).to match(outputs)
         end
       end
 


### PR DESCRIPTION
Reduce the patching needed should a distro wish to switch the default
from using the system connection by default to using a session
connection by default.

Should now only require patching the default value and a single test
checking the defaults.
