### PR TITLE
Support different rexml location for older vagrant

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'log4r'
-require 'rexml'
+
+begin
+  require 'rexml'
+rescue LoadError
+  require 'rexml/rexml'
+end
 
 module VagrantPlugins
   module ProviderLibvirt


### PR DESCRIPTION
Attempt fallback to loading rexml from rexml/rexml which is the path
used by older vagrant releases.

Fixes #1483
