### PR TITLE
Only populate domain_name if not provided

### DIFF
--- a/lib/vagrant-libvirt/action/resolve_disk_settings.rb
+++ b/lib/vagrant-libvirt/action/resolve_disk_settings.rb
@@ -97,13 +97,15 @@ module VagrantPlugins
             # the default storage prefix is typically: /var/lib/libvirt/images/
             storage_prefix = "#{File.dirname(domain_volumes[0][:absolute_path])}/" # steal
           else
-            # Ensure domain name is set for subsequent steps if restarting a machine without a box
-            libvirt_domain = env[:machine].provider.driver.connection.client.lookup_domain_by_uuid(
-              env[:machine].id
-            )
-            domain_xml = libvirt_domain.xml_desc(1)
-            xml_descr = REXML::Document.new(domain_xml)
-            domain_name = xml_descr.elements['domain'].elements['name'].text
+            if domain_name.nil?
+              # Ensure domain name is set for subsequent steps if restarting a machine without a box
+              libvirt_domain = env[:machine].provider.driver.connection.client.lookup_domain_by_uuid(
+                env[:machine].id
+              )
+              domain_xml = libvirt_domain.xml_desc(1)
+              xml_descr = REXML::Document.new(domain_xml)
+              domain_name = xml_descr.elements['domain'].elements['name'].text
+            end
 
             storage_prefix = get_disk_storage_prefix(env[:machine], storage_pool_name)
           end

--- a/spec/unit/action/resolve_disk_settings_spec.rb
+++ b/spec/unit/action/resolve_disk_settings_spec.rb
@@ -356,6 +356,30 @@ describe VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings do
           ]
         )
       end
+
+      context 'when creating using pxe' do
+        before do
+          env[:domain_name] = 'vagrant-test_default'
+        end
+
+        it 'should not query for domain xml' do
+          expect(libvirt_client).to_not receive(:lookup_domain_by_uuid)
+          expect(libvirt_client).to receive(:lookup_storage_pool_by_name).and_return(libvirt_storage_pool)
+          expect(libvirt_storage_pool).to receive(:xml_desc).and_return(storage_pool_xml)
+
+          expect(subject.call(env)).to be_nil
+          expect(env[:disks]).to match(
+            [
+              hash_including(
+                device: 'vda',
+                path: 'vagrant-test_default-vda.qcow2',
+                absolute_path: '/var/lib/libvirt/images/vagrant-test_default-vda.qcow2',
+                pool: 'default'
+              ),
+            ]
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Ensure that when no box is defined for a pxe install, that the domain
name is only populated for subsequent boots and if it is already
provided by a create action, skip attempting to retrieve from a
non-existing domain XML.

Fixes: #1508
