### PR TITLE
Correct destroy method call logic

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
              env[:machine].provider_config.cdroms.empty?
             # if using default configuration of disks and cdroms
             # cdroms are consider volumes, but cannot be destroyed
-            destroy_domain(domain, destroy_volumes: true, flags: undefine_flags)
+            domain.destroy(destroy_volumes: true, flags: undefine_flags)
           else
             domain_xml = libvirt_domain.xml_desc(1)
             xml_descr = REXML::Document.new(domain_xml)
@@ -64,7 +64,7 @@ module VagrantPlugins
               env[:ui].warn(I18n.t('vagrant_libvirt.domain_xml.obsolete_method'))
             end
 
-            destroy_domain(domain, destroy_volumes: false, flags: undefine_flags)
+            domain.destroy(destroy_volumes: false, flags: undefine_flags)
 
             volumes = domain.volumes
 
@@ -169,14 +169,6 @@ module VagrantPlugins
               x.path =~ /\/#{disk[:path]}$/ && x.pool_name == poolname
             end.first
             libvirt_disk.destroy if libvirt_disk
-          end
-        end
-
-        def destroy_domain(domain, destroy_volumes:, flags:)
-          if domain.method(:destroy).parameters.first.include?(:flags)
-            domain.destroy(destroy_volumes: destroy_volumes, flags: flags)
-          else
-            domain.destroy(destroy_volumes: destroy_volumes)
           end
         end
       end

--- a/spec/unit/action/destroy_domain_spec.rb
+++ b/spec/unit/action/destroy_domain_spec.rb
@@ -17,14 +17,10 @@ describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
 
   let(:domain_xml) { File.read(File.join(File.dirname(__FILE__), File.basename(__FILE__, '.rb'), domain_xml_file)) }
 
-  let(:destroy_method) { double('destroy_method') }
-
   before do
     allow(machine.provider).to receive('driver').and_return(driver)
     allow(driver).to receive(:connection).and_return(connection)
     allow(logger).to receive(:info)
-    allow(domain).to receive(:method).with(:destroy).and_return(destroy_method)
-    allow(destroy_method).to receive(:parameters).and_return([[:opt, :options, :flags]])
   end
 
   describe '#call' do
@@ -202,17 +198,6 @@ describe VagrantPlugins::ProviderLibvirt::Action::DestroyDomain do
         it 'sets destroy flags to keep nvram' do
           expect(domain).to receive(:destroy).with(destroy_volumes: true, flags: VagrantPlugins::ProviderLibvirt::Util::DomainFlags::VIR_DOMAIN_UNDEFINE_KEEP_NVRAM)
           expect(subject.call(env)).to be_nil
-        end
-
-        context 'when fog does not support destroy with flags' do
-          before do
-            expect(destroy_method).to receive(:parameters).and_return([[:opt, :options]])
-          end
-
-          it 'skips setting additional destroy flags' do
-            expect(domain).to receive(:destroy).with(destroy_volumes: true)
-            expect(subject.call(env)).to be_nil
-          end
         end
       end
 


### PR DESCRIPTION
Actual implementation of the flags behaviour was different than the code
expected. Update to use the correct behaviour.
