### PR TITLE
Docker image bundle vagrant-libvirt with vagrant

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 Dockerfile
 Gemfile.Lock
 pkg
+
+
+# Vim swap files
+**/.*.sw[po]

--- a/docs/installation.markdown
+++ b/docs/installation.markdown
@@ -110,10 +110,6 @@ vagrant(){
 
 #### Using Podman
 
-Preparing the podman run, only once:
-
-_N.B. This is needed until the entrypoint works for podman to only mount the `~/.vagrant.d` directory_
-
 To run with Podman you need to include
 
 ```bash

--- a/docs/installation.markdown
+++ b/docs/installation.markdown
@@ -112,9 +112,6 @@ vagrant(){
 
 Preparing the podman run, only once:
 
-```bash
-mkdir -p ~/.vagrant.d/{boxes,data,tmp}
-```
 _N.B. This is needed until the entrypoint works for podman to only mount the `~/.vagrant.d` directory_
 
 To run with Podman you need to include
@@ -122,9 +119,6 @@ To run with Podman you need to include
 ```bash
   --entrypoint /bin/bash \
   --security-opt label=disable \
-  -v ~/.vagrant.d/boxes:/vagrant/boxes \
-  -v ~/.vagrant.d/data:/vagrant/data \
-  -v ~/.vagrant.d/tmp:/vagrant/tmp \
 ```
 
 for example:
@@ -134,9 +128,7 @@ vagrant(){
   podman run -it --rm \
     -e LIBVIRT_DEFAULT_URI \
     -v /var/run/libvirt/:/var/run/libvirt/ \
-    -v ~/.vagrant.d/boxes:/vagrant/boxes \
-    -v ~/.vagrant.d/data:/vagrant/data \
-    -v ~/.vagrant.d/tmp:/vagrant/tmp \
+    -v ~/.vagrant.d:/.vagrant.d \
     -v $(realpath "${PWD}"):${PWD} \
     -w $(realpath "${PWD}") \
     --network host \
@@ -147,21 +139,25 @@ vagrant(){
 }
 ```
 
-Running Podman in rootless mode maps the root user inside the container to your host user so we need to bypass [entrypoint.sh](https://github.com/vagrant-libvirt/vagrant-libvirt/blob/main/entrypoint.sh) and mount persistent storage directly to `/vagrant`.
+Running Podman in rootless mode maps the root user inside the container to your host user so we need to bypass [entrypoint.sh](https://github.com/vagrant-libvirt/vagrant-libvirt/blob/main/entrypoint.sh).
 
 #### Extending the container image with additional vagrant plugins
 
 By default the image published and used contains the entire tool chain required
-to reinstall the vagrant-libvirt plugin and it's dependencies, as this is the
-default behaviour of vagrant anytime a new plugin is installed. This means it
-should be possible to use a simple `FROM` statement and ask vagrant to install
-additional plugins.
+to install the vagrant-libvirt plugin and it's dependencies. This allows any plugin
+that requires native extensions to be installed and should be possible to use a
+simple `FROM` statement and ask vagrant to install additional plugins.
 
 ```
 FROM vagrantlibvirt/vagrant-libvirt:latest
 
 RUN vagrant plugin install <plugin>
 ```
+
+Recently the image has now moved to bundling the plugin with the vagrant system plugins
+it should no longer attempt to reinstall each time. Eventually this will become
+the default so additional plugin installs will need to install any dependencies needed
+by them.
 
 ### Ubuntu / Debian
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,19 +104,6 @@ then
     ${USERCMD} --shell /bin/bash -u ${USER_UID} -g ${USER_GID} -o -c "" -m ${USER} >/dev/null 2>&1 || exit 3
 fi
 
-# Perform switching in of boxes, data directory containing machine index
-# and temporary directory from the user mounted environment
-for dir in boxes data tmp
-do
-    # if the directory hasn't been explicitly mounted over, remove it.
-    if [[ -e "/vagrant/${dir}/.remove" ]]
-    then
-        rm -rf /vagrant/${dir}
-        [[ ! -e ${vdir}/${dir} ]] && gosu ${USER} mkdir ${vdir}/${dir}
-        ln -s ${vdir}/${dir} /vagrant/${dir}
-    fi
-done
-
 # make sure the directories can be written to by vagrant otherwise will
 # get a start up error
 find "${VAGRANT_HOME}" -maxdepth 1 ! -exec chown -h ${USER}:${GROUP} {} \+


### PR DESCRIPTION
Move the vagrant-libvirt plugin into being combined directly with
vagrant which both prevents the plugin from being reinstalled by any
subsequent call to `vagrant plugin install <plugin>` and avoids the need
to create and manage symlinks to a /vagrant.d directory for boxes.
