### PR TITLE
Use append to a truncated file to retain owner

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -198,6 +198,8 @@ module VagrantPlugins
             dir = File.dirname(serial[:source][:path])
             begin
               FileUtils.mkdir_p(dir)
+              FileUtils.touch(serial[:source][:path])
+              File.truncate(serial[:source][:path], 0) unless serial[:source].fetch(:append, false)
             rescue ::Errno::EACCES
               raise Errors::SerialCannotCreatePathError,
                     path: dir

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -208,9 +208,12 @@
 <%- end -%>
 <%- @serials.each_with_index do |serial, port| -%>
     <serial type='<%= serial[:type] %>'>
-      <%- unless serial[:source].nil? -%>
-      <source path='<%= serial[:source][:path] %>'/>
-      <%- end -%>
+  <%- unless serial[:source].nil?
+    source = serial[:source]
+    seclabel = serial[:source][:seclabel]
+-%>
+      <source path='<%= source[:path] %>' append='<%= source.fetch(:append, 'on') %>'/>
+  <%- end -%>
       <target port='<%= port %>'/>
     </serial>
 <%- end -%>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -105,7 +105,7 @@
       <target dev='fda' bus='fdc'/>
     </disk>
     <serial type='file'>
-      <source path='/var/log/vm_consoles/machine.log'/>
+      <source path='/var/log/vm_consoles/machine.log' append='on'/>
       <target port='0'/>
     </serial>
     <console type='file'>


### PR DESCRIPTION
Change the default behaviour when logging output from the console to a
file to ensure the file is pre-created and unless append is explicitly
set to true in the source config, truncate the file. Combined with
having the domain template default to enabling append, this causes
libvirt/qemu to not attempt to create the file and thus retains the
owner/group and permissions of the original file.

Relates-to: #1385
