### PR TITLE
Handle pmsuspended resume and add state translation message

### DIFF
--- a/lib/vagrant-libvirt/action/is_suspended.rb
+++ b/lib/vagrant-libvirt/action/is_suspended.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
             if libvirt_domain.has_managed_save?
               env[:result] = env[:machine].state.id == :shutoff
             else
-              env[:result] = env[:machine].state.id == :paused
+              env[:result] = [:paused, :pmsuspended].include?(env[:machine].state.id)
               if env[:result]
                 env[:ui].warn('One time switching to pause suspend mode, found a paused VM.')
                 config.suspend_mode = 'pause'
@@ -32,7 +32,7 @@ module VagrantPlugins
               env[:result] = [:shutoff, :paused].include?(env[:machine].state.id)
               config.suspend_mode = 'managedsave'
             else
-              env[:result] = env[:machine].state.id == :paused
+              env[:result] = [:paused, :pmsuspended].include?(env[:machine].state.id)
             end
           end
 

--- a/lib/vagrant-libvirt/action/resume_domain.rb
+++ b/lib/vagrant-libvirt/action/resume_domain.rb
@@ -20,7 +20,9 @@ module VagrantPlugins
 
           libvirt_domain = env[:machine].provider.driver.connection.client.lookup_domain_by_uuid(env[:machine].id)
           config = env[:machine].provider_config
-          if config.suspend_mode == 'managedsave'
+          if env[:machine].state.id == :pmsuspended
+            libvirt_domain.pmwakeup
+          elsif config.suspend_mode == 'managedsave'
             domain.start
           else
             domain.resume

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -205,6 +205,8 @@ en:
     states:
       paused: |-
         The Libvirt domain is suspended. Run `vagrant resume` to resume it.
+      pmsuspended: |-
+        The Libvirt domain is suspended. Run `vagrant resume` to resume it.
       shutting_down: |-
         The Libvirt domain is shutting down. Wait for it to complete and
         then run `vagrant up` to start it or `vagrant destroy` to remove.


### PR DESCRIPTION
Ensure there is a translation message for state and call the correct
wakeup depending on which form of suspend/pause the machine is in.

Closes: #1200
