### PR TITLE
Change the default amount of video ram to 16MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ end
   values](http://libvirt.org/formatdomain.html#elementsVideo) are "vga",
   "cirrus", "vmvga", "xen", "vbox", or "qxl".
 * `video_vram` - Used by some graphics card types to vary the amount of RAM
-  dedicated to video.  Defaults to 9216.
+  dedicated to video.  Defaults to 16384.
 * `video_accel3d` - Set to `true` to enable 3D acceleration. Defaults to
 `false`.
 * `sound_type` - [Set the virtual sound card](https://libvirt.org/formatdomain.html#elementsSound)

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -879,7 +879,7 @@ module VagrantPlugins
         @graphics_port = -1 if @graphics_port == UNSET_VALUE
         @graphics_ip = '127.0.0.1' if @graphics_ip == UNSET_VALUE
         @video_type = 'cirrus' if @video_type == UNSET_VALUE
-        @video_vram = 9216 if @video_vram == UNSET_VALUE
+        @video_vram = 16384 if @video_vram == UNSET_VALUE
         @video_accel3d = false if @video_accel3d == UNSET_VALUE
         @graphics_gl = @video_accel3d if @graphics_gl == UNSET_VALUE
         @sound_type = nil if @sound_type == UNSET_VALUE

--- a/spec/unit/action/create_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/create_domain_spec/additional_disks_domain.xml
@@ -43,7 +43,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/create_domain_spec/custom_disk_settings.xml
+++ b/spec/unit/action/create_domain_spec/custom_disk_settings.xml
@@ -37,7 +37,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/create_domain_spec/default_domain.xml
+++ b/spec/unit/action/create_domain_spec/default_domain.xml
@@ -37,7 +37,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/create_domain_spec/two_disk_settings.xml
+++ b/spec/unit/action/create_domain_spec/two_disk_settings.xml
@@ -43,7 +43,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/destroy_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/destroy_domain_spec/additional_disks_domain.xml
@@ -41,7 +41,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/destroy_domain_spec/box_multiple_disks.xml
+++ b/spec/unit/action/destroy_domain_spec/box_multiple_disks.xml
@@ -49,7 +49,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_and_custom_disks.xml
+++ b/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_and_custom_disks.xml
@@ -66,7 +66,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_and_custom_disks_no_aliases.xml
+++ b/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_and_custom_disks_no_aliases.xml
@@ -61,7 +61,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_disks.xml
+++ b/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_disks.xml
@@ -61,7 +61,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/destroy_domain_spec/cdrom_domain.xml
+++ b/spec/unit/action/destroy_domain_spec/cdrom_domain.xml
@@ -42,7 +42,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'  />
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/start_domain_spec/clock_timer_rtc.xml
+++ b/spec/unit/action/start_domain_spec/clock_timer_rtc.xml
@@ -32,7 +32,7 @@
     <input bus='ps2' type='mouse'/>
     <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
     <video>
-      <model heads='1' type='cirrus' vram='9216'/>
+      <model heads='1' type='cirrus' vram='16384'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/start_domain_spec/default.xml
+++ b/spec/unit/action/start_domain_spec/default.xml
@@ -30,7 +30,7 @@
     <input bus='ps2' type='mouse'/>
     <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
     <video>
-      <model heads='1' type='cirrus' vram='9216'/>
+      <model heads='1' type='cirrus' vram='16384'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/action/start_domain_spec/default_added_tpm_path.xml
+++ b/spec/unit/action/start_domain_spec/default_added_tpm_path.xml
@@ -30,7 +30,7 @@
     <input bus='ps2' type='mouse'/>
     <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
     <video>
-      <model heads='1' type='cirrus' vram='9216'/>
+      <model heads='1' type='cirrus' vram='16384'/>
     </video>
   <tpm model='tpm-tis'><backend type='passthrough'><device path='/dev/tpm0'/></backend></tpm></devices>
 </domain>

--- a/spec/unit/action/start_domain_spec/default_added_tpm_version.xml
+++ b/spec/unit/action/start_domain_spec/default_added_tpm_version.xml
@@ -30,7 +30,7 @@
     <input bus='ps2' type='mouse'/>
     <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
     <video>
-      <model heads='1' type='cirrus' vram='9216'/>
+      <model heads='1' type='cirrus' vram='16384'/>
     </video>
   <tpm model='tpm-crb'><backend type='emulator' version='2.0'/></tpm></devices>
 </domain>

--- a/spec/unit/action/start_domain_spec/existing.xml
+++ b/spec/unit/action/start_domain_spec/existing.xml
@@ -52,7 +52,7 @@
     </graphics>
     <audio id='1' type='none'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1' primary='yes'/>
+      <model type='cirrus' vram='16384' heads='1' primary='yes'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
     </video>
     <memballoon model='virtio'>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -98,7 +98,7 @@
       <gl enable='yes'/>
     </graphics>
     <video>
-      <model type='cirrus' vram='9216' heads='1'>
+      <model type='cirrus' vram='16384' heads='1'>
 	<acceleration accel3d='yes'/>
       </model>
     </video>

--- a/spec/unit/templates/domain_cpu_mode_passthrough.xml
+++ b/spec/unit/templates/domain_cpu_mode_passthrough.xml
@@ -33,7 +33,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/templates/domain_custom_cpu_model.xml
+++ b/spec/unit/templates/domain_custom_cpu_model.xml
@@ -31,7 +31,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/templates/domain_defaults.xml
+++ b/spec/unit/templates/domain_defaults.xml
@@ -31,7 +31,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
   </devices>
 </domain>

--- a/spec/unit/templates/tpm/version_1.2.xml
+++ b/spec/unit/templates/tpm/version_1.2.xml
@@ -31,7 +31,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
     <tpm model='tpm-tis'>
       <backend type='passthrough'>

--- a/spec/unit/templates/tpm/version_2.0.xml
+++ b/spec/unit/templates/tpm/version_2.0.xml
@@ -31,7 +31,7 @@
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
-      <model type='cirrus' vram='9216' heads='1'/>
+      <model type='cirrus' vram='16384' heads='1'/>
     </video>
     <tpm model='tpm-crb'>
       <backend type='emulator' version='2.0'>


### PR DESCRIPTION
Libvirt did already change the current 9216kb
to 16384kb when starting a domain so in practice this is a no-op.

The libvirt default was changed in 2014 in https://gitlab.com/libvirt/libvirt/-/commit/81ba2298b27aa3257e7b5136f5dd5055076d7d9c