### PR TITLE
Drop testing against ruby 2.2 for vagrant 2.0.4

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,9 +29,6 @@ jobs:
         vagrant: [main]
         allow_fail: [true]
         include:
-          - ruby: 2.2.10
-            vagrant: v2.0.4
-            allow_fail: false
           - ruby: 2.3.5
             vagrant: v2.1.5
             allow_fail: false


### PR DESCRIPTION
Vagrant 2.0.4 no longer appears in any supported release of a distro,
therefore drop testing of it in CI along with the version of ruby
needed.
