### PR TITLE
From docker only output vagrant to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ can help a lot :-)
   * [USB Device Passthrough](#usb-device-passthrough)
   * [USB Redirector Devices](#usb-redirector-devices)
     * [Filter for USB Redirector Devices](#filter-for-usb-redirector-devices)
-* [Random number generator passthrough](#random-number-generator-passthrough)
 * [Serial Console Devices](#serial-console-devices)
+* [Random number generator passthrough](#random-number-generator-passthrough)
 * [Watchdog device](#watchdog-device)
 * [Smartcard device](#smartcard-device)
 * [Hypervisor Features](#hypervisor-features)
@@ -141,7 +141,7 @@ docker pull vagrantlibvirt/vagrant-libvirt:edge
 
 Running the image:
 ```bash
-docker run -it --rm \
+docker run -i --rm \
   -e LIBVIRT_DEFAULT_URI \
   -v /var/run/libvirt/:/var/run/libvirt/ \
   -v ~/.vagrant.d:/.vagrant.d \
@@ -155,7 +155,7 @@ docker run -it --rm \
 It's possible to define a function in `~/.bashrc`, for example:
 ```bash
 vagrant(){
-  docker run -it --rm \
+  docker run -i --rm \
     -e LIBVIRT_DEFAULT_URI \
     -v /var/run/libvirt/:/var/run/libvirt/ \
     -v ~/.vagrant.d:/.vagrant.d \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,12 @@
 
 set -u -o pipefail
 
+# duplicate stdout as fd 3
+exec 3>&1
+# redirect stdout to stderr by default
+exec 1>&2
+
+
 vdir="/.vagrant.d"
 
 if [[ ! -d ${vdir} ]]
@@ -145,7 +151,7 @@ fi
 if [[ $# -eq 0 ]]
 then
     # if no command provided
-    exec gosu ${USER} vagrant help
+    exec gosu ${USER} vagrant help >&3
 fi
 
-exec gosu ${USER} "$@"
+exec gosu ${USER} "$@" >&3


### PR DESCRIPTION
When running the docker container, only output what is returned by
vagrant to stdout, and redirect everything else to stderr to facilitate
anything parsing stdout.

Fixes: #1463
