### PR TITLE
Fix list networks being read-only

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -198,7 +198,13 @@ module VagrantPlugins
       end
 
       def list_all_networks
-        system_connection.list_all_networks.select do |net|
+        client = if @machine.provider_config.qemu_use_session
+                   system_connection
+                else
+                  connection.client
+                end
+
+        client.list_all_networks.select do |net|
           begin
             net.bridge_name
           rescue Libvirt::Error

--- a/spec/acceptance/networking_spec.rb
+++ b/spec/acceptance/networking_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'package domain', acceptance: true do
+  include_context 'libvirt_acceptance'
+
+  before(:all) do
+    expect(Vagrant::Util::Which.which('virsh')).to be_truthy,
+                                                          'networking tests require virsh, please install'
+    expect(system('virsh --connect=qemu:///system uri >/dev/null')).to be_truthy,
+      'network tests require access to qemu:///system context, please ensure test user has correct permissions'
+  end
+
+  after(:each) do
+    assert_execute('vagrant', 'destroy', '--force')
+  end
+
+  before do
+    environment.skeleton('network_no_autostart')
+  end
+
+  context 'when host is rebooted' do
+    before do
+      result = environment.execute('vagrant', 'up')
+      expect(result).to exit_with(0)
+
+      result = environment.execute('vagrant', 'halt')
+      expect(result).to exit_with(0)
+
+      result = environment.execute('virsh', '--connect=qemu:///system', 'net-destroy', 'vagrant-libvirt-test')
+      expect(result).to exit_with(0)
+    end
+
+    it 'should start networking on restart' do
+      status('Test: machine restarts networking')
+      result = environment.execute('vagrant', 'up')
+      expect(result).to exit_with(0)
+    end
+  end
+end

--- a/spec/acceptance/support-skeletons/network_no_autostart/Vagrantfile
+++ b/spec/acceptance/support-skeletons/network_no_autostart/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# frozen_string_literal: true
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "infernix/tinycore"
+  config.ssh.shell = "/bin/sh"
+  config.ssh.insert_key = false
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :libvirt do |libvirt|
+    # try to use a separate network
+    libvirt.management_network_name = 'vagrant-libvirt-test'
+    # aim for a network address not in use, hopefully!
+    libvirt.management_network_address = '192.168.120.0/24'
+  end
+end

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -242,7 +242,8 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
     ] }
 
     before do
-      allow(subject).to receive(:system_connection).and_return(libvirt_client)
+      allow(subject).to receive(:connection).and_return(connection)
+      allow(connection).to receive(:client).and_return(libvirt_client)
       expect(libvirt_client).to receive(:list_all_networks).and_return(libvirt_networks)
     end
 


### PR DESCRIPTION
Change driver list of networks returned to only be read-only when using
qemu session, to allow for VMs using the system context to be able to
restart any networks needed.
