### PR TITLE
Switch plugin version menu to div and style by JS

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -82,3 +82,11 @@ ul#toc li {
   }
 */
 }
+
+.plugin-version-menu-background-fonts-style {
+  @include fs-2;
+  @media (prefers-color-scheme: dark) {
+    background-color: $grey-dk-300;
+    color: $grey-dk-000;
+  }
+}


### PR DESCRIPTION
Replace the select options for the plugin versions with one managed
purely using div tags and style primarily using JavaScript so the entire
menu can be managed from loading from a single script.

Retain a simple base style in the generated css file to facilitate
switching themes.
