### PR TITLE
Clear and create forwarded ports on suspend/resume

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -52,7 +52,6 @@ module VagrantPlugins
       autoload :StartDomain, action_root.join('start_domain')
       autoload :StartShutdownTimer, action_root.join('shutdown_domain')
       autoload :SuspendDomain, action_root.join('suspend_domain')
-      autoload :TimedProvision, action_root.join('timed_provision')
       autoload :WaitTillUp, action_root.join('wait_till_up')
 
       autoload :Package, 'vagrant/action/general/package'
@@ -94,8 +93,6 @@ module VagrantPlugins
                 b2.use CreateNetworkInterfaces
 
                 b2.use action_start
-
-                b2.use SetupComplete
               else
                 b2.use HandleStoragePool
                 require 'vagrant/action/builtin/handle_box'
@@ -112,6 +109,7 @@ module VagrantPlugins
                 b2.use SetHostname
               end
             else
+              # start VM if halted
               env[:halt_on_error] = true
               b2.use ResolveDiskSettings
               b2.use CreateNetworks
@@ -129,7 +127,6 @@ module VagrantPlugins
       # poweroff state.
       private_class_method def self.action_start
         Vagrant::Action::Builder.new.tap do |b|
-          b.use ConfigValidate
           b.use Call, IsRunning do |env, b2|
             # If the VM is running, run the necessary provisioners
             if env[:result]
@@ -138,16 +135,19 @@ module VagrantPlugins
             end
 
             b2.use Call, IsSuspended do |env2, b3|
-              # if vm is suspended resume it then exit
+              # if vm is suspended resume it
               if env2[:result]
                 b3.use ResumeDomain
-                next
-              end
 
-              if !env[:machine].config.vm.box
+                # if there was a box, want to wait until the communicator is
+                # available and then forward ports
+                next if !env[:machine].config.vm.box
+              elsif !env[:machine].config.vm.box
                 # With no box, we just care about network creation and starting it
                 b3.use SetBootOrder
                 b3.use StartDomain
+
+                next
               else
                 # VM is not running or suspended.
                 b3.use PrepareNFSValidIds
@@ -165,11 +165,12 @@ module VagrantPlugins
                 # Machine should gain IP address when coming up,
                 # so wait for dhcp lease and store IP into machines data_dir.
                 b3.use WaitTillUp
-                require 'vagrant/action/builtin/wait_for_communicator'
-                b3.use WaitForCommunicator, [:running]
-
-                b3.use ForwardPorts
               end
+
+              require 'vagrant/action/builtin/wait_for_communicator'
+              b3.use WaitForCommunicator, [:running]
+
+              b3.use ForwardPorts
             end
           end
         end
@@ -216,13 +217,13 @@ module VagrantPlugins
       # It uses the halt and start actions
       def self.action_reload
         Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
           b.use Call, IsCreated do |env, b2|
             unless env[:result]
               b2.use MessageNotCreated
               next
             end
 
-            b2.use ConfigValidate
             b2.use Provision
             b2.use action_halt
             b2.use action_start
@@ -339,6 +340,7 @@ module VagrantPlugins
                 b3.use MessageNotRunning
                 next
               end
+              b3.use ClearForwardedPorts
               b3.use SuspendDomain
             end
           end
@@ -366,6 +368,7 @@ module VagrantPlugins
               b3.use Provision
               require 'vagrant/action/builtin/wait_for_communicator'
               b3.use WaitForCommunicator, [:running]
+              b3.use ForwardPorts
             end
           end
         end

--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -24,8 +24,12 @@ describe VagrantPlugins::ProviderLibvirt::Action do
     allow(logger).to receive(:trace)
     allow(logger).to receive(:debug)
     allow(logger).to receive(:error)
+    allow(logger).to receive(:warn)
 
     allow(connection.client).to receive(:libversion).and_return(6_002_000)
+
+    # ensure runner available
+    env[:action_runner] = runner
 
     # patch out iterating synced_folders by emptying the list returned
     # where vagrant us using a Collection, otherwise fallback to using
@@ -44,14 +48,289 @@ describe VagrantPlugins::ProviderLibvirt::Action do
     results = responses.dup
 
     allow_any_instance_of(action).to receive(:call) do |cls, env|
-      app = cls.instance_variable_get(:@app)
+      call_next(cls, env) do |_, env|
+        env[:result] = results[0]
+        if results.length > 1
+          results.shift
+        end
+      end
+    end
+  end
 
-      env[:result] = results[0]
-      if results.length > 1
-        results.shift
+  def receive_and_call_next(&block)
+    return receive(:call) { |cls, env| call_next(cls, env, &block) }
+  end
+
+  def call_next(cls, env)
+    app = cls.instance_variable_get(:@app)
+
+    yield(app, env) if block_given?
+
+    app.call(env)
+  end
+
+  describe '#action_up' do
+    before do
+      # typically set by the up command
+      env[:destroy_on_error] = true
+    end
+
+    context 'not created' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, false)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsSuspended, false)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, false)
       end
 
