### PR TITLE
Make failure to apply XML domain update non fatal

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -438,16 +438,17 @@ module VagrantPlugins
 
               error_msg = "Libvirt failed to fully update the domain with the specified XML. Result differs from requested:\n" +
                 "--- requested\n+++ result\n#{diff}\n" +
-                "Typically this means there is a bug in the XML being sent, please log an issue"
+                "Typically this means there is a bug in the XML being sent, please log an issue as this will halt machine start in the future."
 
-              env[:ui].error("Updated domain settings did not fully apply, attempting restore to previous definition: #{error_msg}")
-              begin
-                env[:machine].provider.driver.connection.define_domain(descr)
-              rescue Fog::Errors::Error => e
-                env[:ui].error("Failed to restore previous domain definition: #{e.message}")
-              end
+              env[:ui].warn(error_msg)
+              #env[:ui].error("Updated domain settings did not fully apply, attempting restore to previous definition: #{error_msg}")
+              #begin
+              #  env[:machine].provider.driver.connection.define_domain(descr)
+              #rescue Fog::Errors::Error => e
+              #  env[:ui].error("Failed to restore previous domain definition: #{e.message}")
+              #end
 
-              raise Errors::UpdateServerError, error_message: error_msg
+              #raise Errors::UpdateServerError, error_message: error_msg
             end
           end
 

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -88,13 +88,16 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
       end
 
       it 'should error and revert the update' do
-        expect(ui).to receive(:error).with(/\+  <cpu mode="host-passthrough" \/>.*Typically this means there is a bug in the XML being sent, please log an issue/m)
+        expect(ui).to receive(:warn).with(/\+  <cpu mode="host-passthrough" \/>.*Typically this means there is a bug in the XML being sent, please log an issue/m)
         expect(connection).to receive(:define_domain).and_return(libvirt_domain)
-        expect(connection).to receive(:define_domain).with(domain_xml) # undo
+        #expect(connection).to receive(:define_domain).with(domain_xml) # undo
         expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml, updated_domain_xml)
-        expect(domain).to_not receive(:start)
+        #expect(domain).to_not receive(:start)
 
-        expect { subject.call(env) }.to raise_error(VagrantPlugins::ProviderLibvirt::Errors::UpdateServerError)
+        #expect { subject.call(env) }.to raise_error(VagrantPlugins::ProviderLibvirt::Errors::UpdateServerError)
+        expect(libvirt_domain).to receive(:autostart=)
+        expect(domain).to receive(:start)
+        expect(subject.call(env)).to be_nil
       end
     end
 


### PR DESCRIPTION
As this is the first time people may be alerted to an issue applying
changes, given that previously they would be silently discarded, better
to switch to warning the end user rather than blocking the domain start.
This is no worse than the previous position, and allows previous
configurations that were understood to be working, to continue to work
as they are, with hopefully issues logged by users that will allow
more correct XML to be sent before making failure to match the changes
applied fatal.
