### PR TITLE
Tweak fedora installation instructions

### DIFF
--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -50,7 +50,9 @@ See [Requirements]({{ '/installation/#requirements' | relative_url }}) for guide
    sudo sed -i \
        '/^\(exclude=.*\)/ {/vagrant-libvirt/! s//\1 vagrant-libvirt/;:a;n;ba;q}; $aexclude=vagrant-libvirt' \
        /etc/dnf/dnf.conf
-   sudo dnf install --assumeyes @virtualization vagrant rubygem-fog-libvirt
+   vagrant_libvirt_deps=($(sudo dnf repoquery --disableexcludes main --depends vagrant-libvirt 2>/dev/null | cut -d' ' -f1))
+   dependencies=$(sudo dnf repoquery --qf "%{name}" ${vagrant_libvirt_deps[@]/#/--whatprovides })
+   sudo dnf install --assumeyes @virtualization ${dependencies}
    ```
 2. Install the latest release of vagrant-libvirt
 ```

--- a/docs/installation.markdown
+++ b/docs/installation.markdown
@@ -222,7 +222,9 @@ sudo dnf remove vagrant-libvirt
 sudo sed -i \
     '/^\(exclude=.*\)/ {/vagrant-libvirt/! s//\1 vagrant-libvirt/;:a;n;ba;q}; $aexclude=vagrant-libvirt' \
     /etc/dnf/dnf.conf
-sudo dnf install --assumeyes @virtualization vagrant rubygem-fog-libvirt
+vagrant_libvirt_deps=($(sudo dnf repoquery --disableexcludes main --depends vagrant-libvirt 2>/dev/null | cut -d' ' -f1))
+dependencies=$(sudo dnf repoquery --qf "%{name}" ${vagrant_libvirt_deps[@]/#/--whatprovides })
+sudo dnf install --assumeyes @virtualization ${dependencies}
 ```
 
 The above `sed` command will add `vagrant-libvirt` to the list of packages to be excluded from being installed.


### PR DESCRIPTION
To ensure dependencies are installed from fedora install
of directly from rubygems, restore retrieval of the
dependencies from repositories, with adjustments now
that vagrant-libvirt is marked as disabled.
