### PR TITLE
Replace use of secret for org name

### DIFF
--- a/.github/workflows/docker-meta.yml
+++ b/.github/workflows/docker-meta.yml
@@ -35,7 +35,8 @@ jobs:
           echo ghcr.io/${{ github.repository_owner }}/vagrant-libvirt >> ${GITHUB_ENV}
           if [[ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]] && [[ ${{ github.event_name }} != pull_request* ]]
           then
-              echo ${{ secrets.DOCKERHUB_ORGANIZATION }}/vagrant-libvirt >> ${GITHUB_ENV}
+              ORG_NAME=$(echo ${{ github.repository_owner }} | tr -d '-')
+              echo ${ORG_NAME}/vagrant-libvirt >> ${GITHUB_ENV}
           fi
           echo 'EOF' >> ${GITHUB_ENV}
       -


### PR DESCRIPTION
Rely on whether docker username/token is available to publish the image
to docker hub only and discard use of the secret for the org name.

Ensure org name is normalized for dockerhub.
