### PR TITLE
Fix older bundle cloning of dependencies via git

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -81,6 +81,9 @@ jobs:
       run: |
         gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
         gem update bundler --conservative
+    - name: Ensure bundle uses https instead of insecure git
+      run: |
+        git config --global url."https://github.com/".insteadOf git://github.com/
     - name: Handle additional ruby 3.0 setup
       if: ${{ matrix.ruby == '3.0.0' }}
       run: |


### PR DESCRIPTION
Bundler for older ruby versions uses anonymous git to clone ruby
dependencies directly from repos. Ensure these all use https by
configuring git to replace the URL automatically.
