### PR TITLE
Emit default for bootmenu to be off

### DIFF
--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -73,9 +73,7 @@
 <%- if @nvram -%>
     <nvram><%= @nvram %></nvram>
 <%- end -%>
-<%- if @boot_order.count >= 1 -%>
-    <bootmenu enable='yes'/>
-<%- end -%>
+    <bootmenu enable='<%= @boot_order.count >= 1 ? "yes" : "no" %>'/>
     <kernel><%= @kernel %></kernel>
     <initrd><%= @initrd %></initrd>
     <cmdline><%= @cmd_line %></cmdline>

--- a/spec/unit/action/create_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/create_domain_spec/additional_disks_domain.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/create_domain_spec/custom_disk_settings.xml
+++ b/spec/unit/action/create_domain_spec/custom_disk_settings.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/create_domain_spec/default_domain.xml
+++ b/spec/unit/action/create_domain_spec/default_domain.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/create_domain_spec/sysinfo.xml
+++ b/spec/unit/action/create_domain_spec/sysinfo.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/create_domain_spec/sysinfo_only_required.xml
+++ b/spec/unit/action/create_domain_spec/sysinfo_only_required.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/create_domain_spec/two_disk_settings.xml
+++ b/spec/unit/action/create_domain_spec/two_disk_settings.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/destroy_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/destroy_domain_spec/additional_disks_domain.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/destroy_domain_spec/box_multiple_disks.xml
+++ b/spec/unit/action/destroy_domain_spec/box_multiple_disks.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_and_custom_disks.xml
+++ b/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_and_custom_disks.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_and_custom_disks_no_aliases.xml
+++ b/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_and_custom_disks_no_aliases.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_disks.xml
+++ b/spec/unit/action/destroy_domain_spec/box_multiple_disks_and_additional_disks.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/destroy_domain_spec/cdrom_domain.xml
+++ b/spec/unit/action/destroy_domain_spec/cdrom_domain.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/resolve_disk_settings_spec/default_domain.xml
+++ b/spec/unit/action/resolve_disk_settings_spec/default_domain.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/resolve_disk_settings_spec/default_no_aliases.xml
+++ b/spec/unit/action/resolve_disk_settings_spec/default_no_aliases.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/resolve_disk_settings_spec/multi_volume_box.xml
+++ b/spec/unit/action/resolve_disk_settings_spec/multi_volume_box.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/resolve_disk_settings_spec/multi_volume_box_additional_and_custom_no_aliases.xml
+++ b/spec/unit/action/resolve_disk_settings_spec/multi_volume_box_additional_and_custom_no_aliases.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/resolve_disk_settings_spec/multi_volume_box_additional_storage.xml
+++ b/spec/unit/action/resolve_disk_settings_spec/multi_volume_box_additional_storage.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/action/set_boot_order_spec/default.xml
+++ b/spec/unit/action/set_boot_order_spec/default.xml
@@ -7,6 +7,7 @@
   <vcpu placement="static">2</vcpu>
   <os>
     <type arch="x86_64" machine="pc-i440fx-6.0">hvm</type>
+    <bootmenu enable="yes"/>
     <boot dev="hd"/>
   </os>
   <features>

--- a/spec/unit/action/set_boot_order_spec/explicit_boot_order.xml
+++ b/spec/unit/action/set_boot_order_spec/explicit_boot_order.xml
@@ -8,6 +8,7 @@
   <vcpu placement="static">2</vcpu>
   <os>
     <type arch="x86_64" machine="pc-i440fx-6.0">hvm</type>
+    <bootmenu enable="yes"/>
     
   </os>
   <features>

--- a/spec/unit/action/start_domain_spec/existing.xml
+++ b/spec/unit/action/start_domain_spec/existing.xml
@@ -7,6 +7,7 @@
   <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <bootmenu enable='no'/>
     <boot dev='hd'/>
   </os>
   <features>

--- a/spec/unit/action/start_domain_spec/existing_added_nvram.xml
+++ b/spec/unit/action/start_domain_spec/existing_added_nvram.xml
@@ -7,6 +7,7 @@
   <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type><loader type='pflash'>/path/to/loader/file</loader><nvram>/path/to/nvram/file</nvram>
+    <bootmenu enable='no'/>
     <boot dev='hd'/>
   </os>
   <features>

--- a/spec/unit/action/start_domain_spec/existing_reordered.xml
+++ b/spec/unit/action/start_domain_spec/existing_reordered.xml
@@ -7,6 +7,7 @@
   <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <bootmenu enable='no'/>
     <boot dev='hd'/>
   </os>
   <features>

--- a/spec/unit/action/start_domain_spec/nvram_domain.xml
+++ b/spec/unit/action/start_domain_spec/nvram_domain.xml
@@ -7,6 +7,7 @@
   <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <bootmenu enable='no'/>
     <loader type='pflash'>/path/to/loader/file</loader>
     <nvram>/path/to/nvram/file</nvram>
     <boot dev='hd'/>

--- a/spec/unit/action/start_domain_spec/nvram_domain_other_setting.xml
+++ b/spec/unit/action/start_domain_spec/nvram_domain_other_setting.xml
@@ -7,6 +7,7 @@
   <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <bootmenu enable='no'/>
     <loader type='pflash'>/path/to/loader/file</loader>
     <nvram>/path/to/nvram/file1</nvram>
     <boot dev='hd'/>

--- a/spec/unit/action/start_domain_spec/nvram_domain_removed.xml
+++ b/spec/unit/action/start_domain_spec/nvram_domain_removed.xml
@@ -7,6 +7,7 @@
   <vcpu placement='static'>2</vcpu>
   <os>
     <type arch='x86_64' machine='pc-i440fx-6.0'>hvm</type>
+    <bootmenu enable='no'/>
     
     
     <boot dev='hd'/>

--- a/spec/unit/templates/domain_cpu_mode_passthrough.xml
+++ b/spec/unit/templates/domain_cpu_mode_passthrough.xml
@@ -12,6 +12,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/templates/domain_custom_cpu_model.xml
+++ b/spec/unit/templates/domain_custom_cpu_model.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/templates/domain_defaults.xml
+++ b/spec/unit/templates/domain_defaults.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/templates/domain_scsi_bus_storage.xml
+++ b/spec/unit/templates/domain_scsi_bus_storage.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/templates/domain_scsi_device_storage.xml
+++ b/spec/unit/templates/domain_scsi_device_storage.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/templates/domain_scsi_multiple_controllers_storage.xml
+++ b/spec/unit/templates/domain_scsi_multiple_controllers_storage.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/templates/tpm/version_1.2.xml
+++ b/spec/unit/templates/tpm/version_1.2.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>

--- a/spec/unit/templates/tpm/version_2.0.xml
+++ b/spec/unit/templates/tpm/version_2.0.xml
@@ -10,6 +10,7 @@
   </cpu>
   <os>
     <type>hvm</type>
+    <bootmenu enable='no'/>
     <kernel></kernel>
     <initrd></initrd>
     <cmdline></cmdline>


### PR DESCRIPTION
Ensure the bootmenu is disabled by default. When not specified it will
default to the hypervisor default behaviour, however this is not
necessarily defined consistently across different distros. Therefore for
a consistent behaviour, simply ensure it is always configured to be off,
unless explicitly required to be enabled when the boot order is
configured.

Fixes: #947
