### PR TITLE
Fix allow_existing for disks against newer versions of libvirt.

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -151,9 +151,11 @@ module VagrantPlugins
             rescue Libvirt::Error => e
               # It is hard to believe that e contains just a string
               # and no useful error code!
-              msg = "Call to virStorageVolCreateXML failed: " +
-                    "storage volume '#{disk[:absolute_path]}' exists already"
-              if e.message == msg and disk[:allow_existing]
+              msgs = [disk[:name], disk[:absolute_path]].map do |name|
+                "Call to virStorageVolCreateXML failed: " +
+                "storage volume '#{name}' exists already"
+              end
+              if msgs.include?(e.message) and disk[:allow_existing]
                 disk[:preexisting] = true
               else
                 raise Errors::FogCreateDomainVolumeError,


### PR DESCRIPTION
When running vagrant-libvirt on an up-to-date Debian unstable with
libvirt 8.4.0 the expected error message doesn't contain the full
path any more.