### PR TITLE
Unit context improvements

### DIFF
--- a/spec/unit/action/clean_machine_folder_spec.rb
+++ b/spec/unit/action/clean_machine_folder_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt/action/clean_machine_folder'
 

--- a/spec/unit/action/cleanup_on_failure_spec.rb
+++ b/spec/unit/action/cleanup_on_failure_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant/action/runner'
 

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
 
 require 'fog/libvirt/models/compute/volume'
 

--- a/spec/unit/action/create_domain_volume_spec.rb
+++ b/spec/unit/action/create_domain_volume_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
 
 require 'fog/libvirt/models/compute/volume'
 

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
 
 require 'vagrant-libvirt/action/destroy_domain'
 

--- a/spec/unit/action/forward_ports_spec.rb
+++ b/spec/unit/action/forward_ports_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
 
 require 'vagrant-libvirt/errors'
 require 'vagrant-libvirt/action/forward_ports'

--- a/spec/unit/action/halt_domain_spec.rb
+++ b/spec/unit/action/halt_domain_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
+
 require 'vagrant-libvirt/action/halt_domain'
 
 describe VagrantPlugins::ProviderLibvirt::Action::HaltDomain do

--- a/spec/unit/action/handle_box_image_spec.rb
+++ b/spec/unit/action/handle_box_image_spec.rb
@@ -2,8 +2,6 @@
 
 require 'spec_helper'
 require 'json'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
 
 require 'vagrant-libvirt/action/destroy_domain'
 require 'vagrant-libvirt/util/byte_number'

--- a/spec/unit/action/package_domain_spec.rb
+++ b/spec/unit/action/package_domain_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt/action/clean_machine_folder'
 

--- a/spec/unit/action/prepare_nfs_settings_spec.rb
+++ b/spec/unit/action/prepare_nfs_settings_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt/action/prepare_nfs_settings'
 

--- a/spec/unit/action/remove_libvirt_image_spec.rb
+++ b/spec/unit/action/remove_libvirt_image_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt/action/remove_libvirt_image'
 

--- a/spec/unit/action/set_boot_order_spec.rb
+++ b/spec/unit/action/set_boot_order_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
 
 require 'vagrant-libvirt/action/set_boot_order'
 

--- a/spec/unit/action/shutdown_domain_spec.rb
+++ b/spec/unit/action/shutdown_domain_spec.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
+
 require 'vagrant-libvirt/action/shutdown_domain'
 
 describe VagrantPlugins::ProviderLibvirt::Action::StartShutdownTimer do

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
 
 require 'vagrant-libvirt/errors'
 require 'vagrant-libvirt/action/start_domain'

--- a/spec/unit/action/wait_till_up_spec.rb
+++ b/spec/unit/action/wait_till_up_spec.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 require 'vagrant-libvirt/action/wait_till_up'
 require 'vagrant-libvirt/errors'
-
-require 'spec_helper'
-require 'support/sharedcontext'
-require 'support/libvirt_context'
 
 describe VagrantPlugins::ProviderLibvirt::Action::WaitTillUp do
   subject { described_class.new(app, env) }

--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant/action/runner'
 

--- a/spec/unit/cap/mount_9p_spec.rb
+++ b/spec/unit/cap/mount_9p_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt'
 

--- a/spec/unit/cap/synced_folder_9p_spec.rb
+++ b/spec/unit/cap/synced_folder_9p_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt/cap/synced_folder_9p'
 require 'vagrant-libvirt/util/unindent'

--- a/spec/unit/cap/synced_folder_virtiofs_spec.rb
+++ b/spec/unit/cap/synced_folder_virtiofs_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt/cap/synced_folder_virtiofs'
 require 'vagrant-libvirt/util/unindent'

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -3,7 +3,6 @@
 require 'support/binding_proc'
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt/config'
 

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -4,7 +4,6 @@ require 'fog/libvirt/requests/compute/dhcp_leases'
 
 require 'spec_helper'
 require 'support/binding_proc'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt/driver'
 

--- a/spec/unit/plugin_spec.rb
+++ b/spec/unit/plugin_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'support/sharedcontext'
 
 require 'vagrant-libvirt'
 require 'vagrant-libvirt/plugin'

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'support/sharedcontext'
+require 'spec_helper'
 
 require 'vagrant-libvirt/config'
 require 'vagrant-libvirt/util/erb_template'


### PR DESCRIPTION
Move the unit context to a name matching the other contexts. Remove some
unnecessary entries from it that are unused, and remove references to
the old name relying on spec helper to load all contexts.
