### PR TITLE
Fix release workflow default branch detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         id: remote_default_branch
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
           script: |
             repo = await github.repos.get({
                 owner: context.repo.owner,


### PR DESCRIPTION
Ensure that the github script to retrieve the default branch uses string
encoding instead of json. This will strip the unnecessary quotes
preventing matching.
