### PR TITLE
feat: add websocket graphics config

### DIFF
--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -169,6 +169,9 @@ end
   or "spice".
 * `graphics_port` - Sets the port for the display protocol to bind to.
   Defaults to `-1`, which will be set automatically by libvirt.
+* `graphics_websocket` - Sets the websocket port for the display protocol to bind to.
+  Defaults to `-1`, which will be set automatically by libvirt.
+  The autoport configuration has no effect on the websocket port due to security reasons.
 * `graphics_ip` - Sets the IP for the display protocol to bind to.  Defaults to
   "127.0.0.1".
 * `graphics_passwd` - Sets the password for the display protocol. Working for
@@ -305,6 +308,7 @@ defined domain:
 * `cpu_mode` - Updated. Pay attention that custom mode is not supported
 * `graphics_type` - Updated
 * `graphics_port` - Updated
+* `graphics_websocket` - Updated
 * `graphics_ip` - Updated
 * `graphics_passwd` - Updated
 * `graphics_autoport` - Updated

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -271,7 +271,7 @@ module VagrantPlugins
           end
 
           env[:ui].info(" -- Graphics Type:     #{@graphics_type}")
-          env[:ui].info(" -- Graphics Websocket: #{@graphics_websocket}")
+          env[:ui].info(" -- Graphics Websocket: #{@graphics_websocket}") if @graphics_websocket != -1
           if !@graphics_autoport
             env[:ui].info(" -- Graphics Port:     #{@graphics_port}")
             env[:ui].info(" -- Graphics IP:       #{@graphics_ip}")

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -65,6 +65,7 @@ module VagrantPlugins
           @graphics_type = config.graphics_type
           @graphics_autoport = config.graphics_autoport
           @graphics_port = config.graphics_port
+          @graphics_websocket = config.graphics_websocket
           @graphics_ip = config.graphics_ip
           @graphics_passwd = config.graphics_passwd
           @graphics_gl = config.graphics_gl
@@ -270,6 +271,7 @@ module VagrantPlugins
           end
 
           env[:ui].info(" -- Graphics Type:     #{@graphics_type}")
+          env[:ui].info(" -- Graphics Websocket: #{@graphics_websocket}")
           if !@graphics_autoport
             env[:ui].info(" -- Graphics Port:     #{@graphics_port}")
             env[:ui].info(" -- Graphics IP:       #{@graphics_ip}")

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -548,14 +548,21 @@ module VagrantPlugins
             raise Errors::DomainStartError, error_message: e.message
           end
 
-          if config.graphics_autoport
-            #libvirt_domain = env[:machine].provider.driver.connection.client.lookup_domain_by_uuid(env[:machine].id)
-            xmldoc = REXML::Document.new(libvirt_domain.xml_desc)
-            graphics = REXML::XPath.first(xmldoc, '/domain/devices/graphics')
-            env[:ui].info(I18n.t('vagrant_libvirt.starting_domain_with_graphics'))
-            env[:ui].info(" -- Graphics Port:     #{graphics.attributes['port']}")
-            env[:ui].info(" -- Graphics IP:       #{graphics.attributes['listen']}")
-            env[:ui].info(" -- Graphics Password: #{config.graphics_passwd.nil? ? 'Not defined' : 'Defined'}")
+          #libvirt_domain = env[:machine].provider.driver.connection.client.lookup_domain_by_uuid(env[:machine].id)
+          xmldoc = REXML::Document.new(libvirt_domain.xml_desc)
+          graphics = REXML::XPath.first(xmldoc, '/domain/devices/graphics')
+
+          if !graphics.nil?
+            if config.graphics_autoport
+              env[:ui].info(I18n.t('vagrant_libvirt.starting_domain_with_graphics'))
+              env[:ui].info(" -- Graphics Port:      #{graphics.attributes['port']}")
+              env[:ui].info(" -- Graphics IP:        #{graphics.attributes['listen']}")
+              env[:ui].info(" -- Graphics Password:  #{config.graphics_passwd.nil? ? 'Not defined' : 'Defined'}")
+            end
+
+            if config.graphics_websocket == -1
+              env[:ui].info(" -- Graphics Websocket: #{graphics.attributes['websocket']}")
+            end
           end
 
           @app.call(env)

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -280,6 +280,10 @@ module VagrantPlugins
                 graphics.attributes['port'] = config.graphics_port
               end
             end
