### PR TITLE
Handle autoport when port explicit set

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -272,12 +272,24 @@ module VagrantPlugins
               graphics.attributes['listen'] = config.graphics_ip
               graphics.delete_element('//listen')
             end
-            if graphics.attributes['autoport'] != config.graphics_autoport
-              descr_changed = true
-              graphics.attributes['autoport'] = config.graphics_autoport
-              if config.graphics_autoport == 'no'
-                graphics.attributes.delete('autoport')
+            unless config.graphics_port.nil? or config.graphics_port == -1
+              if graphics.attributes['autoport'] != 'no'
+                descr_changed = true
+                graphics.attributes['autoport'] = 'no'
+              end
+              if graphics.attributes['port'] != config.graphics_port
+                descr_changed = true
                 graphics.attributes['port'] = config.graphics_port
+              end
+            else
+              if graphics.attributes['autoport'] != config.graphics_autoport
+                descr_changed = true
+                graphics.attributes['autoport'] = config.graphics_autoport
+                if config.graphics_autoport == 'no'
+                  graphics.attributes['port'] = config.graphics_port
+                else
+                  graphics.attributes['port'] = '-1'
+                end
               end
             end
             if graphics.attributes['websocket'] != config.graphics_websocket.to_s


### PR DESCRIPTION
Better handle setting the autoport value when the port is explicitly set
to ensure that the XML sent to update the VM is correct and will be the
XML that is reflected in the defined machine.

By prioritizing checking if the port is provided, graphics_autoport =
"yes" is ignored.

Fixes: #1687
