### PR TITLE
Use instance doubles for driver where possible

### DIFF
--- a/spec/support/libvirt_context.rb
+++ b/spec/support/libvirt_context.rb
@@ -10,6 +10,7 @@ shared_context 'libvirt' do
   let(:libvirt_context) { true                      }
   let(:id)              { 'dummy-vagrant_dummy'     }
   let(:connection)      { double('connection') }
+  let(:driver)          { instance_double(VagrantPlugins::ProviderLibvirt::Driver) }
   let(:domain)          { instance_double(::Fog::Libvirt::Compute::Server) }
   let(:libvirt_client)  { instance_double(::Libvirt::Connect) }
   let(:libvirt_domain)  { instance_double(::Libvirt::Domain) }
@@ -33,5 +34,8 @@ shared_context 'libvirt' do
 
     allow(machine).to receive(:id).and_return(id)
     allow(Log4r::Logger).to receive(:new).and_return(logger)
+
+    allow(machine.provider).to receive('driver').and_return(driver)
+    allow(driver).to receive(:connection).and_return(connection)
   end
 end

--- a/spec/unit/action/cleanup_on_failure_spec.rb
+++ b/spec/unit/action/cleanup_on_failure_spec.rb
@@ -34,8 +34,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::CleanupOnFailure do
   let(:state) { double('state') }
 
   before do
-    allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
-      .to receive(:connection).and_return(connection)
     allow(machine).to receive(:id).and_return('test-machine-id')
     allow(machine).to receive(:state).and_return(state)
 

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -26,10 +26,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
 
   describe '#call' do
     before do
-      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
-        .to receive(:connection).and_return(connection)
-      allow(connection).to receive(:client).and_return(libvirt_client)
-
       allow(connection).to receive(:servers).and_return(servers)
       allow(connection).to receive(:volumes).and_return(volumes)
       allow(volumes).to receive(:all).and_return([domain_volume])

--- a/spec/unit/action/create_domain_volume_spec.rb
+++ b/spec/unit/action/create_domain_volume_spec.rb
@@ -26,9 +26,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume do
 
   describe '#call' do
     before do
-      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
-        .to receive(:connection).and_return(connection)
-      allow(connection).to receive(:client).and_return(libvirt_client)
       allow(connection).to receive(:volumes).and_return(volumes)
       allow(volumes).to receive(:all).and_return(all)
       allow(all).to receive(:first).and_return(box_volume)

--- a/spec/unit/action/handle_box_image_spec.rb
+++ b/spec/unit/action/handle_box_image_spec.rb
@@ -15,7 +15,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
   include_context 'unit'
   include_context 'libvirt'
 
-  let(:libvirt_client) { double('libvirt_client') }
   let(:volumes) { double('volumes') }
   let(:all) { double('all') }
   let(:box_volume) { double('box_volume') }
@@ -54,13 +53,8 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
   byte_number_20G = ByteNumber.new(21474836480)
 
 
-
-
   describe '#call' do
     before do
-      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
-        .to receive(:connection).and_return(connection)
-      allow(connection).to receive(:client).and_return(libvirt_client)
       allow(connection).to receive(:volumes).and_return(volumes)
       allow(volumes).to receive(:all).and_return(all)
       allow(env[:ui]).to receive(:clear_line)

--- a/spec/unit/action/package_domain_spec.rb
+++ b/spec/unit/action/package_domain_spec.rb
@@ -12,8 +12,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::PackageDomain do
   include_context 'libvirt'
   include_context 'temporary_dir'
 
-  let(:libvirt_client) { double('libvirt_client') }
-  let(:libvirt_domain) { double('libvirt_domain') }
   let(:servers) { double('servers') }
   let(:volumes) { double('volumes') }
   let(:metadata_file) { double('file') }
@@ -21,9 +19,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::PackageDomain do
 
   describe '#call' do
     before do
-      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
-        .to receive(:connection).and_return(connection)
-      allow(connection).to receive(:client).and_return(libvirt_client)
       allow(libvirt_client).to receive(:lookup_domain_by_uuid).and_return(libvirt_domain)
 
       allow(connection).to receive(:servers).and_return(servers)

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -13,19 +13,19 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
   include_context 'unit'
   include_context 'libvirt'
 
-  let(:libvirt_domain) { double('libvirt_domain') }
-  let(:libvirt_client) { double('libvirt_client') }
   let(:servers) { double('servers') }
 
   let(:domain_xml) { File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), test_file)) }
   let(:updated_domain_xml) { File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), updated_test_file)) }
 
+  before do
+    allow(driver).to receive(:created?).and_return(true)
+  end
+
   describe '#call' do
     let(:test_file) { 'default.xml' }
 
     before do
-      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
-        .to receive(:connection).and_return(connection)
       allow(connection).to receive(:client).and_return(libvirt_client)
       allow(libvirt_client).to receive(:lookup_domain_by_uuid).and_return(libvirt_domain)
 
@@ -43,7 +43,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
     end
 
     it 'should execute without changing' do
-      allow(libvirt_domain).to receive(:undefine)
+      expect(libvirt_domain).to_not receive(:undefine)
       expect(libvirt_domain).to receive(:autostart=)
       expect(domain).to receive(:start)
 
@@ -54,7 +54,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
       let(:test_file) { 'existing.xml' }
 
       it 'should execute without changing' do
-        allow(libvirt_domain).to receive(:undefine)
+        expect(libvirt_domain).to_not receive(:undefine)
         expect(libvirt_domain).to receive(:autostart=)
         expect(domain).to receive(:start)
 

--- a/spec/unit/action/wait_till_up_spec.rb
+++ b/spec/unit/action/wait_till_up_spec.rb
@@ -18,8 +18,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::WaitTillUp do
 
   describe '#call' do
     before do
-      allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Provider).to receive(:driver)
-        .and_return(driver)
       allow(driver).to receive(:get_domain).and_return(domain)
       allow(driver).to receive(:state).and_return(:running)
       # return some information for domain when needed

--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -14,13 +14,10 @@ describe VagrantPlugins::ProviderLibvirt::Action do
   include_context 'libvirt'
   include_context 'unit'
 
-  let(:libvirt_domain) { double('libvirt_domain') }
   let(:runner) { Vagrant::Action::Runner.new(env) }
   let(:state) { double('state') }
 
   before do
-    allow_any_instance_of(VagrantPlugins::ProviderLibvirt::Driver)
-      .to receive(:connection).and_return(connection)
     allow(machine).to receive(:id).and_return('test-machine-id')
     allow(machine).to receive(:state).and_return(state)
 

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -46,6 +46,8 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
     allow(machine.provider_config).to receive(:qemu_use_session).and_return(false)
     allow(logger).to receive(:info)
     allow(logger).to receive(:debug)
+    allow(machine.provider).to receive('driver').and_call_original
+    allow(machine2.provider).to receive('driver').and_call_original
   end
 
   describe '#connection' do


### PR DESCRIPTION
Switch to instance doubles for driver where possible and reduce usage of
allow_any_instance_of.

Additionally replace some incorrect allows with expects to validate
calls are not made.
