### PR TITLE
Adding SEV support

### DIFF
--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -149,6 +149,14 @@ end
     {:cpus => "2-3", :memory => "4096"}
   ]
   ```
+* `launchsecurity` - Configure Secure Encryption Virtualization for the guest, requires additional components to be configured to work, see [examples](./examples.html#secure-encryption-virtualization). For more information look at [libvirt documentation](https://libvirt.org/kbase/launch_security_sev.html).
+  ```
+  libvirt.launchsecurity :type => 'sev', :cbitpos => 47, :reducedPhysBits => 1, :policy => "0x0003"
+  ```
+* `memtune` - Configure the memtune settings for the guest, primarily exposed to facilitate enabling Secure Encryption Virtualization. Note that when configuring `hard_limit` that the value is in kB as opposed to `libvirt.memory` which is in Mb. Additionally it must be set to be higher than `libvirt.memory`, see [libvirt documentation](https://libvirt.org/kbase/launch_security_sev.html) for details on why.
+  ```
+  libvirt.memtune :type => "hard_limit", :value => 2500000 # Note here the value in kB (not in Mb)
+  ```
 * `loader` - Sets path to custom UEFI loader.
 * `kernel` - To launch the guest with a kernel residing on host filesystems.
   Equivalent to qemu `-kernel`.

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -38,6 +38,7 @@ module VagrantPlugins
           @features_hyperv = config.features_hyperv
           @clock_offset = config.clock_offset
           @clock_timers = config.clock_timers
+          @launchsecurity_data = config.launchsecurity_data
           @shares = config.shares
           @cpu_mode = config.cpu_mode
           @cpu_model = config.cpu_model
@@ -52,6 +53,8 @@ module VagrantPlugins
           @nested = config.nested
           @memory_size = config.memory.to_i * 1024
           @memory_backing = config.memory_backing
+          @memtunes = config.memtunes
+
           @management_network_mac = config.management_network_mac
           @domain_volume_cache = config.volume_cache || 'default'
           @kernel = config.kernel
@@ -240,6 +243,10 @@ module VagrantPlugins
           @memory_backing.each do |backing|
             env[:ui].info(" -- Memory Backing:    #{backing[:name]}: #{backing[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')}")
           end
+
+          @memtunes.each do |type, options|
+            env[:ui].info(" -- Memory Tuning:     #{type}: #{options[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')}, value: #{options[:value]}")
+          end
           unless @shares.nil?
             env[:ui].info(" -- Shares:            #{@shares}")
           end
@@ -309,6 +316,10 @@ module VagrantPlugins
 
           unless @disks.empty?
             env[:ui].info(" -- Disks:         #{_disks_print(@disks)}")
+          end
+
+          if not @launchsecurity_data.nil?
+            env[:ui].info(" -- Launch security:   #{@launchsecurity_data.map { |k, v| "#{k.to_s}=#{v}" }.join(", ")}")
           end
 
           @disks.each do |disk|

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -76,6 +76,7 @@ module VagrantPlugins
             @mac = iface_configuration.fetch(:mac, false)
             @model_type = iface_configuration.fetch(:model_type, @nic_model_type)
             @driver_name = iface_configuration.fetch(:driver_name, false)
+            @driver_iommu = iface_configuration.fetch(:driver_iommu, false )
             @driver_queues = iface_configuration.fetch(:driver_queues, false)
             @device_name = iface_configuration.fetch(:iface_name, false)
             @mtu = iface_configuration.fetch(:mtu, nil)
@@ -84,12 +85,15 @@ module VagrantPlugins
             template_name = 'interface'
             @type = nil
             @udp_tunnel = nil
+
+            @logger.debug("Interface configuration: #{iface_configuration}")
             # Configuration for public interfaces which use the macvtap driver
             if iface_configuration[:iface_type] == :public_network
               @device = iface_configuration.fetch(:dev, 'eth0')
               @mode = iface_configuration.fetch(:mode, 'bridge')
               @type = iface_configuration.fetch(:type, 'direct')
               @model_type = iface_configuration.fetch(:model_type, @nic_model_type)
+              @driver_iommu = iface_configuration.fetch(:driver_iommu, false )
               @driver_name = iface_configuration.fetch(:driver_name, false)
               @driver_queues = iface_configuration.fetch(:driver_queues, false)
               @portgroup = iface_configuration.fetch(:portgroup, nil)
@@ -124,13 +128,14 @@ module VagrantPlugins
               }
               @tunnel_type = iface_configuration.fetch(:model_type, @nic_model_type)
               @driver_name = iface_configuration.fetch(:driver_name, false)
+              @driver_iommu = iface_configuration.fetch(:driver_iommu, false )
               @driver_queues = iface_configuration.fetch(:driver_queues, false)
               template_name = 'tunnel_interface'
               @logger.info("Setting up #{@type} tunnel interface using  #{@tunnel_ip} port #{@tunnel_port}")
             end
 
             message = "Creating network interface eth#{@iface_number}"
-            message += " connected to network #{@network_name}."
+            message += " connected to network #{@network_name} based on template #{template_name}."
             if @mac
               @mac = @mac.scan(/(\h{2})/).join(':')
               message += " Using MAC address: #{@mac}"
@@ -141,7 +146,9 @@ module VagrantPlugins
               # FIXME: all options for network driver should be hash from Vagrantfile
               driver_options = {}
               driver_options[:name] = @driver_name if @driver_name
+              driver_options[:iommu] = @driver_iommu ? "on" : "off"
               driver_options[:queues] = @driver_queues if @driver_queues
+
               @udp_tunnel ||= {}
               xml = if template_name == 'interface' or
                        template_name == 'tunnel_interface'
@@ -259,12 +266,15 @@ module VagrantPlugins
               xml.source(source_options) do
                 xml.local(udp_tunnel) if type == 'udp'
               end
+
+              @logger.debug "Driver options: #{driver_options}"
+
               xml.mac(address: mac) if mac
               xml.target(dev: target_dev_name(device_name, type, iface_number))
               xml.alias(name: "net#{iface_number}")
               xml.model(type: model_type.to_s)
               xml.mtu(size: Integer(mtu)) if mtu
-              xml.driver(driver_options)
+              xml.driver(**driver_options)
               xml.address(type: 'pci', bus: pci_bus, slot: pci_slot) if pci_bus and pci_slot
             end
           end.to_xml(

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -45,6 +45,13 @@
     <<%= backing[:name] %> <%= backing[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')  %>/>
   <%- end -%>
   </memoryBacking>
+<%- end -%>
+<%- unless @memtunes.empty? -%>
+  <memtune>
+  <%- @memtunes.each do |name, options| -%>
+    <<%= name %> <%= options[:config].map { |k,v| "#{k}='#{v}'"}.join(' ')  %>><%= options[:value] %></<%= name %>>
+  <%- end -%>
+  </memtune>
 <%- end%>
 <%- if !@cpu_affinity.empty? || @shares -%>
   <cputune>
@@ -229,7 +236,11 @@
     </channel>
 <%- end -%>
 <%- @inputs.each do |input| -%>
-    <input type='<%= input[:type] %>' bus='<%= input[:bus] %>'/>
+    <input type='<%= input[:type] %>' bus='<%= input[:bus] %>'>
+  <%- unless @launchsecurity_data.nil? -%>
+      <driver iommu='on' />
+  <%- end -%>
+    </input>
 <%- end -%>
 <%- if !@sound_type.nil? -%>
     <%# Sound device-%>
@@ -265,6 +276,9 @@
 <%- if @rng[:model] == "random"%>
     <rng model='virtio'>
       <backend model='random'>/dev/random</backend>
+  <%- unless @launchsecurity_data.nil? -%>
+      <driver iommu='on' />
+  <%- end -%>
     </rng>
 <%- end -%>
 <%-
@@ -338,18 +352,32 @@
 <%- end -%>
 <%- if not @usbctl_dev.empty? -%>
     <%# USB Controller -%>
-    <controller type='usb' model='<%= @usbctl_dev[:model] %>' <%= "ports=\"#{@usbctl_dev[:ports]}\" " if @usbctl_dev[:ports] %>/>
+    <controller type='usb' model='<%= @usbctl_dev[:model] %>' <%= "ports=\"#{@usbctl_dev[:ports]}\" " if @usbctl_dev[:ports] %>>
+  <%- unless @launchsecurity_data.nil? -%>
+      <driver iommu='on' />
+  <%- end -%>
+    </controller>
 <%- end -%>
 <%- unless @memballoon_enabled.nil? -%>
   <%- if @memballoon_enabled -%>
     <memballoon model='<%= @memballoon_model %>'>
       <address type='pci' domain='0x0000' bus='<%= @memballoon_pci_bus %>' slot='<%= @memballoon_pci_slot %>' function='0x0'/>
+  <%- unless @launchsecurity_data.nil? -%>
+      <driver iommu='on' />
+  <%- end -%>
     </memballoon>
   <%- else -%>
     <memballoon model='none'/>
   <%- end -%>
 <%- end -%>
   </devices>
+<%- unless @launchsecurity_data.nil? -%>
+  <launchSecurity type='<%= @launchsecurity_data[:type] %>'>
+    <cbitpos><%= @launchsecurity_data[:cbitpos] %></cbitpos>
+    <reducedPhysBits><%= @launchsecurity_data[:reducedPhysBits] %></reducedPhysBits>
+    <policy><%= @launchsecurity_data[:policy] %></policy>
+  </launchSecurity>
+<%- end -%>
 <%- if not @qemu_args.empty? or not @qemu_env.empty? -%>
   <qemu:commandline>
   <%- @qemu_args.each do |arg| -%>

--- a/lib/vagrant-libvirt/templates/public_interface.xml.erb
+++ b/lib/vagrant-libvirt/templates/public_interface.xml.erb
@@ -12,12 +12,15 @@
   <% end %>
   <model type='<%=@model_type%>'/>
   <% if @driver_name and @driver_queues %>
-    <driver name='<%=@driver_name%>' queues='<%=@driver_queues%>'/>
+    <driver <% if @driver_iommu %> iommu="on" <% end %> name='<%=@driver_name%>' queues='<%=@driver_queues%>'/>
   <% elsif @driver_queues %>
-    <driver queues='<%=@driver_queues%>'/>
+    <driver <% if @driver_iommu %> iommu="on" <% end %> queues='<%=@driver_queues%>'/>
   <% elsif @driver_name %>
-    <driver name='<%=@driver_name%>'/>
+    <driver <% if @driver_iommu %> iommu="on" <% end %> name='<%=@driver_name%>'/>
+  <% elsif @driver_iommu %>
+    <driver iommu='on' />
   <% end %>
+
   <% if @ovs %>
   <virtualport type='openvswitch'>
     <% if @ovs_interfaceid %>

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
           management_network_domain = env[:machine].provider_config.management_network_domain
           management_network_mtu = env[:machine].provider_config.management_network_mtu
           management_network_keep = env[:machine].provider_config.management_network_keep
+          management_network_driver_iommu = env[:machine].provider_config.management_network_driver_iommu
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -74,7 +75,7 @@ module VagrantPlugins
             }
           end
 
-
+          management_network_options[:driver_iommu] = management_network_driver_iommu
 
           unless management_network_mac.nil?
             management_network_options[:mac] = management_network_mac

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,10 @@ RSpec.configure do |config|
 
   # don't run acceptance tests by default
   config.filter_run_excluding :acceptance => true
+
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = 2000 if c.respond_to?("max_formatted_output_length=")
+  end
 end
 
 begin

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -185,6 +185,38 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
         end
       end
 
+      context 'launchSecurity' do
+        let(:vagrantfile_providerconfig) do
+          <<-EOF
+          libvirt.launchsecurity :type => 'sev', :cbitpos => 47, :reducedPhysBits => 1, :policy => "0x0003"
+          EOF
+        end
+
+        it 'should emit the settings to the ui' do
+          expect(ui).to receive(:info).with(/ -- Launch security:   type=sev, cbitpos=47, reducedPhysBits=1, policy=0x0003/)
+          expect(servers).to receive(:create).and_return(machine)
+
+          expect(subject.call(env)).to be_nil
+        end
+      end
+
+      context 'memtunes' do
+        let(:vagrantfile_providerconfig) do
+          <<-EOF
+          libvirt.memtune :type => 'hard_limit', :value => 250000
+          libvirt.memtune :type => 'soft_limit', :value => 200000
+          EOF
+        end
+
+        it 'should emit the settings to the ui' do
+          expect(ui).to receive(:info).with(/ -- Memory Tuning:     hard_limit: unit='KiB', value: 250000/)
+          expect(ui).to receive(:info).with(/ -- Memory Tuning:     soft_limit: unit='KiB', value: 200000/)
+          expect(servers).to receive(:create).and_return(machine)
+
+          expect(subject.call(env)).to be_nil
+        end
+      end
+
       context 'sysinfo' do
         let(:domain_xml_file) { 'sysinfo.xml' }
         let(:vagrantfile_providerconfig) do

--- a/spec/unit/action/create_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/create_domain_spec/additional_disks_domain.xml
@@ -41,7 +41,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/action/create_domain_spec/custom_disk_settings.xml
+++ b/spec/unit/action/create_domain_spec/custom_disk_settings.xml
@@ -35,7 +35,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/action/create_domain_spec/default_domain.xml
+++ b/spec/unit/action/create_domain_spec/default_domain.xml
@@ -35,7 +35,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/action/create_domain_spec/sysinfo.xml
+++ b/spec/unit/action/create_domain_spec/sysinfo.xml
@@ -58,7 +58,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/action/create_domain_spec/sysinfo_only_required.xml
+++ b/spec/unit/action/create_domain_spec/sysinfo_only_required.xml
@@ -41,7 +41,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/action/create_domain_spec/two_disk_settings.xml
+++ b/spec/unit/action/create_domain_spec/two_disk_settings.xml
@@ -41,7 +41,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -4,6 +4,7 @@ require_relative '../../spec_helper'
 
 require 'vagrant-libvirt/errors'
 require 'vagrant-libvirt/action/start_domain'
+require 'vagrant-libvirt/util/unindent'
 
 describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
   subject { described_class.new(app, env) }
@@ -223,6 +224,108 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
         expect(domain).to receive(:start)
 
         expect(subject.call(env)).to be_nil
+      end
+    end
+
+    context 'launchSecurity' do
+      let(:updated_domain_xml_new_launch_security) {
+        new_xml = domain_xml.dup
+        new_xml.gsub!(
+          /<\/devices>/,
+          <<-EOF.unindent.rstrip
+          </devices>
+            <launchSecurity type='sev'>
+              <cbitpos>47</cbitpos>
+              <reducedPhysBits>1</reducedPhysBits>
+              <policy>0x0003</policy>
+            </launchSecurity>
+          EOF
+        )
+        new_xml
+      }
+
+      it 'should create if not already set' do
+        machine.provider_config.launchsecurity_data = {:type => 'sev', :cbitpos => 47, :reducedPhysBits => 1, :policy => "0x0003"}
+
+        expect(ui).to_not receive(:warn)
+        expect(connection).to receive(:define_domain).and_return(libvirt_domain)
+        expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml, updated_domain_xml_new_launch_security)
+        expect(libvirt_domain).to receive(:autostart=)
+        expect(domain).to receive(:start)
+
+        expect(subject.call(env)).to be_nil
+      end
+
+      context 'already exists' do
+        let(:domain_xml_launch_security) { updated_domain_xml_new_launch_security }
+        let(:updated_domain_xml_launch_security) {
+          new_xml = domain_xml_launch_security.dup
+          new_xml.gsub!(/<cbitpos>47/, '<cbitpos>48')
+          new_xml.gsub!(/<reducedPhysBits>1/, '<reducedPhysBits>2')
+          new_xml.gsub!(/<policy>0x0003/, '<policy>0x0004')
+          new_xml
+        }
+
+
+        it 'should update all settings' do
+          machine.provider_config.launchsecurity_data = {:type => 'sev', :cbitpos => 48, :reducedPhysBits => 2, :policy => "0x0004"}
+
+          expect(ui).to_not receive(:warn)
+          expect(connection).to receive(:define_domain).and_return(libvirt_domain)
+          expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml_launch_security, updated_domain_xml_launch_security)
+          expect(libvirt_domain).to receive(:autostart=)
+          expect(domain).to receive(:start)
+
+          expect(subject.call(env)).to be_nil
+        end
+
+        it 'should remove if disabled' do
+          machine.provider_config.launchsecurity_data = nil
+
+          expect(ui).to_not receive(:warn)
+          expect(connection).to receive(:define_domain).and_return(libvirt_domain)
+          expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml_launch_security, domain_xml)
+          expect(libvirt_domain).to receive(:autostart=)
+          expect(domain).to receive(:start)
+
+          expect(subject.call(env)).to be_nil
+        end
+
+        context 'with controllers' do
+          # makes domain_xml contain 2 controllers and memballoon
+          # which should mean that launchsecurity element exists, but without
+          # iommu set on controllers
+          let(:test_file) { 'existing.xml' }
+          let(:updated_domain_xml_launch_security_controllers) {
+            new_xml = updated_domain_xml_new_launch_security.dup
+            new_xml.gsub!(
+              /<controller type='pci' index='0' model='pci-root'\/>/,
+              "<controller type='pci' index='0' model='pci-root'><driver iommu='on'/></controller>",
+            )
+            new_xml.gsub!(
+              /(<address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'\/>)/,
+              '\1<driver iommu="on"/>',
+            )
+            # memballoon
+            new_xml.gsub!(
+              /(<address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'\/>)/,
+              '\1<driver iommu="on"/>',
+            )
+            new_xml
+          }
+
+          it 'should set driver iommu on all controllers' do
+            machine.provider_config.launchsecurity_data = {:type => 'sev', :cbitpos => 47, :reducedPhysBits => 1, :policy => "0x0003"}
+
+            expect(ui).to_not receive(:warn)
+            expect(connection).to receive(:define_domain).and_return(libvirt_domain)
+            expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml_launch_security, updated_domain_xml_launch_security_controllers)
+            expect(libvirt_domain).to receive(:autostart=)
+            expect(domain).to receive(:start)
+
+            expect(subject.call(env)).to be_nil
+          end
+        end
       end
     end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -704,6 +704,31 @@ describe VagrantPlugins::ProviderLibvirt::Config do
     end
   end
 
+  describe '#launchsecurity' do
+    it 'should reject invalid type' do
+      expect { subject.launchsecurity(:type => 'bad') }.to raise_error("Launch security type only supports SEV. Explicitly set 'sev' as a type")
+    end
+
+    it 'should save when valid' do
+      expect(subject.launchsecurity(:type => 'sev', :cbitpos => 47, :reducedPhysBits => 1, :policy => "0x0003")).to be_truthy
+    end
+  end
+
+  describe '#memtune' do
+    it 'should raise an exception without type' do
+      expect { subject.memtune(:value => 250000) }.to raise_error('Missing memtune type')
+    end
+
+    it 'should raise an exception if type unrecognized' do
+      expect { subject.memtune(:type => 'limit', :value => 250000) }.to raise_error('Memtune type \'limit\' not allowed (hard_limit, soft_limit, swap_hard_limit are allowed)')
+    end
+
+    it 'should accept multiple calls' do
+      expect(subject.memtune(:type => 'hard_limit', :value => 250000)).to be_truthy
+      expect(subject.memtune(:type => 'soft_limit', :value => 200000)).to be_truthy
+    end
+  end
+
   def assert_invalid
     subject.finalize!
     errors = subject.validate(machine).values.first
@@ -1044,6 +1069,27 @@ describe VagrantPlugins::ProviderLibvirt::Config do
     let(:two) { described_class.new }
 
     subject { one.merge(two) }
+
+    context 'memtunes' do
+      it 'should merge where type is different' do
+        one.memtune(type: 'hard_limit', value: '250000')
+        two.memtune(type: 'soft_limit', value: '200000')
+        subject.finalize!
+        expect(subject.memtunes).to eq({
+          'hard_limit' => {value: '250000', config: {unit: 'KiB'}},
+          'soft_limit' => {value: '200000', config: {unit: 'KiB'}},
+        })
+      end
+
+      it 'should override where type is the same' do
+        one.memtune(type: 'hard_limit', value: '250000')
+        two.memtune(type: 'hard_limit', value: '200000')
+        subject.finalize!
+        expect(subject.memtunes).to eq({
+          'hard_limit' => {value: '200000', config: {unit: 'KiB'}},
+        })
+      end
+    end
 
     context 'storage' do
       context 'with disks' do

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -13,6 +13,10 @@
   <numatune>
     <memory nodeset='1-4,^3,6'/>
   </numatune>
+  <memtune>
+    <hard_limit unit='KiB'>250000</hard_limit>
+    <soft_limit unit='KiB'>200000</soft_limit>
+  </memtune>
   <cputune>
     <vcpupin vcpu="0" cpuset="0" />
     <shares>1024</shares>
@@ -107,7 +111,8 @@
       <source path='/tmp/foo'/>
       <target type='guestfwd' address='192.0.2.42' port='4242'/>
     </channel>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'>
       <gl enable='yes'/>
     </graphics>
@@ -154,7 +159,8 @@
         <device path='/dev/tpm0'/>
       </backend>
     </tpm>
-    <controller type='usb' model='nec-xhci' ports="4" />
+    <controller type='usb' model='nec-xhci' ports="4" >
+    </controller>
   </devices>
   <qemu:commandline>
     <qemu:arg value='-device'/>

--- a/spec/unit/templates/domain_cpu_mode_passthrough.xml
+++ b/spec/unit/templates/domain_cpu_mode_passthrough.xml
@@ -31,7 +31,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/templates/domain_custom_cpu_model.xml
+++ b/spec/unit/templates/domain_custom_cpu_model.xml
@@ -29,7 +29,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/templates/domain_defaults.xml
+++ b/spec/unit/templates/domain_defaults.xml
@@ -29,7 +29,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/templates/domain_scsi_bus_storage.xml
+++ b/spec/unit/templates/domain_scsi_bus_storage.xml
@@ -36,7 +36,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/templates/domain_scsi_device_storage.xml
+++ b/spec/unit/templates/domain_scsi_device_storage.xml
@@ -36,7 +36,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/templates/domain_scsi_multiple_controllers_storage.xml
+++ b/spec/unit/templates/domain_scsi_multiple_controllers_storage.xml
@@ -122,7 +122,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -67,6 +67,8 @@ describe 'templates/domain' do
       domain.clock_timer(name: 't2', track: 'b', tickpolicy: 'c', frequency: 'd', mode: 'e',  present: 'yes')
       domain.hyperv_feature(name: 'spinlocks', state: 'on', retries: '4096')
       domain.cputopology(sockets: '1', cores: '3', threads: '2')
+      domain.memtune(type: 'hard_limit', value: '250000')
+      domain.memtune(type: 'soft_limit', value: '200000')
       domain.cpuaffinitiy(0 => '0')
       domain.machine_type = 'pc-compatible'
       domain.machine_arch = 'x86_64'

--- a/spec/unit/templates/tpm/version_1.2.xml
+++ b/spec/unit/templates/tpm/version_1.2.xml
@@ -29,7 +29,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>

--- a/spec/unit/templates/tpm/version_2.0.xml
+++ b/spec/unit/templates/tpm/version_2.0.xml
@@ -29,7 +29,8 @@
     <console type='pty'>
       <target port='0'/>
     </console>
-    <input type='mouse' bus='ps2'/>
+    <input type='mouse' bus='ps2'>
+    </input>
     <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>


### PR DESCRIPTION
Secure Encryption Virtualization is supported by libvirt and this
change adds support for vagrant-libvirt to enable it.

It requires a UEFI base box and needs a combination of options to be
configured for it to work.

Co-authored-by: MUNTANÉ CALVO Enric emc@csem.ch
Closes: #1372