### PR TITLE
Ensure boot order is preserved unless overridden

### DIFF
--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -196,7 +196,9 @@ end
 * `boot` - Change the boot order and enables the boot menu. Possible options
   are "hd", "network", "cdrom". Defaults to "hd" with boot menu disabled. When
   "network" is set without "hd", only all NICs will be tried; see below for
-  more detail.
+  more detail. Defining this in subsequent provider blocks or latter Vagrantfile's
+  (see [Load Order and Merging](https://www.vagrantup.com/docs/vagrantfile)) will
+  result in the definition in the last block being used.
 * `nic_adapter_count` - Defaults to '8'. Only use case for increasing this
   count is for VMs that virtualize switches such as Cumulus Linux. Max value
   for Cumulus Linux VMs is 33.

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -1089,6 +1089,8 @@ module VagrantPlugins
 
       def merge(other)
         super.tap do |result|
+          result.boot_order = other.boot_order != [] ? other.boot_order : boot_order
+
           c = disks.dup
           c += other.disks
           result.disks = c

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -869,5 +869,23 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         )
       end
     end
+
+    context 'boot_order' do
+      it 'should merge' do
+        one.boot 'network'
+
+        subject.finalize!
+        expect(subject.boot_order).to eq(['network'])
+      end
+
+      it 'should have last definition win' do
+        one.boot 'network'
+        two.boot 'hd'
+        two.boot 'cdrom'
+
+        subject.finalize!
+        expect(subject.boot_order).to eq(['hd', 'cdrom'])
+      end
+    end
   end
 end


### PR DESCRIPTION
Add boot_order to the merge function to ensure that provider config
sections will persist the value if defined in earlier blocks. However to
ensure it is possible to override, definitions in latter sections will
replace the earlier definitions, but only if provided.

Fixes: #937
