### PR TITLE
Handle setting of graphics options avoiding XML diff

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -210,6 +210,7 @@ module VagrantPlugins
                   descr_changed = true
                   graphics.attributes['autoport'] = config.graphics_autoport
                   if config.graphics_autoport == 'no'
+                    graphics.attributes.delete('autoport')
                     graphics.attributes['port'] = config.graphics_port
                   end
                 end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -896,8 +896,7 @@ module VagrantPlugins
         @initrd = '' if @initrd == UNSET_VALUE
         @dtb = nil if @dtb == UNSET_VALUE
         @graphics_type = 'vnc' if @graphics_type == UNSET_VALUE
-        @graphics_autoport = 'yes' if @graphics_port == UNSET_VALUE
-        @graphics_autoport = 'no' if @graphics_port != UNSET_VALUE
+        @graphics_autoport = @graphics_port == UNSET_VALUE ? 'yes' : nil
         if (@graphics_type != 'vnc' && @graphics_type != 'spice') ||
            @graphics_passwd == UNSET_VALUE
           @graphics_passwd = nil


### PR DESCRIPTION
The attribute autoport="no" will be dropped, therefore ensure that when
graphics_autoport should be disabled, default it to nil, which allows
the existing code to exclude it from the domain template.

Otherwise being set to no will result in an apparent difference due to
the returned XML after update dropping the attribute.
