### PR TITLE
Ignore networks that cannot be used

### DIFF
--- a/spec/unit/util/network_util_spec.rb
+++ b/spec/unit/util/network_util_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'vagrant-libvirt/util/network_util'
+
+describe 'VagrantPlugins::ProviderLibvirt::Util::NetworkUtil' do
+  include_context 'libvirt'
+
+  subject do
+    Class.new {
+      include VagrantPlugins::ProviderLibvirt::Util::NetworkUtil
+
+      def initialize
+        @logger = Log4r::Logger.new('test-logger')
+      end
+    }.new
+  end
+
+  def create_libvirt_network(name, attrs={})
+    default_attrs = {
+      :active? => true,
+      :autostart? => true,
+    }
+    network_xml = File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), name + '.xml'))
+    double = instance_double(::Libvirt::Network)
+    allow(double).to receive(:xml_desc).and_return(network_xml)
+    allow(double).to receive(:name).and_return(name)
+
+    xml = REXML::Document.new(network_xml)
+    bridge = REXML::XPath.first(xml, '/network/bridge')
+    default_attrs[:bridge_name] = !bridge.nil? ? bridge.attributes['name'] : Libvirt::Error.new("network #{name} does not have attribute bridge_name")
+
+    default_attrs.merge(attrs).each do |aname, avalue|
+      if avalue.is_a?(Exception)
+        allow(double).to receive(aname).and_raise(avalue)
+      else
+        allow(double).to receive(aname).and_return(avalue)
+      end
+    end
+
+    double
+  end
+
+  describe '#libvirt_networks' do
+    let(:default_network) { create_libvirt_network('default') }
+    let(:additional_network) { create_libvirt_network('vagrant-libvirt') }
+    let(:hostdev_network) { create_libvirt_network('hostdev', {:active? => false}) }
+
+    it 'should retrieve the list of networks' do
+      expect(logger).to_not receive(:debug)
+      expect(libvirt_client).to receive(:list_all_networks).and_return([default_network, additional_network])
+
+      expect(subject.libvirt_networks(libvirt_client)).to match_array([
+        hash_including(:name => 'default'),
+        hash_including(:name => 'vagrant-libvirt'),
+      ])
+    end
+
+    it 'should handle networks without bridge names' do
+      expect(logger).to receive(:debug).with(/Ignoring hostdev as it does not/)
+      expect(libvirt_client).to receive(:list_all_networks).and_return([default_network, hostdev_network, additional_network])
+
+      expect(subject.libvirt_networks(libvirt_client)).to match_array([
+        hash_including(:name => 'default'),
+        hash_including(:name => 'vagrant-libvirt'),
+      ])
+    end
+  end
+end

--- a/spec/unit/util/network_util_spec/default.xml
+++ b/spec/unit/util/network_util_spec/default.xml
@@ -1,0 +1,16 @@
+<network>
+  <name>default</name>
+  <uuid>39e02111-c66c-4653-86a9-8d20673a4eb1</uuid>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='virbr0' stp='on' delay='0'/>
+  <mac address='74-c3-fd-27-a8-c9'/>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+    </dhcp>
+  </ip>
+</network>

--- a/spec/unit/util/network_util_spec/hostdev.xml
+++ b/spec/unit/util/network_util_spec/hostdev.xml
@@ -1,0 +1,6 @@
+<network>
+  <name>passthrough</name>
+  <forward mode='hostdev' managed='yes'>
+    <pf dev='eth3'/>
+  </forward>
+</network>

--- a/spec/unit/util/network_util_spec/vagrant-libvirt.xml
+++ b/spec/unit/util/network_util_spec/vagrant-libvirt.xml
@@ -1,0 +1,16 @@
+<network connections='1' ipv6='yes'>
+  <name>vagrant-libvirt</name>
+  <uuid>7347e8a9-bd25-409c-b4c3-ebf8744322bc</uuid>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='virbr1' stp='on' delay='0'/>
+  <mac address='52:54:00:d1:56:08'/>
+  <ip address='192.168.121.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.121.1' end='192.168.121.254'/>
+    </dhcp>
+  </ip>
+</network>


### PR DESCRIPTION
If the network does not have a bridge name, ignore it and move onto the
next one. This allows for hostdev networks to exist without breaking.

Includes some rudimentary testing to exercise the lookup code along with
a small bit of refactoring based on the realisation that there is no
need to lookup the network information twice as it is available if the
list_all_networks API is used.

Fixes: #599
