### PR TITLE
Use equivalent-xml to compare xml

### DIFF
--- a/spec/unit/action/start_domain_spec/default_with_different_formatting.xml
+++ b/spec/unit/action/start_domain_spec/default_with_different_formatting.xml
@@ -1,0 +1,37 @@
+<domain xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0' type=''>
+  <name/>
+  <title/>
+  <description/>
+  <uuid/>
+  <memory/>
+  <vcpu>1</vcpu>
+  <cpu check="none" mode="host-model">
+
+
+  </cpu>
+  <os>
+    <type>hvm</type>
+    <kernel/>
+    <initrd/>
+    <cmdline/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'/>
+  <devices>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target port='0'/>
+    </console>
+    <input bus='ps2' type='mouse'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+    <video>
+      <model heads='1' type='cirrus' vram='16384'/>
+    </video>
+  </devices>
+</domain>

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fog-libvirt', '>= 0.6.0'
   s.add_runtime_dependency 'fog-core', '~> 2'
   s.add_runtime_dependency 'rexml'
+  s.add_runtime_dependency 'equivalent-xml'
   s.add_runtime_dependency 'diffy'
 
   # Make sure to allow use of the same version as Vagrant by being less specific


### PR DESCRIPTION
Using diffy alone is insufficient to spot when the XML returned by
libvirt for the changes applied is equivalent but formatted differently.

When libvirt returns slightly differently formatted XML corresponding to
what changes were actually applied, it can result in an error being
assumed to have happened when the update actually worked as expected.

Equivalent-xml handles detecting XML documents as being identical,
therefore switching to using it instead of diffy should produce more
reliable results, while retaining diffy for better formatted diffs
should an issue occur is useful.

Fixes: #1556
