### PR TITLE
Select better defaults when graphics type is spice

### DIFF
--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -107,7 +107,7 @@
       <gl enable='yes'/>
     </graphics>
     <video>
-      <model type='cirrus' vram='16384' heads='1'>
+      <model type='virtio' vram='16384' heads='1'>
         <acceleration accel3d='yes'/>
       </model>
     </video>


### PR DESCRIPTION
Reduce the number of other graphics settings that need to be adjusted
once the type has been set to spice by defaulting the remaining options
to ones better suited for spice, in addition to adding the required
channel automatically.

Fixes: #1482
