### PR TITLE
Add libvirt-dev to Ubuntu install

### DIFF
--- a/docs/installation.markdown
+++ b/docs/installation.markdown
@@ -166,7 +166,7 @@ You may need to modify your `sources.list` to uncomment the deb-src entries wher
 ```shell
 sudo apt-get purge vagrant-libvirt
 sudo apt-mark hold vagrant-libvirt
-sudo apt-get install -y qemu libvirt-daemon-system ebtables libguestfs-tools
+sudo apt-get install -y qemu libvirt-daemon-system libvirt-dev ebtables libguestfs-tools
 sudo apt-get install -y vagrant ruby-fog-libvirt
 vagrant plugin install vagrant-libvirt
 ```


### PR DESCRIPTION
Installation of vagrant-libvirt was failing for me until I installed the libvirt-dev package. 

[Here's](https://packages.ubuntu.com/jammy/all/libvirt-dev/filelist) a list of files from the libvirt-dev package. I believe that vagrant-libvirt needs some of these files such as libvirt.pc.