### PR TITLE
Update development steps

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -110,7 +110,7 @@ jobs:
       run: |
         mkdir -p $HOME/.vagrant.d/
         # tell integration tests to use boxes from the cached location
-        export VAGRANT_HOME=$HOME/.vagrant.d
+        export VAGRANT_LIBVIRT_VAGRANT_HOME=$HOME/.vagrant.d
         # use software emulation due to lack of nested emulation
         cat <<EOF > $HOME/.vagrant.d/Vagrantfile
         Vagrant.configure("2") do |config|

--- a/README.md
+++ b/README.md
@@ -75,20 +75,18 @@ To work on the `vagrant-libvirt` plugin, clone this repository out, and use
 ```shell
 git clone https://github.com/vagrant-libvirt/vagrant-libvirt.git
 cd vagrant-libvirt
+bundle config --local with development
+bundle config --local path 'vendor/bundle'
 bundle install
 ```
 
 Once you have the dependencies, verify the unit tests pass with `rspec`:
 
 ```shell
-export VAGRANT_HOME=$(mktemp -d)
 bundle exec rspec --fail-fast --color --format documentation
 ```
 
 If those pass, you're ready to start developing the plugin.
-
-Setting `VAGRANT_HOME` is to avoid issues with conflicting with other
-plugins/gems or data already present under `~/.vagrant.d`.
 
 Additionally if you wish to test against a specific version of vagrant you
 can control the version using the following before running the tests:
@@ -96,6 +94,13 @@ can control the version using the following before running the tests:
 ```shell
 export VAGRANT_VERSION=v2.2.14
 bundle update && bundle exec rspec --fail-fast --color --format documentation
+```
+
+To run the acceptance tests which involve bringing up VMs and exercising
+various functionality aspects run the following (warning, may have issues if
+distro ruby is newer than supported by vagrant):
+```shell
+bundle exec rspec --fail-fast --color --format documentation --tag acceptance
 ```
 
 **Note** rvm is used by the maintainers to help provide an environment to test
@@ -132,7 +137,7 @@ end
 Now you can use bundler to execute Vagrant:
 
 ```shell
-$ bundle exec vagrant up --provider=libvirt
+bundle exec vagrant up --provider=libvirt
 ```
 
 **IMPORTANT NOTE:** bundle is crucial. You need to use bundled Vagrant.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,10 +41,18 @@ end
 RSpec.configure do |config|
   require 'tmpdir'
 
-  # set VAGRANT_HOME before any thing that requires vagrant is loaded to prevent
-  # the global plugin manager from trying to use the default VAGRANT_HOME.
-  temp_dir = Dir.mktmpdir("rspec-")
-  ENV['VAGRANT_HOME'] = temp_dir
+  if ENV['VAGRANT_LIBVIRT_VAGRANT_HOME'].nil?
+    # set VAGRANT_HOME before any thing that requires vagrant is loaded to prevent
+    # the global plugin manager from trying to use the default VAGRANT_HOME.
+    temp_dir = Dir.mktmpdir("rspec-")
+    ENV['VAGRANT_HOME'] = temp_dir
+  else
+    ENV['VAGRANT_HOME'] = ENV['VAGRANT_LIBVIRT_VAGRANT_HOME']
+  end
+
+  # acceptance tests need the boxes dir to exist to allow symlinking of isolated
+  # environments while allowing the boxes to be cached.
+  FileUtils.mkdir_p(File.join(ENV['VAGRANT_HOME'], 'boxes'))
 
   # ensure that setting of LIBVIRT_DEFAULT_URI in the environment is not picked
   # up directly by tests, instead they must set as needed. Some build envs will

--- a/spec/support/acceptance/isolated_environment.rb
+++ b/spec/support/acceptance/isolated_environment.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
 
           # Execute, logging out the stdout/stderr as we get it
           @logger.info("Executing: #{[command].concat(args).inspect}")
-          Vagrant::Spec::Subprocess.execute(command, *args, **options) do |type, data|
+          Vagrant::Spec::Subprocess.new(command, *args, **options).execute do |type, data|
             @logger.debug("#{type}: #{data}") if type == :stdout || type == :stderr
             yield type, data if block_given?
           end

--- a/spec/support/libvirt_acceptance_context.rb
+++ b/spec/support/libvirt_acceptance_context.rb
@@ -22,7 +22,7 @@ shared_context 'libvirt_acceptance' do
 
   before(:each) do
     # allow execution environment to cache boxes used
-    symlink_boxes(ENV.fetch('VAGRANT_HOME', nil), environment)
+    symlink_boxes(ENV.fetch('VAGRANT_HOME', File.expand_path('~/.vagrant.d')), environment)
   end
 
   after(:each) do


### PR DESCRIPTION
Ensure the development steps can be successfully executed with system
ruby on Fedora 36 to try and help new contributors have an easier
on-ramp.

Support running acceptance tests locally, though note that it may
require rvm if vagrant doesn't support the ruby version used by the
distro.
