### PR TITLE
Report graphics port after resolving

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -258,9 +258,11 @@ module VagrantPlugins
           env[:ui].info(" -- Kernel:            #{@kernel}")
           env[:ui].info(" -- Initrd:            #{@initrd}")
           env[:ui].info(" -- Graphics Type:     #{@graphics_type}")
-          env[:ui].info(" -- Graphics Port:     #{@graphics_port}")
-          env[:ui].info(" -- Graphics IP:       #{@graphics_ip}")
-          env[:ui].info(" -- Graphics Password: #{@graphics_passwd.nil? ? 'Not defined' : 'Defined'}")
+          if !@graphics_autoport
+            env[:ui].info(" -- Graphics Port:     #{@graphics_port}")
+            env[:ui].info(" -- Graphics IP:       #{@graphics_ip}")
+            env[:ui].info(" -- Graphics Password: #{@graphics_passwd.nil? ? 'Not defined' : 'Defined'}")
+          end
           env[:ui].info(" -- Video Type:        #{@video_type}")
           env[:ui].info(" -- Video VRAM:        #{@video_vram}")
           env[:ui].info(" -- Video 3D accel:    #{@video_accel3d}")

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -478,6 +478,16 @@ module VagrantPlugins
             raise Errors::DomainStartError, error_message: e.message
           end
 
+          if config.graphics_autoport
+            #libvirt_domain = env[:machine].provider.driver.connection.client.lookup_domain_by_uuid(env[:machine].id)
+            xmldoc = REXML::Document.new(libvirt_domain.xml_desc)
+            graphics = REXML::XPath.first(xmldoc, '/domain/devices/graphics')
+            env[:ui].info(I18n.t('vagrant_libvirt.starting_domain_with_graphics'))
+            env[:ui].info(" -- Graphics Port:     #{graphics.attributes['port']}")
+            env[:ui].info(" -- Graphics IP:       #{graphics.attributes['listen']}")
+            env[:ui].info(" -- Graphics Password: #{config.graphics_passwd.nil? ? 'Not defined' : 'Defined'}")
+          end
+
           @app.call(env)
         end
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -29,6 +29,8 @@ en:
       Updating domain definition due to configuration change
     starting_domain: |-
       Starting domain.
+    starting_domain_with_graphics: |-
+      Domain launching with graphics connection settings...
     terminating: |-
       Removing domain...
     poweroff_domain: |-

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -64,6 +64,22 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
         expect(subject.call(env)).to be_nil
       end
 
+      context 'graphics autoport disabled' do
+        let(:vagrantfile_providerconfig) do
+          <<-EOF
+          libvirt.graphics_port = 5900
+          EOF
+        end
+
+        it 'should emit the graphics port' do
+          expect(servers).to receive(:create).and_return(machine)
+          expect(volumes).to_not receive(:create) # additional disks only
+          expect(ui).to receive(:info).with(' -- Graphics Port:     5900')
+
+          expect(subject.call(env)).to be_nil
+        end
+      end
+
       context 'additional disks' do
         let(:disks) do
           [


### PR DESCRIPTION
Allow libvirt to start the domain before reading back the XML to
retrieve the port assigned automatically for subsequent graphics access
when autoport is enabled.

Fixes: #992
