### PR TITLE
unrestrict fog-core version to ~> 2

### DIFF
--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-mocks", ">= 3.5"
 
   s.add_runtime_dependency 'fog-libvirt', '>= 0.6.0'
-  s.add_runtime_dependency 'fog-core', '~> 2.1'
+  s.add_runtime_dependency 'fog-core', '~> 2'
   s.add_runtime_dependency 'rexml'
 
   # Make sure to allow use of the same version as Vagrant by being less specific


### PR DESCRIPTION
`fog-core` is currently pinned at `~> 2.1`, which depends on `formatador < 1`. However, `formatador` got recently updated to `1.0` and thus vagrant-libvirt blocks the update of `formatador` in openSUSE Tumbleweed. With this change, we can depend on newer versions of `fog-core`, which allow for `formatador < 2`.