### PR TITLE
Fix ipv6-only routed networks

### DIFF
--- a/lib/vagrant-libvirt/templates/private_network.xml.erb
+++ b/lib/vagrant-libvirt/templates/private_network.xml.erb
@@ -18,7 +18,7 @@
     <% end %>
   <% end %>
 
-  <% if @network_forward_mode != 'veryisolated' %>
+  <% if @network_forward_mode != 'veryisolated' && !@network_address.nil? %>
     <ip address="<%= @network_address %>" netmask="<%= @network_netmask %>">
     <% if @tftp_root %>
       <tftp root="<%= @tftp_root %>" />


### PR DESCRIPTION
Trying to create a routed network with just ipv6 fails with:
Error occurred while creating new network: Call to virNetworkDefineXML failed: XML error: Missing required address attribute in network 'test'.

Since an ipv4 address should be optional for this scenario, make it so.

This makes the following configuration work:

  config.vm.network :private_network,
    :libvirt__network_name => "test",
    :libvirt__forward_mode => "route",
    :libvirt__dhcp_enabled => false,
    :libvirt__guest_ipv6 => "yes",
    :libvirt__ipv6_address => "fc00::",
    :libvirt__ipv6_prefix => "64"