+            if graphics.attributes['websocket'] != config.graphics_websocket.to_s
+              descr_changed = true
+              graphics.attributes['websocket'] = config.graphics_websocket
+            end
             if graphics.attributes['keymap'] != config.keymap
               descr_changed = true
               graphics.attributes['keymap'] = config.keymap

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -120,6 +120,7 @@ module VagrantPlugins
       attr_accessor :graphics_type
       attr_accessor :graphics_autoport
       attr_accessor :graphics_port
+      attr_accessor :graphics_websocket
       attr_accessor :graphics_passwd
       attr_accessor :graphics_ip
       attr_accessor :graphics_gl
@@ -294,6 +295,7 @@ module VagrantPlugins
         @graphics_type     = UNSET_VALUE
         @graphics_autoport = UNSET_VALUE
         @graphics_port     = UNSET_VALUE
+        @graphics_websocket = UNSET_VALUE
         @graphics_ip       = UNSET_VALUE
         @graphics_passwd   = UNSET_VALUE
         @graphics_gl       = UNSET_VALUE
@@ -1021,6 +1023,7 @@ module VagrantPlugins
           @graphics_passwd = nil
         end
         @graphics_port = @graphics_type == 'spice' ? nil : -1 if @graphics_port == UNSET_VALUE
+        @graphics_websocket = @graphics_type == 'spice' ? nil : -1 if @graphics_websocket == UNSET_VALUE
         @graphics_ip = @graphics_type == 'spice' ? nil : '127.0.0.1' if @graphics_ip == UNSET_VALUE
         @video_accel3d = false if @video_accel3d == UNSET_VALUE
         @graphics_gl = @video_accel3d if @graphics_gl == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -253,6 +253,7 @@
         'type' => @graphics_type,
         'port' => @graphics_port,
         'autoport' => @graphics_autoport,
+        'websocket' => @graphics_websocket,
         'listen' => @graphics_ip,
         'keymap' => @keymap,
         'passwd' => @graphics_passwd,

--- a/spec/support/environment_helper.rb
+++ b/spec/support/environment_helper.rb
@@ -20,7 +20,7 @@ class EnvironmentHelper
     1024
   end
 
-  %w(cpus cpu_mode loader nvram boot_order machine_type disk_bus disk_device nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms floppies driver).each do |name|
+  %w(cpus cpu_mode loader nvram boot_order machine_type disk_bus disk_device nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_websocket graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms floppies driver).each do |name|
     define_method(name.to_sym) do
       nil
     end

--- a/spec/unit/action/create_domain_spec.rb
+++ b/spec/unit/action/create_domain_spec.rb
@@ -66,13 +66,15 @@ describe VagrantPlugins::ProviderLibvirt::Action::CreateDomain do
         let(:vagrantfile_providerconfig) do
           <<-EOF
           libvirt.graphics_port = 5900
+          libvirt.graphics_websocket = 5700
           EOF
         end
 
-        it 'should emit the graphics port' do
+        it 'should emit the graphics port and websocket' do
           expect(servers).to receive(:create).and_return(machine)
           expect(volumes).to_not receive(:create) # additional disks only
           expect(ui).to receive(:info).with(' -- Graphics Port:     5900')
+          expect(ui).to receive(:info).with(' -- Graphics Websocket: 5700')
 
           expect(subject.call(env)).to be_nil
         end

--- a/spec/unit/action/create_domain_spec/additional_disks_domain.xml
+++ b/spec/unit/action/create_domain_spec/additional_disks_domain.xml
@@ -43,7 +43,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/action/create_domain_spec/custom_disk_settings.xml
+++ b/spec/unit/action/create_domain_spec/custom_disk_settings.xml
@@ -37,7 +37,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/action/create_domain_spec/default_domain.xml
+++ b/spec/unit/action/create_domain_spec/default_domain.xml
@@ -37,7 +37,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/action/create_domain_spec/sysinfo.xml
+++ b/spec/unit/action/create_domain_spec/sysinfo.xml
@@ -60,7 +60,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/action/create_domain_spec/sysinfo_only_required.xml
+++ b/spec/unit/action/create_domain_spec/sysinfo_only_required.xml
@@ -43,7 +43,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/action/create_domain_spec/two_disk_settings.xml
+++ b/spec/unit/action/create_domain_spec/two_disk_settings.xml
@@ -43,7 +43,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/action/start_domain_spec.rb
+++ b/spec/unit/action/start_domain_spec.rb
@@ -344,7 +344,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::StartDomain do
           expect(libvirt_domain).to receive(:xml_desc).and_return(domain_xml, launched_domain_xml)
           expect(libvirt_domain).to receive(:autostart=)
           expect(domain).to receive(:start)
