### PR TITLE
silence the qemu_use_agent warning message

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -234,7 +234,6 @@ module VagrantPlugins
           @logger.debug(response)
           addresses = JSON.parse(response)
         rescue StandardError => e
-          puts "Unable to receive IP via qemu agent: [#{e.message}]"
           @logger.debug("Unable to receive IP via qemu agent: [#{e.message}]")
         end
 


### PR DESCRIPTION
the message fills the screen with expected warnings messages

when we need to debug this problem the message is already logged, so there is no need to show it in the normal case

these are the warning messages that were displayed:

```
==> debian: Waiting for domain to get an IP address...
Unable to receive IP via qemu agent: [Call to virDomainQemuAgentCommand failed: Guest agent is not responding: QEMU guest agent is not connected]
...
==> debian: Waiting for machine to boot. This may take a few minutes...
Unable to receive IP via qemu agent: [Call to virDomainQemuAgentCommand failed: Guest agent is not responding: QEMU guest agent is not connected]
...
```
