### PR TITLE
Support overriding fog timeout for testing

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -10,6 +10,8 @@ require 'vagrant-libvirt/util/resolvers'
 module VagrantPlugins
   module ProviderLibvirt
     class Config < Vagrant.plugin('2', :config)
+      DEFAULT_FOG_TIMEOUT = 2
+
       # manually specify URI
       # will supercede most other options if provided
       attr_accessor :uri
@@ -195,6 +197,8 @@ module VagrantPlugins
       # serial consoles
       attr_accessor :serials
 
+      attr_accessor :fog_timeout
+
       def initialize
         @uri               = UNSET_VALUE
         @driver            = UNSET_VALUE
@@ -342,6 +346,8 @@ module VagrantPlugins
         @qemu_use_agent  = UNSET_VALUE
 
         @serials           = []
+
+        @fog_timeout = UNSET_VALUE
       end
 
       def boot(device)
@@ -966,6 +972,8 @@ module VagrantPlugins
         @qemu_use_agent = false if @qemu_use_agent == UNSET_VALUE
 
         @serials = [{:type => 'pty', :source => nil}] if @serials == []
+
+        @fog_timeout = DEFAULT_FOG_TIMEOUT if @fog_timeout == UNSET_VALUE
       end
 
       def validate(machine)
@@ -1036,6 +1044,10 @@ module VagrantPlugins
           if !machine.provider_config.disk_driver_opts.empty?
             machine.ui.warn("Libvirt Provider: volume_cache has no effect when disk_driver is defined.")
           end
+        end
+
+        if @fog_timeout != DEFAULT_FOG_TIMEOUT
+          machine.ui.warn("libvirt configuration option fog_timeout is an advanced option, use of it outside of testing typically means there is another issue")
         end
 
         { 'Libvirt Provider' => errors }

--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -110,7 +110,7 @@ module VagrantPlugins
 
         # Get IP address from dhcp leases table
         begin
-          ip_address = get_ipaddress_from_domain(domain)
+          ip_address = get_ipaddress_from_domain(domain, machine.provider_config.fog_timeout)
         rescue Fog::Errors::TimeoutError
           @logger.info('Timeout at waiting for an ip address for machine %s' % machine.name)
 
@@ -199,9 +199,9 @@ module VagrantPlugins
         ip_address
       end
 
-      def get_ipaddress_from_domain(domain)
+      def get_ipaddress_from_domain(domain, timeout)
         ip_address = nil
-        domain.wait_for(2) do
+        domain.wait_for(timeout) do
           addresses.each_pair do |type, ip|
             # Multiple leases are separated with a newline, return only
             # the most recent address


### PR DESCRIPTION
To facilitate testing, support overriding the fog timeout for scenarios
where it is not possible to ensure a fast enough communication.

Typically this is when it is necessary to test within a nested qemu VM
without acceleration being available.