-          expect(ui).to receive(:info).with(' -- Graphics Port:     5900')
+          expect(ui).to receive(:info).with(' -- Graphics Port:      5900')
 
           expect(subject.call(env)).to be_nil
         end

--- a/spec/unit/action/start_domain_spec/clock_timer_removed.xml
+++ b/spec/unit/action/start_domain_spec/clock_timer_removed.xml
@@ -30,7 +30,7 @@
       <target port='0'/>
     </console>
     <input bus='ps2' type='mouse'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'/>
     <video>
       <model heads='1' type='cirrus' vram='16384'/>
     </video>

--- a/spec/unit/action/start_domain_spec/clock_timer_rtc.xml
+++ b/spec/unit/action/start_domain_spec/clock_timer_rtc.xml
@@ -30,7 +30,7 @@
       <target port='0'/>
     </console>
     <input bus='ps2' type='mouse'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'/>
     <video>
       <model heads='1' type='cirrus' vram='16384'/>
     </video>

--- a/spec/unit/action/start_domain_spec/clock_timer_rtc_tsc.xml
+++ b/spec/unit/action/start_domain_spec/clock_timer_rtc_tsc.xml
@@ -31,7 +31,7 @@
       <target port='0'/>
     </console>
     <input bus='ps2' type='mouse'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'/>
     <video>
       <model heads='1' type='cirrus' vram='16384'/>
     </video>

--- a/spec/unit/action/start_domain_spec/default.xml
+++ b/spec/unit/action/start_domain_spec/default.xml
@@ -28,7 +28,7 @@
       <target port='0'/>
     </console>
     <input bus='ps2' type='mouse'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'/>
     <video>
       <model heads='1' type='cirrus' vram='16384'/>
     </video>

--- a/spec/unit/action/start_domain_spec/default_added_tpm_path.xml
+++ b/spec/unit/action/start_domain_spec/default_added_tpm_path.xml
@@ -28,7 +28,7 @@
       <target port='0'/>
     </console>
     <input bus='ps2' type='mouse'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'/>
     <video>
       <model heads='1' type='cirrus' vram='16384'/>
     </video>

--- a/spec/unit/action/start_domain_spec/default_added_tpm_version.xml
+++ b/spec/unit/action/start_domain_spec/default_added_tpm_version.xml
@@ -28,7 +28,7 @@
       <target port='0'/>
     </console>
     <input bus='ps2' type='mouse'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'/>
     <video>
       <model heads='1' type='cirrus' vram='16384'/>
     </video>

--- a/spec/unit/action/start_domain_spec/default_with_different_formatting.xml
+++ b/spec/unit/action/start_domain_spec/default_with_different_formatting.xml
@@ -29,7 +29,7 @@
       <target port='0'/>
     </console>
     <input bus='ps2' type='mouse'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'/>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'/>
     <video>
       <model heads='1' type='cirrus' vram='16384'/>
     </video>

--- a/spec/unit/action/start_domain_spec/existing.xml
+++ b/spec/unit/action/start_domain_spec/existing.xml
@@ -48,7 +48,7 @@
     </console>
     <input type='mouse' bus='ps2'/>
     <input type='keyboard' bus='ps2'/>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'>
+    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us' websocket='-1'>
       <listen type='address' address='127.0.0.1'/>
     </graphics>
     <audio id='1' type='none'/>

--- a/spec/unit/action/start_domain_spec/existing_added_nvram.xml
+++ b/spec/unit/action/start_domain_spec/existing_added_nvram.xml
@@ -48,7 +48,7 @@
     </console>
     <input bus='ps2' type='mouse'/>
     <input bus='ps2' type='keyboard'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'>
       <listen address='127.0.0.1' type='address'/>
     </graphics>
     <audio id='1' type='none'/>

