### PR TITLE
Handle REXML requires for Ubuntu focal

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,6 +41,12 @@ jobs:
           - ruby: 2.6.6
             vagrant: v2.2.14
             allow_fail: false
+          - ruby: 2.7.2
+            vagrant: v2.2.10
+            allow_fail: false
+            # above block is to ensure compatible with Ubuntu 20.04 vagrant package
+            # although it uses 2.2.10 it is the earliest version that will install on
+            # ruby 2.7 without patching
           - ruby: 3.0.0
             vagrant:
             allow_fail: false

--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -2,11 +2,8 @@
 
 require 'log4r'
 
-begin
-  require 'rexml'
-rescue LoadError
-  require 'rexml/rexml'
-end
+require 'rexml/document'
+require 'rexml/xpath'
 
 require 'vagrant-libvirt/util/domain_flags'
 

--- a/lib/vagrant-libvirt/action/resolve_disk_settings.rb
+++ b/lib/vagrant-libvirt/action/resolve_disk_settings.rb
@@ -2,11 +2,8 @@
 
 require 'log4r'
 
-begin
-  require 'rexml'
-rescue LoadError
-  require 'rexml/rexml'
-end
+require 'rexml/document'
+require 'rexml/xpath'
 
 require 'vagrant-libvirt/util/resolvers'
 

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -3,6 +3,8 @@
 require 'log4r'
 
 require 'rexml/document'
+require 'rexml/formatters/pretty'
+require 'rexml/xpath'
 
 require 'vagrant-libvirt/util/xml'
 

--- a/lib/vagrant-libvirt/util/compat.rb
+++ b/lib/vagrant-libvirt/util/compat.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
       module Compat
         def self.action_hook_args(name, action)
           # handle different number of arguments for action_hook depending on vagrant version
-          if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('2.2.11')
+          if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('2.2.10')
             return name, action
           end
 


### PR DESCRIPTION
The distribution provided vagrant package on Ubuntu 20.04 is version
2.2.6 running on ruby 2.7.2. It appears that the rexml layout is
slightly different and imports different paths than the current code
expects. Add this combination to the unit tests and switch the requires
to load the specific library requirements instead of relying on rexml
loading everything underneath.

Additionally it appears the hook behaviour change appeared earlier that
the understood vagrant release of 2.2.11, and 2.2.6 also requires the
newer hook behaviour.
