### PR TITLE
Management network keep option

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,8 @@ used by this network are configurable at the provider level.
 * `management_network_domain` - Domain name assigned to the management network.
 * `management_network_mtu` - MTU size of management network. If not specified,
   the Libvirt default (1500) will be used.
+* `management_network_keep` - Starting from version *0.7.0*, *always_destroy* is set to *true* by default for any network.
+  This option allows to change this behaviour for the management network.
 
 You may wonder how vagrant-libvirt knows the IP address a VM received.  Libvirt
 doesn't provide a standard way to find out the IP address of a running domain.

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -62,6 +62,7 @@ module VagrantPlugins
       attr_accessor :management_network_pci_slot
       attr_accessor :management_network_domain
       attr_accessor :management_network_mtu
+      attr_accessor :management_network_keep
 
       # System connection information
       attr_accessor :system_uri
@@ -220,6 +221,7 @@ module VagrantPlugins
         @management_network_pci_bus = UNSET_VALUE
         @management_network_domain = UNSET_VALUE
         @management_network_mtu = UNSET_VALUE
+        @management_network_keep = UNSET_VALUE
 
         # System connection information
         @system_uri      = UNSET_VALUE
@@ -824,6 +826,7 @@ module VagrantPlugins
         @management_network_pci_slot = nil if @management_network_pci_slot == UNSET_VALUE
         @management_network_domain = nil if @management_network_domain == UNSET_VALUE
         @management_network_mtu = nil if @management_network_mtu == UNSET_VALUE
+        @management_network_keep = false if @management_network_keep == UNSET_VALUE
 
         # Domain specific settings.
         @title = '' if @title == UNSET_VALUE

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -32,6 +32,7 @@ module VagrantPlugins
           management_network_pci_slot = env[:machine].provider_config.management_network_pci_slot
           management_network_domain = env[:machine].provider_config.management_network_domain
           management_network_mtu = env[:machine].provider_config.management_network_mtu
+          management_network_keep = env[:machine].provider_config.management_network_keep
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -90,6 +91,10 @@ module VagrantPlugins
           unless management_network_pci_bus.nil? and management_network_pci_slot.nil?
             management_network_options[:bus] = management_network_pci_bus
             management_network_options[:slot] = management_network_pci_slot
+          end
+
+          if management_network_keep
+            management_network_options[:always_destroy] = false
           end
 
           # if there is a box and management network is disabled


### PR DESCRIPTION
Starting from version *0.7.0* (https://newreleases.io/project/github/vagrant-libvirt/vagrant-libvirt/release/0.7.0), *always_destroy* is set to *true* by default for any network.

However, in certain cases, it would be useful to keep the management network, especially when it has been already configured (externally) with Static IP leases.

This option allows to change the *always_destroy* behaviour for the management network.


