### PR TITLE
Only call destroy on active networks

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_networks.rb
+++ b/lib/vagrant-libvirt/action/destroy_networks.rb
@@ -68,7 +68,7 @@ module VagrantPlugins
             # Shutdown network first.
             # Undefine network.
             begin
-              libvirt_network.destroy
+              libvirt_network.destroy if libvirt_network.active?
               libvirt_network.undefine
               @logger.info 'Undefined it'
             rescue => e


### PR DESCRIPTION
When removing networks, skip calling destroy to deactivate the network
if it is not currently active. This avoids errors when the host has been
rebooted and vagrant machines are removed as the networks are typically
not automatically started.
