### PR TITLE
Avoid setting cpu element on unsupported architectures

### DIFF
--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -5,33 +5,35 @@
   <uuid><%= @uuid %></uuid>
   <memory><%= @memory_size %></memory>
   <vcpu<% if @cpuset %> cpuset='<%= @cpuset %>'<% end %>><%= @cpus %></vcpu>
+<%- unless @cpu_mode.nil? -%>
   <cpu mode='<%= @cpu_mode %>'>
-<%- if @cpu_mode != 'host-passthrough' -%>
+  <%- if @cpu_mode != 'host-passthrough' -%>
     <model fallback='<%= @cpu_fallback %>'><% if @cpu_mode == 'custom' %><%= @cpu_model %><% end %></model>
-<%- end -%>
-<%- if @nested -%>
-  <%- if @cpu_features.select{|x| x[:name] == 'vmx'}.empty? -%>
+  <%- end -%>
+  <%- if @nested -%>
+    <%- if @cpu_features.select{|x| x[:name] == 'vmx'}.empty? -%>
     <feature policy='optional' name='vmx'/>
-  <%- end -%>
-  <%- if @cpu_features.select{|x| x[:name] == 'svm'}.empty? -%>
+    <%- end -%>
+    <%- if @cpu_features.select{|x| x[:name] == 'svm'}.empty? -%>
     <feature policy='optional' name='svm'/>
+    <%- end -%>
   <%- end -%>
-<%- end -%>
-<%- @cpu_features.each do |cpu_feature| -%>
+  <%- @cpu_features.each do |cpu_feature| -%>
     <feature name='<%= cpu_feature[:name] %>' policy='<%= cpu_feature[:policy] %>'/>
-<%- end -%>
-<%- unless @cpu_topology.empty? -%>
+  <%- end -%>
+  <%- unless @cpu_topology.empty? -%>
     <%# CPU topology -%>
     <topology sockets='<%= @cpu_topology[:sockets] %>' cores='<%= @cpu_topology[:cores] %>' threads='<%= @cpu_topology[:threads] %>'/>
-<%- end -%>
-<%- if @numa_nodes -%>
-    <numa>
-  <%- @numa_nodes.each_with_index do |node, index| -%>
-      <cell id='<%= index %>' cpus='<%= node[:cpus] %>' memory='<%= node[:memory] %>'<% if node.key?(:memAccess) %> memAccess='<%= node[:memAccess] %>'<% end %>/>
   <%- end -%>
+  <%- if @numa_nodes -%>
+    <numa>
+    <%- @numa_nodes.each_with_index do |node, index| -%>
+      <cell id='<%= index %>' cpus='<%= node[:cpus] %>' memory='<%= node[:memory] %>'<% if node.key?(:memAccess) %> memAccess='<%= node[:memAccess] %>'<% end %>/>
+    <%- end -%>
     </numa>
-<%- end -%>
+  <%- end -%>
   </cpu>
+<%- end -%>
 <%- if @nodeset -%>
   <numatune>
     <memory nodeset='<%= @nodeset %>'/>

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -163,6 +163,71 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
       end
     end
 
+    context 'cpu' do
+      let(:test_file) { 'existing.xml' }
+      let(:updated_domain_xml) {
+        new_xml = domain_xml.dup
+        new_xml.gsub!(
+          /<cpu .*\/>/,
+          <<-EOF
+          <cpu check='partial' mode='custom'>
+            <model fallback='allow'>Haswell</model>
+            <feature name='vmx' policy='optional'/>
+            <feature name='svm' policy='optional'/>
+          </cpu>
+          EOF
+        )
+        new_xml
+      }
+      let(:vagrantfile_providerconfig) {
+        <<-EOF
+        libvirt.cpu_mode = 'custom'
+        libvirt.cpu_model = 'Haswell'
+        libvirt.nested = true
+        EOF
+      }
+
+      it 'should set cpu related settings when changed' do
+        expect(ui).to_not receive(:warn)
+        expect(connection).to receive(:define_domain).and_return(libvirt_domain)
+        expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml, updated_domain_xml)
+        expect(libvirt_domain).to receive(:autostart=)
+        expect(domain).to receive(:start)
+
+        expect(subject.call(env)).to be_nil
+      end
+
+      let(:domain_xml_no_cpu) {
+        new_xml = domain_xml.dup
+        new_xml.gsub!(/<cpu .*\/>/, '')
+        new_xml
+      }
+      let(:updated_domain_xml_new_cpu) {
+        new_xml = domain_xml.dup
+        new_xml.gsub!(
+          /<cpu .*\/>/,
+          <<-EOF
+          <cpu mode='custom'>
+            <model fallback='allow'>Haswell</model>
+            <feature name='vmx' policy='optional'/>
+            <feature name='svm' policy='optional'/>
+          </cpu>
+          EOF
+        )
+        new_xml
+      }
+
+      it 'should add cpu settings if not already present' do
+        expect(ui).to_not receive(:warn)
+        expect(connection).to receive(:define_domain).and_return(libvirt_domain)
+        expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml_no_cpu, updated_domain_xml_new_cpu)
+        expect(libvirt_domain).to receive(:autostart=)
+        expect(domain).to receive(:start)
+
+        expect(subject.call(env)).to be_nil
+      end
+    end
+
     context 'graphics' do
       context 'autoport not disabled' do
         let(:test_file) { 'existing.xml' }


### PR DESCRIPTION
The CPU element to manage the mode, model, features (including nested),
is only available on some architectures. To allow this plugin to
generate XML valid for other architectures such as RISC-V, the CPU
element needs to be optional and only enabled when the architecture
specified supports it.

Include checks in the validation section to help prevent the setting of
an unsupported architecture with any of the CPU features that require
the CPU element to be available.

Fixes: #1538
