### PR TITLE
Ensure disk controller passed to create domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,12 @@ end
   _target_](http://libvirt.org/formatdomain.html#elementsDisks). NOTE: this
   option applies only to disks associated with a box image. To set the bus type
   on additional disks, see the [Additional Disks](#additional-disks) section.
+* `disk_controller_model` - the controller model to use. Ignored unless either
+  `disk_bus` is set to `scsi` or `disk_device` starts with `sd`, which is a hint
+  to use scsi. Defaults to `virtio-scsi` when it encounters either of the
+  config values for `disk_bus` or `disk_device`. See [libvirt controller models](
+  https://libvirt.org/formatdomain.html#controllers) for other posible values.
+  NOTE: this option applies only to the disks associated with a box image.
 * `disk_device` - The disk device to emulate. Defaults to vda if not
   set, which should be fine for paravirtualized guests, but some fully
   virtualized guests may require hda. NOTE: this option also applies only to

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -44,6 +44,7 @@ module VagrantPlugins
           @nvram = config.nvram
           @machine_type = config.machine_type
           @machine_arch = config.machine_arch
+          @disk_controller_model = config.disk_controller_model
           @disk_driver_opts = config.disk_driver_opts
           @nested = config.nested
           @memory_size = config.memory.to_i * 1024

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -122,8 +122,9 @@
       <target dev='<%= volume[:device] %>' bus='<%= volume[:bus] %>'/>
     </disk>
 <%- end -%>
-<%- if @disk_bus == "scsi" and @disk_controller_model != nil %>
-  <%- for idx in 0..(@domain_volumes.length / 7) do %>
+<%- scsi_volumes = @domain_volumes.select { |x| x[:bus] == 'scsi' } %>
+<%- if !scsi_volumes.empty? and !@disk_controller_model.nil? %>
+  <%- for idx in 0..(scsi_volumes.length / 7) do %>
     <controller type='scsi' model='<%= @disk_controller_model %>' index='<%= idx -%>'/>
   <%- end -%>
 <%- end -%>

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -152,6 +152,24 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
           expect(subject.call(env)).to be_nil
         end
       end
+
+      context 'with disk controller model virtio-scsi' do
+        before do
+          allow(machine.provider_config).to receive(:disk_controller_model).and_return('virtio-scsi')
+          expect(volumes).to receive(:all).with(name: 'vagrant-test_default.img').and_return([domain_volume])
+
+          env[:domain_volumes][0][:bus] = 'scsi'
+        end
+
+        it 'should add a virtio-scsi disk controller' do
+          expect(ui).to receive(:info).with(/ -- Image\(vda\):.*/)
+          expect(servers).to receive(:create) do |args|
+            expect(args[:xml]).to match(/<controller type='scsi' model='virtio-scsi' index='0'\/>/)
+          end.and_return(machine)
+
+          expect(subject.call(env)).to be_nil
+        end
+      end
     end
 
     context 'connection => qemu:///session' do


### PR DESCRIPTION
Previous PR added tests but missed that the disk controller was not
being set correctly in the create domain action by default.

Update config documentation to include option.

Relates-to: #692
Fixes: #633
Fixes: #917
Fixes: #999
Fixes: #1054