### PR TITLE
Improve handling when run using root user

### DIFF
--- a/docs/installation.markdown
+++ b/docs/installation.markdown
@@ -86,7 +86,7 @@ docker run -i --rm \
   -v /var/run/libvirt/:/var/run/libvirt/ \
   -v ~/.vagrant.d:/.vagrant.d \
   -v $(realpath "${PWD}"):${PWD} \
-  -w $(realpath "${PWD}") \
+  -w "${PWD}" \
   --network host \
   vagrantlibvirt/vagrant-libvirt:latest \
     vagrant status
@@ -100,7 +100,7 @@ vagrant(){
     -v /var/run/libvirt/:/var/run/libvirt/ \
     -v ~/.vagrant.d:/.vagrant.d \
     -v $(realpath "${PWD}"):${PWD} \
-    -w $(realpath "${PWD}") \
+    -w "${PWD}" \
     --network host \
     vagrantlibvirt/vagrant-libvirt:latest \
       vagrant $@
@@ -126,7 +126,7 @@ vagrant(){
     -v /var/run/libvirt/:/var/run/libvirt/ \
     -v ~/.vagrant.d:/.vagrant.d \
     -v $(realpath "${PWD}"):${PWD} \
-    -w $(realpath "${PWD}") \
+    -w "${PWD}" \
     --network host \
     --entrypoint /bin/bash \
     --security-opt label=disable \


### PR DESCRIPTION
Allow for the image to be run with the root user if desired, however
change to requiring setting of a variable to allow it to continue as it
may change ownership of files unexpectedly.

Additionally ensure that the workdir passed to docker matches the target
mount path used, in case the realpath to ${PWD} resolves to be different
to it's value resulting in the starting workdir being somewhere
different to the current path on the host.

Fixes: #1442
