### PR TITLE
Remove need to explicitly set VAGRANT_HOME before running tests

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -2,7 +2,9 @@
 
 require 'log4r'
 
+require 'vagrant-libvirt/util/erb_template'
 require 'vagrant-libvirt/util/resolvers'
+require 'vagrant-libvirt/util/storage_util'
 
 module VagrantPlugins
   module ProviderLibvirt

--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -8,6 +8,8 @@ rescue LoadError
   require 'rexml/rexml'
 end
 
+require 'vagrant-libvirt/util/domain_flags'
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/lib/vagrant-libvirt/action/handle_box_image.rb
+++ b/lib/vagrant-libvirt/action/handle_box_image.rb
@@ -5,6 +5,8 @@ require 'open3'
 require 'json'
 
 require 'vagrant-libvirt/util/byte_number'
+require 'vagrant-libvirt/util/storage_util'
+require 'vagrant-libvirt/util/ui'
 
 module VagrantPlugins
   module ProviderLibvirt

--- a/lib/vagrant-libvirt/action/package_domain.rb
+++ b/lib/vagrant-libvirt/action/package_domain.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'log4r'
 
+require 'vagrant-libvirt/util/ui'
 require 'vagrant-libvirt/util/unindent'
 
 module VagrantPlugins

--- a/lib/vagrant-libvirt/cap/synced_folder_9p.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_9p.rb
@@ -7,7 +7,9 @@ require 'digest/md5'
 
 require 'vagrant/util/subprocess'
 require 'vagrant/errors'
+
 require 'vagrant-libvirt/errors'
+require 'vagrant-libvirt/util/erb_template'
 
 module VagrantPlugins
   module SyncedFolder9P

--- a/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
@@ -5,9 +5,11 @@ require 'ostruct'
 require 'nokogiri'
 require 'digest/md5'
 
-require 'vagrant/util/subprocess'
 require 'vagrant/errors'
+require 'vagrant/util/subprocess'
+
 require 'vagrant-libvirt/errors'
+require 'vagrant-libvirt/util/erb_template'
 
 module VagrantPlugins
   module SyncedFolderVirtioFS

--- a/spec/unit/plugin_spec.rb
+++ b/spec/unit/plugin_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'support/sharedcontext'
 
+require 'vagrant-libvirt'
 require 'vagrant-libvirt/plugin'
 
 


### PR DESCRIPTION
Ensure that the tests always set VAGRANT_HOME into the environment to
prevent the global plugin manager from trying to load the plugins under
this directory.
