### PR TITLE
Allow bridges referenced by libvirt networks

### DIFF
--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -514,7 +514,7 @@ virtual network.
 
 Additionally for public networks, to facilitate validating if the device provided
 can be used, vagrant-libvirt will check both the host interfaces visible to libvirt
-and the existing networks for any existing bridge names. While some name patters are
+and the existing networks for any existing bridge names. While some name patterns are
 automatically excluded as presumed incorrect, if this pattern list is incorrect
 it may be overridden by setting the option:
 * `host_device_exclude_prefixes` - ignore any device starting with any of these

--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -512,6 +512,14 @@ virtual network.
   are listed [here](http://www.libvirt.org/formatdomain.html#elementsNICSDirect).
   Default is 'false'.
 
+Additionally for public networks, to facilitate validating if the device provided
+can be used, vagrant-libvirt will check both the host interfaces visible to libvirt
+and the existing networks for any existing bridge names. While some name patters are
+automatically excluded as presumed incorrect, if this pattern list is incorrect
+it may be overridden by setting the option:
+* `host_device_exclude_prefixes` - ignore any device starting with any of these
+  string patterns as a valid bridge device for a public network definition.
+
 ### Management Network
 
 vagrant-libvirt uses a private network to perform some management operations on

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -1215,8 +1215,9 @@ module VagrantPlugins
         @host_devices ||= begin
           (
             machine.provider.driver.list_host_devices.map { |iface| iface.name } +
-            machine.provider.driver.list_networks.map { |net| net.bridge_name if net.bridge_name }
-          ).uniq do |dev|
+            machine.provider.driver.list_networks.map { |net| net.bridge_name }
+          ).uniq.select do |dev|
+            next if dev.empty?
             dev != "lo" && !@host_device_exclude_prefixes.any? { |exclude| dev.start_with?(exclude) }
           end
         end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -1213,7 +1213,10 @@ module VagrantPlugins
 
       def host_devices(machine)
         @host_devices ||= begin
-          machine.provider.driver.connection.client.list_all_interfaces().map { |iface| iface.name }.uniq.select do |dev|
+          (
+            machine.provider.driver.list_host_devices.map { |iface| iface.name } +
+            machine.provider.driver.list_networks.map { |net| net.bridge_name if net.bridge_name }
+          ).uniq do |dev|
             dev != "lo" && !@host_device_exclude_prefixes.any? { |exclude| dev.start_with?(exclude) }
           end
         end

--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -201,6 +201,14 @@ module VagrantPlugins
         state
       end
 
+      def list_host_devices
+        @connection.client.list_all_interfaces
+      end
+
+      def list_networks
+        @connection.client.list_all_networks
+      end
+
       private
 
       def get_ipaddress_from_system(mac)

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -652,8 +652,8 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         expect(driver).to receive(:list_networks).and_return(libvirt_networks)
         expect(host_devices[0]).to receive(:name).and_return('eth0')
         expect(host_devices[1]).to receive(:name).and_return('virbr0')
-        expect(libvirt_networks[0]).to receive(:bridge_name).and_return('').twice
-        expect(libvirt_networks[1]).to receive(:bridge_name).and_return('virbr0').twice
+        expect(libvirt_networks[0]).to receive(:bridge_name).and_return('')
+        expect(libvirt_networks[1]).to receive(:bridge_name).and_return('virbr0')
       end
 
       it 'should validate use of existing device' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -640,12 +640,20 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         instance_double(Libvirt::Interface),
         instance_double(Libvirt::Interface),
       ] }
+      let(:libvirt_networks) { [
+        instance_double(Libvirt::Network),
+        instance_double(Libvirt::Network),
+      ] }
+      let(:driver) { instance_double(::VagrantPlugins::ProviderLibvirt::Driver) }
       before do
         machine.config.vm.network :public_network, dev: 'eth0', ip: "192.168.2.157"
-        expect(machine).to receive_message_chain('provider.driver.connection.client').and_return(libvirt_client)
-        expect(libvirt_client).to receive(:list_all_interfaces).and_return(host_devices)
+        allow(machine.provider).to receive(:driver).and_return(driver)
+        expect(driver).to receive(:list_host_devices).and_return(host_devices)
+        expect(driver).to receive(:list_networks).and_return(libvirt_networks)
         expect(host_devices[0]).to receive(:name).and_return('eth0')
         expect(host_devices[1]).to receive(:name).and_return('virbr0')
+        expect(libvirt_networks[0]).to receive(:bridge_name).and_return('').twice
+        expect(libvirt_networks[1]).to receive(:bridge_name).and_return('virbr0').twice
       end
 
       it 'should validate use of existing device' do


### PR DESCRIPTION
Permit reference to bridge devices referenced by existing libvirt
networks.

Fixes: #1553
