### PR TITLE
extra disk :device is optional, causes nil to String error

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -47,14 +47,16 @@ module VagrantPlugins
 
           # additional disk bus
           config.disks.each do |disk|
-            device = disk[:device]
-            bus = disk[:bus]
-            REXML::XPath.each(xml_descr, '/domain/devices/disk[@device="disk"]/target[@dev="' + device + '"]') do |disk_target|
-              next unless disk_target.attributes['bus'] != bus
-              @logger.debug "disk #{device} bus updated from '#{disk_target.attributes['bus']}' to '#{bus}'"
-              descr_changed = true
-              disk_target.attributes['bus'] = bus
-              disk_target.parent.delete_element("#{disk_target.parent.xpath}/address")
+            if disk[:device]
+              device = disk[:device]
+              bus = disk[:bus]
+              REXML::XPath.each(xml_descr, '/domain/devices/disk[@device="disk"]/target[@dev="' + device + '"]') do |disk_target|
+                next unless disk_target.attributes['bus'] != bus
+                @logger.debug "disk #{device} bus updated from '#{disk_target.attributes['bus']}' to '#{bus}'"
+                descr_changed = true
+                disk_target.attributes['bus'] = bus
+                disk_target.parent.delete_element("#{disk_target.parent.xpath}/address")
+              end
             end
           end
 


### PR DESCRIPTION
When you add an additional disk with all default settings you get an error when issuing `vagrant reload`

example extra disk:

```
libvirt.storage :file, :size => '20G'
```

on `vagrant reload` you get:

```
/home/ike/.vagrant.d/gems/3.0.4/gems/vagrant-libvirt-0.10.8/lib/vagrant-libvirt/action/start_domain.rb:52:in `+': no implicit conversion of nil into String (TypeError)
        from /home/ike/.vagrant.d/gems/3.0.4/gems/vagrant-libvirt-0.10.8/lib/vagrant-libvirt/action/start_domain.rb:52:in `block in call'
        from /home/ike/.vagrant.d/gems/3.0.4/gems/vagrant-libvirt-0.10.8/lib/vagrant-libvirt/action/start_domain.rb:49:in `each'
```

So this now first checks if the :device is set before trying to do the xpath query for the device

Signed-off-by: BlackEagle <ike.devolder@gmail.com>