### PR TITLE
Mock out synced folders for action tests

### DIFF
--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -16,16 +16,19 @@ describe VagrantPlugins::ProviderLibvirt::Action do
 
   let(:runner) { Vagrant::Action::Runner.new(env) }
   let(:state) { double('state') }
+  let(:synced_folders) { Vagrant::Plugin::V2::SyncedFolder::Collection.new }
 
   before do
     allow(machine).to receive(:id).and_return('test-machine-id')
     allow(machine).to receive(:state).and_return(state)
 
     allow(logger).to receive(:info)
+    allow(logger).to receive(:trace)
     allow(logger).to receive(:debug)
     allow(logger).to receive(:error)
 
     allow(connection.client).to receive(:libversion).and_return(6_002_000)
+    allow(machine).to receive(:synced_folders).and_return(synced_folders)
   end
 
   def allow_action_env_result(action, *responses)
@@ -52,7 +55,7 @@ describe VagrantPlugins::ProviderLibvirt::Action do
       it 'should execute without error' do
         expect(ui).to receive(:info).with('Domain is not created. Please run `vagrant up` first.')
 
-        expect { runner.run(subject.action_halt) }.not_to raise_error
+        expect(runner.run(subject.action_halt)).to match(hash_including({:machine => machine}))
       end
     end
 
@@ -74,7 +77,7 @@ describe VagrantPlugins::ProviderLibvirt::Action do
           expect(ui).to_not receive(:info).with('Domain is not created. Please run `vagrant up` first.')
           expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HaltDomain).to_not receive(:call)
 
-          expect { runner.run(subject.action_halt) }.not_to raise_error
+          expect(runner.run(subject.action_halt)).to match(hash_including({:machine => machine}))
         end
       end
 
@@ -87,7 +90,7 @@ describe VagrantPlugins::ProviderLibvirt::Action do
         it 'should call halt' do
           expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HaltDomain).to receive(:call)
 
-          expect { runner.run(subject.action_halt) }.not_to raise_error
+          expect(runner.run(subject.action_halt)).to match(hash_including({:machine => machine}))
         end
       end
     end

--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'support/sharedcontext'
 
 require 'vagrant/action/runner'
+require 'vagrant/plugin/v2/synced_folder'
 
 require 'vagrant-libvirt/action'
 


### PR DESCRIPTION
Allowing synced folders to be validated as part of the action tests can
cause an excessive amount of time to be consumed due to many calls to
systemd and distro packager to check if nfs is available on the host.
