### PR TITLE
[Fix] forward_ports.rb@redirect_port: no implicit conversion of String into Array (TypeError)

### DIFF
--- a/lib/vagrant-libvirt/action/forward_ports.rb
+++ b/lib/vagrant-libvirt/action/forward_ports.rb
@@ -93,7 +93,7 @@ module VagrantPlugins
             -N
             #{ssh_info[:host]}
           )
-          params += '-g' if gateway_ports
+          params <<= '-g' if gateway_ports
 
           options = (%W(
             User=#{ssh_info[:username]}


### PR DESCRIPTION
Hi 👋🏾 ,

When attempting to do port forwarding with the `gateway_ports` option enabled, this error occurs.

![Screenshot_2023-01-16_12-29](https://user-images.githubusercontent.com/6665717/212675018-ae1a47f5-fbc2-426d-a18c-82824811276a.png)

Regards
