### PR TITLE
Attempt to treat image names as text block

### DIFF
--- a/.github/workflows/docker-meta.yml
+++ b/.github/workflows/docker-meta.yml
@@ -41,7 +41,8 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v4
         with:
-          images: ${{ steps.docker_image_names.outputs.image_names }}
+          images: |
+            ${{ steps.docker_image_names.outputs.image_names }}
           tags: |
             # nightly
             type=schedule


### PR DESCRIPTION
Passing the image names directly to an input variable appears to result
in encoding the newline intended to provide a second name to be built
and have tags appended.
