### PR TITLE
Guest PCI address options for passthrough devices

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -528,10 +528,14 @@ module VagrantPlugins
           pci_domain = options[:domain]
         end
 
-        @pcis.push(domain:    pci_domain,
-                   bus:       options[:bus],
-                   slot:      options[:slot],
-                   function:  options[:function])
+        @pcis.push(domain:          pci_domain,
+                   bus:             options[:bus],
+                   slot:            options[:slot],
+                   function:        options[:function],
+                   guest_domain:    options[:guest_domain],
+                   guest_bus:       options[:guest_bus],
+                   guest_slot:      options[:guest_slot],
+                   guest_function:  options[:guest_function])
       end
 
       def watchdog(options = {})

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -230,15 +230,20 @@
       <backend model='random'>/dev/random</backend>
     </rng>
 <%- end -%>
-<%- @pcis.each do |pci| -%>
+<%-
+  @pcis.each do |pci|
+    pci = pci.reject { |k,v| v.nil? }
+    guest_prefix = "guest_"
+    pci_host = pci.select { |k,_| !k.to_s.start_with?(guest_prefix) }
+    pci_guest = pci.select { |k,_| k.to_s.start_with?(guest_prefix) }
+-%>
     <hostdev mode='subsystem' type='pci' managed='yes'>
       <source>
-	<address <%= pci.select { |k,_| [:domain, :bus, :slot, :function].include? k }
-	  .reject { |k,v| v.nil? }
-	  .map { |k,v| "#{k.to_s}='#{v}'" }
-	  .join(' ')
-	-%>/>
+	<address <%= pci_host.map { |k,v| "#{k.to_s}='#{v}'" } .join(' ') -%>/>
       </source>
+    <%- if !pci_guest.empty? -%>
+      <address type='pci' <%= pci_guest.map { |k,v| "#{k.to_s[guest_prefix.length..-1]}='#{v}'" } .join(' ') -%>/>
+    <%- end -%>
     </hostdev>
 <%- end -%>
 <%- @usbs.each do |usb| -%>

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -239,7 +239,7 @@
 -%>
     <hostdev mode='subsystem' type='pci' managed='yes'>
       <source>
-	<address <%= pci_host.map { |k,v| "#{k.to_s}='#{v}'" } .join(' ') -%>/>
+        <address <%= pci_host.map { |k,v| "#{k.to_s}='#{v}'" } .join(' ') -%>/>
       </source>
     <%- if !pci_guest.empty? -%>
       <address type='pci' <%= pci_guest.map { |k,v| "#{k.to_s[guest_prefix.length..-1]}='#{v}'" } .join(' ') -%>/>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -107,7 +107,7 @@
     </rng>
     <hostdev mode='subsystem' type='pci' managed='yes'>
       <source>
-	<address domain='0x0000' bus='0x06' slot='0x12' function='0x5'/>
+        <address domain='0x0000' bus='0x06' slot='0x12' function='0x5'/>
       </source>
     </hostdev>
     <hostdev mode='subsystem' type='pci' managed='yes'>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -115,6 +115,12 @@
 	<address domain='0x0001' bus='0x03' slot='0x00' function='0x0'/>
       </source>
     </hostdev>
+    <hostdev mode='subsystem' type='pci' managed='yes'>
+      <source>
+	<address domain='0x0002' bus='0x04' slot='0x00' function='0x0'/>
+      </source>
+      <address type='pci' domain='0x0000' bus='0x01' slot='0x01' function='0x0'/>
+    </hostdev>
     <hostdev mode='subsystem' type='usb'>
       <source startupPolicy='mandatory'>
 	<vendor id='0x1234'/>

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -92,6 +92,7 @@ describe 'templates/domain' do
       domain.serial(:type => 'file', :source => {:path => '/var/log/vm_consoles/machine.log'})
       domain.pci(bus: '0x06', slot: '0x12', function: '0x5')
       domain.pci(domain: '0x0001', bus: '0x03', slot: '0x00', function: '0x0')
+      domain.pci(domain: '0x0002', bus: '0x04', slot: '0x00', function: '0x0', guest_domain: '0x0000', guest_bus: '0x01', guest_slot: '0x01', guest_function: '0x0')
       domain.usb_controller(model: 'nec-xhci', ports: '4')
       domain.usb(bus: '1', device: '2', vendor: '0x1234', product: '0xabcd')
       domain.redirdev(type: 'tcp', host: 'localhost', port: '4000')


### PR DESCRIPTION
When assigning a pci passthrough device, the domain, bus, slot and
function parameters pertain to the host device address. Add guest_
flavours of these to allow setting the address of the device in the
guest as well.

Fixes: #1475