### PR TITLE
Use configured_networks helper in validate

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -40,7 +40,7 @@ module VagrantPlugins
 
           # Vagrant gives you adapter 0 by default
           # Assign interfaces to slots.
-          configured_networks(env, @logger).each do |options|
+          configured_networks(env[:machine], @logger).each do |options|
             # don't need to create interface for this type
             next if options[:iface_type] == :forwarded_port
 

--- a/lib/vagrant-libvirt/action/create_networks.rb
+++ b/lib/vagrant-libvirt/action/create_networks.rb
@@ -47,7 +47,7 @@ module VagrantPlugins
           @@lock.synchronize do
             # Iterate over networks If some network is not
             # available, create it if possible. Otherwise raise an error.
-            configured_networks(env, @logger).each do |options|
+            configured_networks(env[:machine], @logger).each do |options|
               # Only need to create private networks
               next if options[:iface_type] != :private_network ||
                       options.fetch(:tunnel_type, nil)

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -18,22 +18,22 @@ module VagrantPlugins
       module NetworkUtil
         include Vagrant::Util::NetworkIP
 
-        def configured_networks(env, logger)
-          qemu_use_session = env[:machine].provider_config.qemu_use_session
-          qemu_use_agent = env[:machine].provider_config.qemu_use_agent
-          management_network_device = env[:machine].provider_config.management_network_device
-          management_network_name = env[:machine].provider_config.management_network_name
-          management_network_address = env[:machine].provider_config.management_network_address
-          management_network_mode = env[:machine].provider_config.management_network_mode
-          management_network_mac = env[:machine].provider_config.management_network_mac
-          management_network_guest_ipv6 = env[:machine].provider_config.management_network_guest_ipv6
-          management_network_autostart = env[:machine].provider_config.management_network_autostart
-          management_network_pci_bus = env[:machine].provider_config.management_network_pci_bus
-          management_network_pci_slot = env[:machine].provider_config.management_network_pci_slot
-          management_network_domain = env[:machine].provider_config.management_network_domain
-          management_network_mtu = env[:machine].provider_config.management_network_mtu
-          management_network_keep = env[:machine].provider_config.management_network_keep
-          management_network_driver_iommu = env[:machine].provider_config.management_network_driver_iommu
+        def configured_networks(machine, logger)
+          qemu_use_session = machine.provider_config.qemu_use_session
+          qemu_use_agent = machine.provider_config.qemu_use_agent
+          management_network_device = machine.provider_config.management_network_device
+          management_network_name = machine.provider_config.management_network_name
+          management_network_address = machine.provider_config.management_network_address
+          management_network_mode = machine.provider_config.management_network_mode
+          management_network_mac = machine.provider_config.management_network_mac
+          management_network_guest_ipv6 = machine.provider_config.management_network_guest_ipv6
+          management_network_autostart = machine.provider_config.management_network_autostart
+          management_network_pci_bus = machine.provider_config.management_network_pci_bus
+          management_network_pci_slot = machine.provider_config.management_network_pci_slot
+          management_network_domain = machine.provider_config.management_network_domain
+          management_network_mtu = machine.provider_config.management_network_mtu
+          management_network_keep = machine.provider_config.management_network_keep
+          management_network_driver_iommu = machine.provider_config.management_network_driver_iommu
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -101,23 +101,23 @@ module VagrantPlugins
           # if there is a box and management network is disabled
           # need qemu agent enabled and at least one network that can be accessed
           if (
-            env[:machine].config.vm.box &&
-            !env[:machine].provider_config.mgmt_attach &&
-            !env[:machine].provider_config.qemu_use_agent &&
-            !env[:machine].config.vm.networks.any? { |type, _| ["private_network", "public_network"].include?(type.to_s) }
+            machine.config.vm.box &&
+            !machine.provider_config.mgmt_attach &&
+            !machine.provider_config.qemu_use_agent &&
+            !machine.config.vm.networks.any? { |type, _| ["private_network", "public_network"].include?(type.to_s) }
           )
             raise Errors::ManagementNetworkRequired
           end
 
           # add management network to list of networks to check
           # unless mgmt_attach set to false
-          networks = if env[:machine].provider_config.mgmt_attach
+          networks = if machine.provider_config.mgmt_attach
                        [management_network_options]
                      else
                        []
                      end
 
-          env[:machine].config.vm.networks.each do |type, original_options|
+          machine.config.vm.networks.each do |type, original_options|
             logger.debug "In config found network type #{type} options #{original_options}"
             # Options can be specified in Vagrantfile in short format (:ip => ...),
             # or provider format # (:libvirt__network_name => ...).

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -768,8 +768,11 @@ describe VagrantPlugins::ProviderLibvirt::Config do
 
     context 'with mac defined' do
       let (:vm) { double('vm') }
+      let(:box) { instance_double(::Vagrant::Box) }
+
       before do
         machine.config.instance_variable_get("@keys")[:vm] = vm
+        allow(vm).to receive(:box).and_return(box)
       end
 
       it 'is valid with valid mac' do
@@ -781,7 +784,7 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         network = [:public, { mac: 'aabbccddeeff' }]
         expect(vm).to receive(:networks).and_return([network])
         assert_valid
-        expect(network[1][:mac]).to eql('aa:bb:cc:dd:ee:ff')
+        expect(network[1][:mac]).to eql('aabbccddeeff')
       end
 
       it 'should be invalid if MAC not formatted correctly' do
@@ -996,10 +999,16 @@ describe VagrantPlugins::ProviderLibvirt::Config do
         EOF
       end
       let(:driver) { instance_double(::VagrantPlugins::ProviderLibvirt::Driver) }
+      let(:host_devices) { [
+        'lo',
+        'eth0',
+        'virbr0',
+      ] }
 
       before do
         allow(machine.provider).to receive(:driver).and_return(driver)
         allow(driver).to receive_message_chain('connection.client.libversion').and_return(6_002_000)
+        allow(driver).to receive(:host_devices).and_return(host_devices)
       end
 
       context 'when type is 9p' do


### PR DESCRIPTION
Switch to configured networks helper in validate to ensure that that the
validation checks the final list of networks that will be used, not just
those initial configured.

This will help ensure the management network is validated in addition to
the user specified networks.
