### PR TITLE
Ensure explicit setting of inputs respected

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -1100,6 +1100,8 @@ module VagrantPlugins
 
           result.disk_driver_opts = disk_driver_opts.merge(other.disk_driver_opts)
 
+          result.inputs = inputs != UNSET_VALUE ? inputs.dup + (other.inputs != UNSET_VALUE ? other.inputs : []) : other.inputs
+
           c = sysinfo == UNSET_VALUE ? {} : sysinfo.dup
           c.merge!(other.sysinfo) { |_k, x, y| x.respond_to?(:each_pair) ? x.merge(y) : x + y } if other.sysinfo != UNSET_VALUE
           result.sysinfo = c

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -580,6 +580,22 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         end
       end
     end
+
+    context '@inputs' do
+      it 'should contain ps/2 mouse by default' do
+        subject.finalize!
+
+        expect(subject.inputs).to eq([{:bus=>"ps2", :type=>"mouse"}])
+      end
+
+      it 'should contain only the specific entries' do
+        subject.input :type => "keyboard", :bus => "usb"
+
+        subject.finalize!
+
+        expect(subject.inputs).to eq([{:bus=>"usb", :type=>"keyboard"}])
+      end
+    end
   end
 
   def assert_invalid
@@ -885,6 +901,23 @@ describe VagrantPlugins::ProviderLibvirt::Config do
 
         subject.finalize!
         expect(subject.boot_order).to eq(['hd', 'cdrom'])
+      end
+    end
+
+    context 'inputs' do
+      it 'should merge' do
+        one.input :type => "tablet", :bus => "usb"
+        two.input :type => "keyboard", :bus => "usb"
+
+        subject.finalize!
+        expect(subject.inputs).to eq([{:type => "tablet", :bus => "usb"}, {:type => "keyboard", :bus => "usb"}])
+      end
+
+      it 'should respect explicit blanking' do
+        one.inputs = []
+
+        subject.finalize!
+        expect(subject.inputs).to eq([])
       end
     end
   end


### PR DESCRIPTION
Make sure that explicit defining of input devices prevents injection of
the default mouse using ps/2 entry.

Fixes: #1092