-      app.call(env)
+      it 'should create a new machine' do
+        expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CleanupOnFailure).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HandleStoragePool).to receive_and_call_next
+        expect_any_instance_of(Vagrant::Action::Builtin::HandleBox).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateDomain).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworkInterfaces).to receive_and_call_next
+
+        # start action
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::PrepareNFSValidIds).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SyncedFolderCleanup).to receive_and_call_next
+        expect_any_instance_of(Vagrant::Action::Builtin::SyncedFolders).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ShareFolders).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetBootOrder).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::StartDomain).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::WaitTillUp).to receive_and_call_next
+        expect_any_instance_of(Vagrant::Action::Builtin::WaitForCommunicator).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ForwardPorts).to receive_and_call_next
+
+        # remaining up action
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetHostname).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to receive_and_call_next
+
+        expect(runner.run(subject.action_up)).to match(hash_including({:machine => machine}))
+      end
+
+      context 'no box' do
+        before do
+          machine.config.vm.box = nil
+        end
+
+        it 'should create a new machine' do
+          expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CleanupOnFailure).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateDomain).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworkInterfaces).to receive_and_call_next
+
+          # start action
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetBootOrder).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::StartDomain).to receive_and_call_next
+
+          # remaining up action
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to receive_and_call_next
+
+          expect(runner.run(subject.action_up)).to match(hash_including({:machine => machine}))
+        end
+      end
+
+      context 'on error' do
+        it 'should cleanup on error' do
+          expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HandleStoragePool).to receive_and_call_next
+          expect_any_instance_of(Vagrant::Action::Builtin::HandleBox).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateDomain).to receive_and_call_next
+          # setup for error
+          expect(state).to receive(:id).and_return(:created)
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive(:call).and_raise(
+            ::VagrantPlugins::ProviderLibvirt::Errors::CreateNetworkError.new(:error_message => 'errmsg')
+          )
+          expect(subject).to receive(:action_destroy).and_return(Vagrant::Action::Builder.new)
+
+          # remaining up
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to_not receive(:call)
+
+          expect { runner.run(subject.action_up) }.to raise_error(::VagrantPlugins::ProviderLibvirt::Errors::CreateNetworkError)
+        end
+
+        it 'should do nothing if already finished setup' do
+          expect(state).to receive(:id).and_return(:created)
+          expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+          # don't intercept CleanupOnFailure or SetupComplete
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive(:call) do |cls, env|
+            app = cls.instance_variable_get(:@app)
+
+            app.call(env)
+
+            raise Vagrant::Errors::VagrantError.new
+          end
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetNameOfDomain).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HandleStoragePool).to receive_and_call_next
+          expect_any_instance_of(Vagrant::Action::Builtin::HandleBox).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateDomainVolume).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateDomain).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworkInterfaces).to receive_and_call_next
+
+          # start action
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::PrepareNFSValidIds).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SyncedFolderCleanup).to receive_and_call_next
+          expect_any_instance_of(Vagrant::Action::Builtin::SyncedFolders).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ShareFolders).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetBootOrder).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::StartDomain).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::WaitTillUp).to receive_and_call_next
+          expect_any_instance_of(Vagrant::Action::Builtin::WaitForCommunicator).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ForwardPorts).to receive_and_call_next
+
+          # remaining up action
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetHostname).to receive_and_call_next
+
+          expect(subject).to_not receive(:action_destroy)
+          expect(subject).to_not receive(:action_halt)
+
+          expect { runner.run(subject.action_up) }.to raise_error(::Vagrant::Errors::VagrantError)
+        end
+      end
+    end
+
+    context 'halted' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsSuspended, false)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, false)
+      end
+
+      it 'should start existing machine' do
+        expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CleanupOnFailure).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+
+        # start action
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::PrepareNFSValidIds).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SyncedFolderCleanup).to receive_and_call_next
+        expect_any_instance_of(Vagrant::Action::Builtin::SyncedFolders).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ShareFolders).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetBootOrder).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::StartDomain).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::WaitTillUp).to receive_and_call_next
+        expect_any_instance_of(Vagrant::Action::Builtin::WaitForCommunicator).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ForwardPorts).to receive_and_call_next
+
+        # remaining up
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to receive_and_call_next
+
+        expect(runner.run(subject.action_up)).to match(hash_including({:machine => machine}))
+      end
+
+      context 'no box' do
+        before do
+          machine.config.vm.box = nil
+        end
+
+        it 'should start existing machine' do
+          expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CleanupOnFailure).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+
+          # start action
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetBootOrder).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::StartDomain).to receive_and_call_next
+
+          # remaining up
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to receive_and_call_next
+
+          expect(runner.run(subject.action_up)).to match(hash_including({:machine => machine}))
+        end
+      end
+
+      context 'on error' do
+        it 'should call halt on error' do
+          expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CleanupOnFailure).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+          # setup for error
+          expect(state).to receive(:id).and_return(:created)
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive(:call).and_raise(
+            ::VagrantPlugins::ProviderLibvirt::Errors::CreateNetworkError.new(:error_message => 'errmsg')
+          )
+          expect(subject).to receive(:action_halt).and_return(Vagrant::Action::Builder.new)
+
+          # remaining up
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to_not receive(:call)
+
+          expect { runner.run(subject.action_up) }.to raise_error(::VagrantPlugins::ProviderLibvirt::Errors::CreateNetworkError)
+        end
+      end
+    end
+
+    context 'suspended' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsSuspended, true)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, false)
+      end
+
+      it 'should resume existing machine' do
+        expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CleanupOnFailure).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+
+        # start action
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResumeDomain).to receive_and_call_next
+        expect_any_instance_of(Vagrant::Action::Builtin::WaitForCommunicator).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ForwardPorts).to receive_and_call_next
+
+        # remaining up
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to receive_and_call_next
+
+        expect(runner.run(subject.action_up)).to match(hash_including({:machine => machine}))
+      end
+
+      context 'no box' do
+        before do
+          machine.config.vm.box = nil
+        end
+
+        it 'should resume existing machine' do
+          expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CleanupOnFailure).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+
+          # start action
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResumeDomain).to receive_and_call_next
+
+          # remaining up
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to receive_and_call_next
+
+          expect(runner.run(subject.action_up)).to match(hash_including({:machine => machine}))
+        end
+      end
     end
   end
 
