### PR TITLE
Fix issue where "iommu" was configured for non-virtio network devices

### DIFF
--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -150,7 +150,7 @@ module VagrantPlugins
               # FIXME: all options for network driver should be hash from Vagrantfile
               driver_options = {}
               driver_options[:name] = @driver_name if @driver_name
-              driver_options[:iommu] = @driver_iommu ? "on" : "off" if @nic_model_type == 'virtio'
+              driver_options[:iommu] = @driver_iommu ? "on" : "off" if @model_type == 'virtio'
               driver_options[:queues] = @driver_queues if @driver_queues
 
               @udp_tunnel ||= {}


### PR DESCRIPTION
When setting the `model_type` of a network to something else than `virtio`, the `iommu` parameter was still set for the device which isn't allowed.

I noticed that the if-statement for setting the parameter was looking at the default NIC model type (in `@nic_model_type`) instead of final, configured value in `@model_type`. This PR changes that.

I wanted to add a test but my experience with the Ruby world is 0. I couldn't find an existing test that was easily adopted. I think I only saw tests that go from XML -> configuration object, and not the other way around? If you can guide me in where/how I could add a test I'd happily do so.