### PR TITLE
Ensure usernames with at symbols handled

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -782,7 +782,7 @@ module VagrantPlugins
           finalize_id_ssh_key_file
 
           uri += '+ssh://'
-          uri += "#{@username}@" if @username && @username != UNSET_VALUE
+          uri += "#{URI.escape(@username)}@" if @username && @username != UNSET_VALUE
 
           uri += (@host && @host != UNSET_VALUE ? @host : 'localhost')
 

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -782,7 +782,7 @@ module VagrantPlugins
           finalize_id_ssh_key_file
 
           uri += '+ssh://'
-          uri += "#{URI.escape(@username)}@" if @username && @username != UNSET_VALUE
+          uri += "#{URI.encode_www_form_component(@username)}@" if @username && @username != UNSET_VALUE
 
           uri += (@host && @host != UNSET_VALUE ? @host : 'localhost')
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -197,6 +197,13 @@ describe VagrantPlugins::ProviderLibvirt::Config do
             :env => {'LIBVIRT_DEFAULT_URI' => 'qemu:///custom'},
           }
         ],
+        [ # when username explicitly set with @ symbol for domains
+          {:username => 'my_user@my_domain', :host => 'remote'},
+          {:uri => %r{qemu://remote/(system|session)}, :username => 'my_user@my_domain'},
+          {
+            :env => {'LIBVIRT_DEFAULT_URI' => 'qemu:///custom'},
+          }
+        ],
         [ # when username explicitly set with host but without ssh
           {:username => 'my_user', :host => 'remote'},
           {:uri => %r{qemu://remote/(system|session)}, :username => 'my_user'},


### PR DESCRIPTION
Domain usernames may use '@' as part of the username, which requires
escaping to be able to be used within an URI.