@@ -88,6 +367,11 @@ describe VagrantPlugins::ProviderLibvirt::Action do
 
           expect(runner.run(subject.action_halt)).to match(hash_including({:machine => machine}))
         end
+
+        it 'should clear forwarded ports' do
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ClearForwardedPorts).to receive(:call)
+          expect(runner.run(subject.action_halt)).to match(hash_including({:machine => machine}))
+        end
       end
 
       context 'when shutdown domain fails' do
@@ -100,6 +384,103 @@ describe VagrantPlugins::ProviderLibvirt::Action do
           expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::HaltDomain).to receive(:call)
 
           expect(runner.run(subject.action_halt)).to match(hash_including({:machine => machine}))
+        end
+      end
+    end
+  end
+
+  describe '#action_suspend' do
+    context 'not created' do
+      before do
+        expect(state).to receive(:id).and_return(:not_created)
+      end
+
+      it 'should execute without error' do
+        expect(ui).to receive(:info).with('Domain is not created. Please run `vagrant up` first.')
+
+        expect(runner.run(subject.action_suspend)).to match(hash_including({:machine => machine}))
+      end
+    end
+
+    context 'when created' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+      end
+
+      context 'when running' do
+        before do
+          allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, true)
+        end
+
+        it 'should clear ports and suspend the domain' do
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ClearForwardedPorts).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SuspendDomain).to receive_and_call_next
+
+          expect(runner.run(subject.action_suspend)).to match(hash_including({:machine => machine}))
+        end
+      end
+
+      context 'when not running' do
+        before do
+          allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, false)
+        end
+
+        it 'should report not running' do
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ClearForwardedPorts).to_not receive(:call)
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SuspendDomain).to_not receive(:call)
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::MessageNotRunning).to receive_and_call_next
+
+          expect(runner.run(subject.action_suspend)).to match(hash_including({:machine => machine}))
+        end
+      end
+    end
+  end
+
+  describe '#action_resume' do
+    context 'not created' do
+      before do
+        expect(state).to receive(:id).and_return(:not_created)
+      end
+
+      it 'should execute without error' do
+        expect(ui).to receive(:info).with('Domain is not created. Please run `vagrant up` first.')
+
+        expect(runner.run(subject.action_resume)).to match(hash_including({:machine => machine}))
+      end
+    end
+
+    context 'when created' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+      end
+
+      context 'when suspended' do
+        before do
+          allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsSuspended, true)
+        end
+
+        it 'should setup networking resume domain and forward ports' do
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResumeDomain).to receive_and_call_next
+          expect_any_instance_of(Vagrant::Action::Builtin::Provision).to receive_and_call_next
+          expect_any_instance_of(Vagrant::Action::Builtin::WaitForCommunicator).to receive_and_call_next
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ForwardPorts).to receive_and_call_next
+
+          expect(runner.run(subject.action_resume)).to match(hash_including({:machine => machine}))
+        end
+      end
+
+      context 'when not suspended' do
+        before do
+          allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsSuspended, false)
+        end
+
+        it 'should report not running' do
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to_not receive(:call)
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResumeDomain).to_not receive(:call)
+          expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::MessageNotSuspended).to receive_and_call_next
+
+          expect(runner.run(subject.action_resume)).to match(hash_including({:machine => machine}))
         end
       end
     end


### PR DESCRIPTION
Ensure forwarded ports are cleared on suspend and recreated on resume.
Included tests to exercise the entire up/start behaviour to ensure the
expected actions are called in various scenarios, moving config validate
to only occur at the entrypoints and dropping it from being called
during start. Also eliminate a duplicate SetupComplete call.

Fixes: #1115
