### PR TITLE
Fix static ipv6 ips on private networks

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -216,6 +216,9 @@ module VagrantPlugins
                   gateway: options[:gateway],
                   route: options[:route]
                 }.merge(network)
+                if IPAddr.new(options[:ip]).ipv6?
+                  network[:type] = :static6
+                end
               else
                 network[:type] = :dhcp
               end


### PR DESCRIPTION
When the :ip is ipv6, set the 'static6' type, so that we select the
correct _static6.erb template to configure the interface in the guest.

With the following configuration, ipv6 works out of the box on CentOS 8:

  (1..2).each do |i|
    config.vm.define "node#{i}" do |node|
      node.vm.hostname = "node#{i}"

      node.vm.network :private_network,
        :ip => "fc00::#{i+9}",
        :netmask => "64",
        :libvirt__dhcp_enabled => false,
        :libvirt__forward_mode => "veryisolated",
        :libvirt__network_name => "test"
    end
  end

Fixes: #914 