### PR TITLE
Avoid creating extra connection mocks unless needed

### DIFF
--- a/spec/support/unit_context.rb
+++ b/spec/support/unit_context.rb
@@ -29,12 +29,9 @@ shared_context 'unit' do
 
   # Mock the communicator to prevent SSH commands for being executed.
   let(:communicator)     { double('communicator') }
-  # Mock the guest operating system.
-  let(:guest)            { double('guest') }
   let(:app)              { ->(env) {} }
 
   before (:each) do
-    allow(machine).to receive(:guest).and_return(guest)
     allow(machine).to receive(:communicate).and_return(communicator)
     allow(machine).to receive(:ui).and_return(ui)
   end

--- a/spec/unit/cap/mount_9p_spec.rb
+++ b/spec/unit/cap/mount_9p_spec.rb
@@ -15,6 +15,9 @@ describe 'VagrantPlugins::ProviderLibvirt::Cap::Mount9P' do
   end
 
   let(:options) { {} }
+  # Mock the guest operating system.
+  let(:guest)            { double('guest') }
+
   describe '#mount_9p_shared_folder' do
     let(:synced_folders) { {
       "/vagrant" => {
@@ -26,6 +29,7 @@ describe 'VagrantPlugins::ProviderLibvirt::Cap::Mount9P' do
     } }
 
     before do
+      allow(machine).to receive(:guest).and_return(guest)
       allow(guest).to receive(:capability).and_return('/home/vagrant/vagant')
       allow(communicator).to receive(:sudo).with('mkdir -p /home/vagrant/vagant')
     end

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -42,40 +42,51 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
     # need to override the default package iso_env as using a different
     # name for the test machines above.
     let(:machine)    { iso_env.machine(:test1, :libvirt) }
-    let(:machine2)   { iso_env.machine(:test2, :libvirt) }
-    let(:connection1) { double("connection 1") }
-    let(:connection2) { double("connection 2") }
-    let(:system_connection1) { double("system connection 1") }
-    let(:system_connection2) { double("system connection 2") }
+    let(:connection) { double("connection 1") }
+    let(:system_connection) { double("system connection 1") }
 
     # make it easier for distros that want to switch the default value for
     # qemu_use_session to true by ensuring it is explicitly false for tests.
     before do
       allow(machine.provider).to receive('driver').and_call_original
-      allow(machine2.provider).to receive('driver').and_call_original
     end
 
     describe '#connection' do
+      let(:machine2)   { iso_env.machine(:test2, :libvirt) }
+      let(:connection2) { double("connection 2") }
+
+      before do
+        allow(machine2.provider).to receive('driver').and_call_original
+      end
+
       it 'should configure a separate connection per machine' do
         expect(Fog::Compute).to receive(:new).with(
-          hash_including({:libvirt_uri => 'qemu+ssh://user@remote1/system'})).and_return(connection1)
+          hash_including({:libvirt_uri => 'qemu+ssh://user@remote1/system'})).and_return(connection)
         expect(Fog::Compute).to receive(:new).with(
           hash_including({:libvirt_uri => 'qemu+ssh://vms@remote2/system'})).and_return(connection2)
 
-        expect(machine.provider.driver.connection).to eq(connection1)
+        expect(machine.provider.driver.connection).to eq(connection)
         expect(machine2.provider.driver.connection).to eq(connection2)
       end
 
       it 'should configure the connection once' do
-        expect(Fog::Compute).to receive(:new).once().and_return(connection1)
+        expect(Fog::Compute).to receive(:new).once().and_return(connection)
 
-        expect(machine.provider.driver.connection).to eq(connection1)
-        expect(machine.provider.driver.connection).to eq(connection1)
-        expect(machine.provider.driver.connection).to eq(connection1)
+        expect(machine.provider.driver.connection).to eq(connection)
+        expect(machine.provider.driver.connection).to eq(connection)
+        expect(machine.provider.driver.connection).to eq(connection)
       end
     end
 
     describe '#system_connection' do
+      let(:machine2)   { iso_env.machine(:test2, :libvirt) }
+      let(:connection2) { double("connection 2") }
+      let(:system_connection2) { double("system connection 2") }
+
+      before do
+        allow(machine2.provider).to receive('driver').and_call_original
+      end
+
       # note that the urls for the two tests are currently
       # incorrect here as they should be the following:
       #   qemu+ssh://user@remote1/system
@@ -87,19 +98,19 @@ describe VagrantPlugins::ProviderLibvirt::Driver do
       # system_uri should be 'qemu+ssh://user@remote1/system'
       # and not 'qemu:///system'.
       it 'should configure a separate connection per machine' do
-        expect(Libvirt).to receive(:open_read_only).with('qemu+ssh://user@remote1/system').and_return(system_connection1)
+        expect(Libvirt).to receive(:open_read_only).with('qemu+ssh://user@remote1/system').and_return(system_connection)
         expect(Libvirt).to receive(:open_read_only).with('qemu+ssh://vms@remote2/system').and_return(system_connection2)
 
-        expect(machine.provider.driver.system_connection).to eq(system_connection1)
+        expect(machine.provider.driver.system_connection).to eq(system_connection)
         expect(machine2.provider.driver.system_connection).to eq(system_connection2)
       end
 
       it 'should configure the connection once' do
-        expect(Libvirt).to receive(:open_read_only).with('qemu+ssh://user@remote1/system').and_return(system_connection1)
+        expect(Libvirt).to receive(:open_read_only).with('qemu+ssh://user@remote1/system').and_return(system_connection)
 
-        expect(machine.provider.driver.system_connection).to eq(system_connection1)
-        expect(machine.provider.driver.system_connection).to eq(system_connection1)
-        expect(machine.provider.driver.system_connection).to eq(system_connection1)
+        expect(machine.provider.driver.system_connection).to eq(system_connection)
+        expect(machine.provider.driver.system_connection).to eq(system_connection)
+        expect(machine.provider.driver.system_connection).to eq(system_connection)
       end
     end
   end


### PR DESCRIPTION
Remove duplication of connection/machine mocks except for the tests
exercising multi machine related tests.
