### PR TITLE
Disable graphics autoport attr when using spice

### DIFF
--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -956,7 +956,7 @@ module VagrantPlugins
         @initrd = '' if @initrd == UNSET_VALUE
         @dtb = nil if @dtb == UNSET_VALUE
         @graphics_type = 'vnc' if @graphics_type == UNSET_VALUE
-        @graphics_autoport = @graphics_port == UNSET_VALUE ? 'yes' : nil
+        @graphics_autoport = @graphics_type != 'spice' && @graphics_port == UNSET_VALUE ? 'yes' : nil
         if (@graphics_type != 'vnc' && @graphics_type != 'spice') ||
            @graphics_passwd == UNSET_VALUE
           @graphics_passwd = nil

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -673,7 +673,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
 
         expect(subject.graphics_port).to eq(nil)
         expect(subject.graphics_ip).to eq(nil)
-        expect(subject.graphics_autoport).to eq('yes')
+        expect(subject.graphics_autoport).to eq(nil)
         expect(subject.channels).to match([a_hash_including({:target_name => 'com.redhat.spice.0'})])
       end
     end


### PR DESCRIPTION
If the graphics type is set to spice, then skip setting the autoport as
the attribute will be discarded by libvirt causing it to appear as
though not all of the XML sent to start the domain was accepted.
