### PR TITLE
Use provided ssh port for machine

### DIFF
--- a/spec/unit/action/prepare_nfs_settings_spec.rb
+++ b/spec/unit/action/prepare_nfs_settings_spec.rb
@@ -34,7 +34,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings do
       let(:udp_socket) { double('udp_socket') }
 
       before do
-        allow(::TCPSocket).to receive(:new).and_return(socket)
         allow(socket).to receive(:close)
 
         allow(::UDPSocket).to receive(:open).and_return(udp_socket)
@@ -42,16 +41,34 @@ describe VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings do
       end
 
       it 'should retrieve the guest IP address' do
-        times_called = 0
-        expect(::TCPSocket).to receive(:new) do
-          # force reaching later code
-          times_called += 1
-          times_called < 2 ? raise("StandardError") : socket
-        end
+        expect(::TCPSocket).to receive(:new).with('192.168.1.2', 'ssh').and_raise(StandardError)
+        expect(::TCPSocket).to receive(:new).with('192.168.2.2', 'ssh').and_return(socket)
         expect(machine).to receive(:ssh_info).and_return({:host => '192.168.1.2'})
         expect(communicator).to receive(:execute).and_yield(:stdout, "192.168.1.2\n192.168.2.2")
 
         expect(subject.call(env)).to be_nil
+      end
+
+      it 'should use the ip if connection refused' do
+        expect(::TCPSocket).to receive(:new).with('192.168.1.2', 'ssh').and_raise(Errno::ECONNREFUSED)
+        expect(machine).to receive(:ssh_info).and_return({:host => '192.168.1.2'})
+
+        expect(subject.call(env)).to be_nil
+      end
+
+      it 'should use the ssh port defined' do
+        expect(::TCPSocket).to receive(:new).with('192.168.1.2', '2022').and_return(socket)
+        expect(machine).to receive(:ssh_info).and_return({:host => '192.168.1.2', :port => '2022'})
+
+        expect(subject.call(env)).to be_nil
+      end
+
+      it 'should raise an exception if machine ip not found' do
+        expect(::TCPSocket).to receive(:new).with('192.168.1.2', 'ssh').and_raise(StandardError)
+        expect(machine).to receive(:ssh_info).and_return({:host => '192.168.1.2'})
+        expect(communicator).to receive(:execute).and_yield(:stdout, "192.168.1.2")
+
+        expect { subject.call(env) }.to raise_error(::Vagrant::Errors::NFSNoHostonlyNetwork)
       end
     end
   end


### PR DESCRIPTION
To allow for a different ssh port to be used when connecting to a
machine for NFS setup, use the port provided in the ssh_info hash
with a fallback to the default ssh port.

This may allow NFS mounting into Windows guests once support is added to
vagrant itself to handle NFS installation.

Fixes: #1640
