### PR TITLE
Allow serials to be disabled

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -341,7 +341,7 @@ module VagrantPlugins
         # Use Qemu agent to get ip address
         @qemu_use_agent  = UNSET_VALUE
 
-        @serials           = []
+        @serials           = UNSET_VALUE
       end
 
       def boot(device)
@@ -701,6 +701,8 @@ module VagrantPlugins
       end
 
       def serial(options={})
+        @serials = [] if @serials == UNSET_VALUE
+
         options = {
           :type => "pty",
           :source => nil,
@@ -965,7 +967,7 @@ module VagrantPlugins
 
         @qemu_use_agent = false if @qemu_use_agent == UNSET_VALUE
 
-        @serials = [{:type => 'pty', :source => nil}] if @serials == []
+        @serials = [{:type => 'pty', :source => nil}] if @serials == UNSET_VALUE
       end
 
       def validate(machine)
@@ -1061,8 +1063,8 @@ module VagrantPlugins
           c.merge!(other.qemu_env) if other.qemu_env != UNSET_VALUE
           result.qemu_env = c
 
-          s = serials.dup
-          s += other.serials
+          s = serials != UNSET_VALUE ? serials.dup : []
+          s += other.serials if other.serials != UNSET_VALUE
           result.serials = s
         end
       end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -1063,9 +1063,11 @@ module VagrantPlugins
           c.merge!(other.qemu_env) if other.qemu_env != UNSET_VALUE
           result.qemu_env = c
 
-          s = serials != UNSET_VALUE ? serials.dup : []
-          s += other.serials if other.serials != UNSET_VALUE
-          result.serials = s
+          if serials != UNSET_VALUE
+            s = serials.dup
+            s += other.serials
+            result.serials = s
+          end
         end
       end
 

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -163,14 +163,16 @@
       <%- end -%>
       <target port='<%= port %>'/>
     </serial>
-    <%- end -%>
+<%- end -%>
+<%- unless @serials.empty? -%>
     <%- console_log = @serials.first -%>
     <console type='<%= console_log[:type] %>'>
       <%- unless console_log[:source].nil? -%>
       <source path='<%= console_log[:source][:path] %>'/>
-<%- end -%>
+      <%- end -%>
       <target port='0'/>
     </console>
+<%- end -%>
 <%- @channels.each do |channel| -%>
     <channel type='<%= channel[:type] %>' >
   <%-if channel[:source_mode] or channel[:source_path] -%>


### PR DESCRIPTION
Facilitate disabling serial devices by allowing for the configuration to
explicitly set serials to an empty array and ignoring adding the default
serial if this is the case.
