### PR TITLE
Ensure provisioner runs when performing a reload

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -213,6 +213,7 @@ module VagrantPlugins
             end
 
             b2.use ConfigValidate
+            b2.use Provision
             b2.use action_halt
             b2.use action_start
           end


### PR DESCRIPTION
with libvirt-vagrant >= 0.8.0 `vagrant reload` no longer executed the provisioner.