### PR TITLE
Ensure XML diff output if not fully applied

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -435,7 +435,7 @@ module VagrantPlugins
                   if proposed != applied
                     require 'diffy'
 
-                    diff = Diffy::Diff.new(proposed, applied, :context => 3).to_s(:text)
+                    diff = Diffy::Diff.new(proposed.to_str, applied.to_str, :context => 3).to_s(:text)
 
                     error_msg = "Libvirt failed to fully update the domain with the specified XML. Result differs from requested:\n" +
                       "--- requested\n+++ result\n#{diff}\n" +

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -88,7 +88,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
       end
 
       it 'should error and revert the update' do
-        expect(ui).to receive(:error)
+        expect(ui).to receive(:error).with(/\+  <cpu mode="host-passthrough" \/>.*Typically this means there is a bug in the XML being sent, please log an issue/m)
         expect(connection).to receive(:define_domain).and_return(libvirt_domain)
         expect(connection).to receive(:define_domain).with(domain_xml) # undo
         expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml, updated_domain_xml)


### PR DESCRIPTION
Make sure to perform a diff of the actual XML strings and not the object
representations if encountering the bug where the XML failed to be
updated correctly.
