### PR TITLE
Use function rather than instance variable

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -202,11 +202,11 @@ module VagrantPlugins
       end
 
       def list_host_devices
-        @connection.client.list_all_interfaces
+        connection.client.list_all_interfaces
       end
 
       def list_networks
-        @connection.client.list_all_networks
+        connection.client.list_all_networks
       end
 
       private


### PR DESCRIPTION
Fix a rather dumb error on my part where after checking the code
behaviour and then moving it to the driver, switched to using the
instance variable instead of the function. Because of this, on the first
usage the instance variable may not be populated, while the function
will correctly set up the connection.

Fixes: #1561
