### PR TITLE
Workflow to notify gem artifact available for PR

### DIFF
--- a/.github/workflows/build-gem-package-notify.yml
+++ b/.github/workflows/build-gem-package-notify.yml
@@ -1,0 +1,57 @@
+name: add gem artifact links
+on:
+  workflow_run:
+    workflows: ['publish-gem']
+    types:
+      - completed
+
+jobs:
+  artifacts-url-comments:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    name: Add artifact links to pull request
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          # This snippet is public-domain, taken from
+          # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
+          script: |
+            async function upsertComment(owner, repo, issue_number, purpose, body) {
+              const {data: comments} = await github.rest.issues.listComments(
+                {owner, repo, issue_number});
+              const marker = `<!-- bot: ${purpose} -->`;
+              body = marker + "\n" + body;
+              const existing = comments.filter((c) => c.body.includes(marker));
+              if (existing.length > 0) {
+                const last = existing[existing.length - 1];
+                core.info(`Updating comment ${last.id}`);
+                await github.rest.issues.updateComment({
+                  owner, repo,
+                  body,
+                  comment_id: last.id,
+                });
+              } else {
+                core.info(`Creating a comment in issue / PR #${issue_number}`);
+                await github.rest.issues.createComment({issue_number, body, owner, repo});
+              }
+            }
+            const {owner, repo} = context.repo;
+            const run_id = ${{github.event.workflow_run.id}};
+            const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
+            if (!pull_requests.length) {
+              return core.error("This workflow doesn't match any pull requests!");
+            }
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
+            if (!artifacts.length) {
+              return core.error(`No artifacts found`);
+            }
+            let body = `Download the latest artifacts for this pull request here:\n`;
+            for (const art of artifacts) {
+              body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+            }
+            core.info("Review thread message body:", body);
+            for (const pr of pull_requests) {
+              await upsertComment(owner, repo, pr.number,
+                "nightly-link", body);
+            }

--- a/.github/workflows/publish-gem-package.yml
+++ b/.github/workflows/publish-gem-package.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   build-package:
     runs-on: ubuntu-22.04
+    outputs:
+      artifact_name: ${{ steps.artifact_name.outputs.artifact_name }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -25,9 +27,15 @@ jobs:
     - name: Build gem
       run: |
         rake build
+    - name: Generate artifact name
+      id: artifact_name
+      run: |
+        cd pkg/
+        GEM_PKG=$(ls -1 *.gem)
+        echo ::set-output name=artifact_name::${GEM_PKG}
     - uses: actions/upload-artifact@v3
       with:
-        name: gem
+        name: ${{ steps.artifact_name.outputs.artifact_name }}
         path: pkg/**.gem
 
   publish-package:
@@ -37,7 +45,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: gem
+        name: ${{ needs.build-package.outputs.artifact_name }}
     - name: setup credentials
       run: |
         mkdir ~/.gem


### PR DESCRIPTION
Adds workflow to publish a link to the gem artifact built for the
current PR. Allows for contributors or those impacted by issues to have
an easier test mechanism.
