### PR TITLE
Adjust to ensure previews load isolated code

### DIFF
--- a/.github/workflows/publish-documentation-preview.yml
+++ b/.github/workflows/publish-documentation-preview.yml
@@ -38,6 +38,7 @@ jobs:
           # avoid look up of API as it doesn't work from within actions without exposing the GITHUB_TOKEN here which is a security risk
           cat <<EOF >> docs/_config.yml
           repository_nwo: vagrant-libvirt/vagrant-libvirt
+          plugin_script_base_path: /${REPO_NAME}/pr-preview/pr-${PR_NUMBER}
           EOF
 
           BUNDLE_GEMFILE=./docs/Gemfile bundle install

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,7 +1,9 @@
 <script src="{% asset "js/site_constants.js" @path %}"></script>
 <div id="plugin-version-menu" class="site-footer"></div>
 {%- assign basePath = "" %}
-{%- if site.baseurl.size != 0 %}
+{%- if site.plugin_script_base_path %}
+{%-   assign basePath = site.plugin_script_base_path %}
+{%- elsif site.baseurl.size != 0 %}
 {%-   assign basePath = "/vagrant-libvirt" %}
 {%- endif %}
 <script src="{{ basePath }}/assets/js/plugin_versions_menu.js"></script>


### PR DESCRIPTION
Ensure previews use the plugin script from the tree instead
of the common one for latest and version releases