### PR TITLE
Validate provided synced_folders types for access

### DIFF
--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -688,7 +688,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
   def assert_valid
     subject.finalize!
     errors = subject.validate(machine).values.first
-    expect(errors).to be_empty
+    expect(errors).to be_empty, lambda { "received errors unexpectedly: #{errors}" }
   end
 
   describe '#validate' do
@@ -890,6 +890,87 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         subject.storage :file, :device => :floppy
 
         expect{ subject.finalize! }.to raise_error('Only two floppies may be attached at a time')
+      end
+    end
+
+    context 'with synced_folders' do
+      let(:vagrantfile) do
+        <<-EOF
+        Vagrant.configure('2') do |config|
+          config.vm.box = "vagrant-libvirt/test"
+          config.vm.define :test
+
+          config.vm.synced_folder "/path/to/share", "/srv", type: "#{type}"
+        end
+        EOF
+      end
+      let(:driver) { instance_double(::VagrantPlugins::ProviderLibvirt::Driver) }
+
+      before do
+        allow(machine.provider).to receive(:driver).and_return(driver)
+        allow(driver).to receive_message_chain('connection.client.libversion').and_return(6_002_000)
+      end
+
+      context 'when type is 9p' do
+        let(:type) { "9p" }
+
+        context 'when using qemu:///session' do
+          before do
+            subject.qemu_use_session = true
+          end
+
+          it 'should validate if user can read host path' do
+            expect(File).to receive(:readable?).with('/path/to/share').and_return(true)
+
+            assert_valid
+          end
+
+          it 'should reject if user does not have read access to host path' do
+            expect(File).to receive(:readable?).with('/path/to/share').and_return(false)
+
+            assert_invalid
+          end
+        end
+
+        context 'when using qemu:///system' do
+          before do
+            subject.qemu_use_session = false
+          end
+
+          it 'should validate without checking if user has read access to host path' do
+            expect(File).to_not receive(:readable?)
+
+            assert_valid
+          end
+        end
+      end
+
+      context 'when type is virtiofs' do
+        let(:type) { "virtiofs" }
+
+        context 'when using qemu:///session' do
+          before do
+            subject.qemu_use_session = true
+          end
+
+          it 'should warn that it may not be supported' do
+            expect(ui).to receive(:warn).with(/Note: qemu session may not support virtiofs for synced_folders.*/)
+
+            assert_valid
+          end
+        end
+
+        context 'when using qemu:///system' do
+          before do
+            subject.qemu_use_session = false
+          end
+
+          it 'should not emit a warning message' do
+            expect(ui).to_not receive(:warn)
+
+            assert_valid
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Reject any 9p synced folders that the user does not have read access to
the host path where using qemu sessions. This is because the VM will
launched with the user permissions instead of system permissions and
will fail to come up if trying to add a path that is not readable to be
mounted into the guest.

Additionally flag that virtiofs may not be supported with qemu sessions,
but do not reject in case support is added in the future.

Fixes: #1430
