### PR TITLE
Use correct url for script download in docs

### DIFF
--- a/docs/_includes/upstream-vagrant-install.html
+++ b/docs/_includes/upstream-vagrant-install.html
@@ -1,7 +1,7 @@
 * Upstream Vagrant Install<br />
 Download and execute the vagrant-libvirt-qa install script (installs latest vagrant by default):
 ```shell
-curl -O https://github.com/vagrant-libvirt/vagrant-libvirt-qa/blob/main/scripts/install.bash
+curl -O https://raw.githubusercontent.com/vagrant-libvirt/vagrant-libvirt-qa/main/scripts/install.bash
 chmod a+x ./install.bash
 ./install.bash
 ```


### PR DESCRIPTION
Reference the correct download URL in the installation documents for
retrieving the install script from the vagrant-libvirt-qa repository.

Fixes: #1601
