### PR TITLE
Make code available as gem for test installs

### DIFF
--- a/.github/workflows/publish-gem-package.yml
+++ b/.github/workflows/publish-gem-package.yml
@@ -39,6 +39,7 @@ jobs:
         name: gem
     - name: setup credentials
       run: |
+        mkdir ~/.gem
         cat <<EOF > ~/.gem/credentials
         ---
         :github: Bearer ${GITHUB_TOKEN}

--- a/.github/workflows/publish-gem-package.yml
+++ b/.github/workflows/publish-gem-package.yml
@@ -33,6 +33,7 @@ jobs:
   publish-package:
     needs: build-package
     runs-on: ubuntu-22.04
+    if: github.ref == 'refs/heads/main'
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -48,8 +49,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: publish package
       run: |
-        ls -la *.gem 
-        echo "gem push --key github \
+        gem push --key github \
           --host https://rubygems.pkg.github.com/${GITHUB_REPOSITORY_OWNER} \
-          pkg/*.gem"
+          *.gem
 

--- a/.github/workflows/publish-gem-package.yml
+++ b/.github/workflows/publish-gem-package.yml
@@ -48,7 +48,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: publish package
       run: |
+        ls -la pkg/*.gem 
         echo "gem push --key github \
-          --host https://rubygems.pkg.github.com/${GITHUB_OWNER} \
+          --host https://rubygems.pkg.github.com/${GITHUB_REPOSITORY_OWNER} \
           pkg/*.gem"
 

--- a/.github/workflows/publish-gem-package.yml
+++ b/.github/workflows/publish-gem-package.yml
@@ -48,7 +48,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: publish package
       run: |
-        ls -la pkg/*.gem 
+        ls -la *.gem 
         echo "gem push --key github \
           --host https://rubygems.pkg.github.com/${GITHUB_REPOSITORY_OWNER} \
           pkg/*.gem"

--- a/.github/workflows/publish-gem-package.yml
+++ b/.github/workflows/publish-gem-package.yml
@@ -1,0 +1,52 @@
+name: publish-gem
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  packages: write
+
+jobs:
+  build-package:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Install rake & ruby
+      run: |
+        sudo apt-get install -y \
+          rake \
+          ruby \
+          ;
+    - name: Build gem
+      run: |
+        rake build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: gem
+        path: pkg/**.gem
+
+  publish-package:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: gem
+    - name: setup credentials
+      run: |
+        cat <<EOF > ~/.gem/credentials
+        ---
+        :github: Bearer ${GITHUB_TOKEN}
+        EOF
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: publish package
+      run: |
+        echo "gem push --key github \
+          --host https://rubygems.pkg.github.com/${GITHUB_OWNER} \
+          pkg/*.gem"
+

--- a/.github/workflows/publish-gem-package.yml
+++ b/.github/workflows/publish-gem-package.yml
@@ -31,6 +31,7 @@ jobs:
         path: pkg/**.gem
 
   publish-package:
+    needs: build-package
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/download-artifact@v3


### PR DESCRIPTION
Make it possible for others to help validate vagrant-libvirt plugin
changes by building a gem that can be installed from a github packages
repository.
