### PR TITLE
Replace tabs with spaces in domain_all_settings.xml

### DIFF
--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -112,12 +112,12 @@
     </hostdev>
     <hostdev mode='subsystem' type='pci' managed='yes'>
       <source>
-	<address domain='0x0001' bus='0x03' slot='0x00' function='0x0'/>
+        <address domain='0x0001' bus='0x03' slot='0x00' function='0x0'/>
       </source>
     </hostdev>
     <hostdev mode='subsystem' type='pci' managed='yes'>
       <source>
-	<address domain='0x0002' bus='0x04' slot='0x00' function='0x0'/>
+        <address domain='0x0002' bus='0x04' slot='0x00' function='0x0'/>
       </source>
       <address type='pci' domain='0x0000' bus='0x01' slot='0x01' function='0x0'/>
     </hostdev>


### PR DESCRIPTION
The xml renderer stopped rendering tabs and now uses spaces instead, which made the test fail.