### PR TITLE
Added fix for issue #1472

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -135,7 +135,9 @@ module VagrantPlugins
         end
 
         # TODO: terminated no longer appears to be a valid fog state, remove?
-        return :not_created if domain.nil? || domain.state.to_sym == :terminated
+        return :not_created if domain.nil?
+        return nil if domain.state.nil?
+        return :not_created if domain.state.to_sym == :terminated
 
         state = domain.state.tr('-', '_').to_sym
         if state == :running

--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -136,7 +136,7 @@ module VagrantPlugins
 
         # TODO: terminated no longer appears to be a valid fog state, remove?
         return :not_created if domain.nil?
-        return nil if domain.state.nil?
+        return :unknown if domain.state.nil?
         return :not_created if domain.state.to_sym == :terminated
 
         state = domain.state.tr('-', '_').to_sym

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -35,10 +35,10 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
   # name for the test machines above.
   let(:machine)    { iso_env.machine(:test1, :libvirt) }
   let(:machine2)   { iso_env.machine(:test2, :libvirt) }
-  let(:connection1) { double("connection 1") } 
-  let(:connection2) { double("connection 2") } 
-  let(:system_connection1) { double("system connection 1") } 
-  let(:system_connection2) { double("system connection 2") } 
+  let(:connection1) { double("connection 1") }
+  let(:connection2) { double("connection 2") }
+  let(:system_connection1) { double("system connection 1") }
+  let(:system_connection2) { double("system connection 2") }
 
   # make it easier for distros that want to switch the default value for
   # qemu_use_session to true by ensuring it is explicitly false for tests.
@@ -246,11 +246,20 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
         }
       ],
       [
+        nil,
+        :unknown,
+        {
+          :setup => ProcWithBinding.new do
+            expect(domain).to receive(:state).and_return('unknown').at_least(:once)
+          end,
+        }
+      ],
+      [
         'terminated',
         :not_created,
         {
           :setup => ProcWithBinding.new do
-            expect(domain).to receive(:state).and_return('terminated')
+            expect(domain).to receive(:state).and_return('terminated').at_least(:once)
           end,
         }
       ],
@@ -259,7 +268,7 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
         :inaccessible,
         {
           :setup => ProcWithBinding.new do
-            expect(domain).to receive(:state).and_return('running').twice()
+            expect(domain).to receive(:state).and_return('running').at_least(:once)
             expect(subject).to receive(:get_domain_ipaddress).and_raise(Fog::Errors::TimeoutError)
           end,
         }
@@ -269,7 +278,7 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
         :running,
         {
           :setup => ProcWithBinding.new do
-            expect(domain).to receive(:state).and_return('running').twice()
+            expect(domain).to receive(:state).and_return('running').at_least(:once)
             expect(subject).to receive(:get_domain_ipaddress).and_return('192.168.121.2')
           end,
         }


### PR DESCRIPTION
**Purpose**
Avoid crash caused by power management suspension where `fog` fails to translate domain state `pmsuspended`.

**Issues**
Closes #1472

**Changes**
- Changed the `driver.state()` function so that it does not crash on undefined domain state. Just return `nil` instead. The provider translates `nil` to `:unknown`.