--- a/spec/unit/action/start_domain_spec/existing_reordered.xml
+++ b/spec/unit/action/start_domain_spec/existing_reordered.xml
@@ -48,7 +48,7 @@
     </console>
     <input bus='ps2' type='mouse'/>
     <input bus='ps2' type='keyboard'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket="-1">
       <listen address='127.0.0.1' type='address'/>
     </graphics>
     <audio id='1' type='none'/>

--- a/spec/unit/action/start_domain_spec/nvram_domain_other_setting.xml
+++ b/spec/unit/action/start_domain_spec/nvram_domain_other_setting.xml
@@ -50,7 +50,7 @@
     </console>
     <input bus='ps2' type='mouse'/>
     <input bus='ps2' type='keyboard'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'>
       <listen address='127.0.0.1' type='address'/>
     </graphics>
     <audio id='1' type='none'/>

--- a/spec/unit/action/start_domain_spec/nvram_domain_removed.xml
+++ b/spec/unit/action/start_domain_spec/nvram_domain_removed.xml
@@ -50,7 +50,7 @@
     </console>
     <input bus='ps2' type='mouse'/>
     <input bus='ps2' type='keyboard'/>
-    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc'>
+    <graphics autoport='yes' keymap='en-us' listen='127.0.0.1' port='-1' type='vnc' websocket='-1'>
       <listen address='127.0.0.1' type='address'/>
     </graphics>
     <audio id='1' type='none'/>

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -660,6 +660,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
 
         expect(subject.graphics_type).to eq('vnc')
         expect(subject.graphics_port).to eq(-1)
+        expect(subject.graphics_websocket).to eq(-1)
         expect(subject.graphics_ip).to eq('127.0.0.1')
         expect(subject.graphics_autoport).to eq('yes')
         expect(subject.channels).to be_empty
@@ -670,6 +671,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         subject.finalize!
 
         expect(subject.graphics_port).to eq(nil)
+        expect(subject.graphics_websocket).to eq(nil)
         expect(subject.graphics_ip).to eq(nil)
         expect(subject.graphics_autoport).to eq(nil)
         expect(subject.channels).to match([a_hash_including({:target_name => 'com.redhat.spice.0'})])

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -113,7 +113,7 @@
     </channel>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'>
       <gl enable='yes'/>
     </graphics>
     <video>

--- a/spec/unit/templates/domain_cpu_mode_passthrough.xml
+++ b/spec/unit/templates/domain_cpu_mode_passthrough.xml
@@ -33,7 +33,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/templates/domain_custom_cpu_model.xml
+++ b/spec/unit/templates/domain_custom_cpu_model.xml
@@ -31,7 +31,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/templates/domain_defaults.xml
+++ b/spec/unit/templates/domain_defaults.xml
@@ -31,7 +31,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/templates/domain_scsi_bus_storage.xml
+++ b/spec/unit/templates/domain_scsi_bus_storage.xml
@@ -38,7 +38,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/templates/domain_scsi_device_storage.xml
+++ b/spec/unit/templates/domain_scsi_device_storage.xml
@@ -38,7 +38,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/templates/domain_scsi_multiple_controllers_storage.xml
+++ b/spec/unit/templates/domain_scsi_multiple_controllers_storage.xml
@@ -124,7 +124,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/templates/tpm/version_1.2.xml
+++ b/spec/unit/templates/tpm/version_1.2.xml
@@ -31,7 +31,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>

--- a/spec/unit/templates/tpm/version_2.0.xml
+++ b/spec/unit/templates/tpm/version_2.0.xml
@@ -31,7 +31,7 @@
     </console>
     <input type='mouse' bus='ps2'>
     </input>
-    <graphics type='vnc' port='-1' autoport='yes' listen='127.0.0.1' keymap='en-us'/>
+    <graphics type='vnc' port='-1' autoport='yes' websocket='-1' listen='127.0.0.1' keymap='en-us'/>
     <video>
       <model type='cirrus' vram='16384' heads='1'/>
     </video>


### PR DESCRIPTION
Hi :wave:, 

this commit adds websocket functionality for VNC. The websocket attribute may be used to specify the port to listen on (with -1 meaning auto-allocation and autoport having no effect due to security reasons).

Let me know what you think or if you would like to have anything changed.