### PR TITLE
improvements and fixes for container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 Gemfile.Lock
 pkg
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,17 @@ ENV VAGRANT_HOME /vagrant
 ARG VAGRANT_VERSION
 ENV VAGRANT_VERSION ${VAGRANT_VERSION}
 
+ARG DEFAULT_UID=1000
+ARG DEFAULT_USER=vagrant
+ARG DEFAULT_GROUP=users
+
 RUN set -e \
     && apt-get -y -qq update \
     && curl -sSL -o /tmp/vagrant.deb "https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb" \
     && apt-get install -y /tmp/vagrant.deb \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && useradd -M --uid ${DEFAULT_UID} --gid ${DEFAULT_GROUP} ${DEFAULT_USER} \
     ;
 
 ENV VAGRANT_DEFAULT_PROVIDER=libvirt
@@ -89,12 +94,6 @@ COPY entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["entrypoint.sh"]
 
 FROM build as final
-
-ARG DEFAULT_UID=1000
-ARG DEFAULT_USER=vagrant
-ARG DEFAULT_GROUP=users
-
-RUN useradd -M --uid ${DEFAULT_UID} --gid ${DEFAULT_GROUP} ${DEFAULT_USER}
 
 COPY entrypoint.sh /usr/local/bin/
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,6 @@ fi
 
 export USER=vagrant
 export GROUP=users
-export HOME=/home/${USER}
 
 echo "Starting with UID: ${USER_UID}, GID: ${USER_GID}"
 if [[ "${USER_GID}" != "0" ]]
@@ -92,10 +91,12 @@ then
     if getent passwd ${USER} > /dev/null
     then
         USERCMD=usermod
+        HOMEFLAG=
     else
         USERCMD=useradd
+        HOMEFLAG=-M
     fi
-    ${USERCMD} --shell /bin/bash -u ${USER_UID} -g ${USER_GID} -o -c "" -m ${USER} >/dev/null 2>&1 || exit 3
+    ${USERCMD} --shell /bin/bash -u ${USER_UID} -g ${USER_GID} -o -c "" ${HOMEFLAG} ${USER} >/dev/null 2>&1 || exit 3
 fi
 
 # Perform switching in of boxes, data directory containing machine index
@@ -103,17 +104,17 @@ fi
 for dir in boxes data tmp
 do
     # if the directory hasn't been explicitly mounted over, remove it.
-    if [[ -e "/vagrant/${dir}/.remove" ]]
+    if [[ -e "${VAGRANT_HOME}/${dir}/.remove" ]]
     then
-        rm -rf /vagrant/${dir}
+        rm -rf "${VAGRANT_HOME}"/${dir}
         [[ ! -e ${vdir}/${dir} ]] && gosu ${USER} mkdir ${vdir}/${dir}
-        ln -s ${vdir}/${dir} /vagrant/${dir}
+        ln -s ${vdir}/${dir} "${VAGRANT_HOME}"/${dir}
     fi
 done
 
 # make sure the directories can be written to by vagrant otherwise will
 # get a start up error
-find ${VAGRANT_HOME} -maxdepth 1 ! -exec chown -h ${USER}:${GROUP} {} \+
+find "${VAGRANT_HOME}" -maxdepth 1 ! -exec chown -h ${USER}:${GROUP} {} \+
 
 LIBVIRT_SOCK=/var/run/libvirt/libvirt-sock
 if [[ ! -S ${LIBVIRT_SOCK} ]]


### PR DESCRIPTION
* Added `Dockerfile` to `.dockerignore` so that changes to it don't invalidate the Docker cache.
* Changed base image from `ubuntu:bionic` (last updated 2019) to `debian:stable-slim` as it's stable and slow-moving.
* Added some `-dev` packages to base layer to support building vagrant plugins.
* Allow additional vagrant plugins to be built and installed by specifying the `DEFAULT_OTHER_PLUGINS` build argument; default is `vagrant-mutate` as it aids in being able to convert non-libvirt images to libvirt format. Example: `--build-arg DEFAULT_OTHER_PLUGINS=vagrant-mutate,vagrant-reload,vagrant-scp,vagrant-sshfs`
* Ensure default `vagrant` user (UID 1000) is created in Docker image.
* Some minor fixes in the `entrypoint.sh` script: remove unused variable, fixed incorrect flag being passed to `usermod` command, and use `$VAGRANT_HOME` environment variable rather than hard-coding directory.