### PR TITLE
Cache requests and style plugin version menu

### DIFF
--- a/docs/_assets/js/version_switcher.js.liquid
+++ b/docs/_assets/js/version_switcher.js.liquid
@@ -1,34 +1,49 @@
-changeVersion = function handleVersionedDocs() {
-    {%- comment %}handle development serving site on root{% endcomment %}
-    {%- if site.baseurl.size == 0 %}
-    const basePath = '';
-    {%- else %}
-    const basePath = '/{{ site.github.repository_name }}';
-    {%- endif %}
+{%- comment %}handle development serving site on root{% endcomment %}
+{%- if site.baseurl.size == 0 %}
+const basePath = '';
+{%- else %}
+const basePath = '/{{ site.github.repository_name }}';
+{%- endif %}
 
+{%- if site.repository_nwo != nil %}
+const repository_nwo = '{{ site.repository_nwo }}';
+{%- else %}
+const repository_nwo = '{{ site.github.repository_nwo }}';
+{%- endif %}
+
+const { buildWebStorage, setupCache } = window.AxiosCacheInterceptor;
+const storage = buildWebStorage(sessionStorage, 'axios-cache:');
+const axiosCached = setupCache(axios.create(), { storage });
+
+changeVersion = function handleVersionedDocs(repository_nwo, basePath) {
     async function loadOptions(select) {
-        const defaultBranchPromise = axios.get(
-            'https://api.github.com/repos/{{ site.repository_nwo or site.github.repository_nwo }}',
+        const defaultBranchPromise = axiosCached.get(
+            `https://api.github.com/repos/${repository_nwo}`,
         ).then(res => {
             return res.data.default_branch;
         });
 
-        const versionDir = await axios.get(
-            'https://api.github.com/repos/{{ site.repository_nwo or site.github.repository_nwo }}/git/trees/gh-pages',
+        const statusPredicate = (status) => status === 404 || status > 200 && status < 400
+        const versionDir = await axiosCached.get(
+            `https://api.github.com/repos/${repository_nwo}/git/trees/gh-pages`, {
+                cache: {
+                    cachePredicate: {
+                        statusCheck: statusPredicate
+                    }
+                },
+                validateStatus: statusPredicate
+            }
         ).then(res => {
-            return res.data.tree.find(t => {
-                return t.path.toLowerCase() === 'version';
-            });
-
-        }).catch(e => {
-            if (e.response.status == "404") {
+            if (res.status === 404) {
                 return null;
             }
 
-            throw(e);
+            return res.data.tree.find(t => {
+                return t.path.toLowerCase() === 'version';
+            });
         });
 
-        if (versionDir === undefined || versionDir === null) {
+        if (versionDir === null) {
             var options = [];
         } else {
             res = await axios.get(versionDir.url);
@@ -75,7 +90,7 @@ changeVersion = function handleVersionedDocs() {
         window.location.pathname = targetPath;
     };
 
-    loadOptions(document.getElementById("docs-version"));
+    loadOptions(document.getElementById("plugin-version"));
 
     return changeVersion;
-}();
+}(repository_nwo, basePath);

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,3 +1,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.27.2/axios.min.js"></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/axios-cache-interceptor@0.10.6/dist/index.bundle.js"
+  integrity="sha256-yJbSlTxKmgU+sjlMx48OSjoiUsboy18gXTxUBniEEO0="
+  crossorigin="anonymous"
+></script>
 <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-light.css' | relative_url }}" media="(prefers-color-scheme: light)">
 <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-dark.css' | relative_url }}" media="(prefers-color-scheme: dark)">

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,6 +1,6 @@
-<div class="site-footer">
+<div class="plugin-version-select site-footer">
   Plugin Version:
-  <select id="docs-version" onChange="changeVersion(this)">
+  <select id="plugin-version" onChange="changeVersion(this)">
   </select>
 </div>
 <script src="{% asset "js/version_switcher.js" @path %}"></script>


### PR DESCRIPTION
Add caching support to reduce the number of requests to lookup the
github APIs when generating the plugin version select menu.
