### PR TITLE
Make NIC model type for management interface configurable

### DIFF
--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -592,6 +592,7 @@ used by this network are configurable at the provider level.
   the Libvirt default (1500) will be used.
 * `management_network_keep` - Starting from version *0.7.0*, *always_destroy* is set to *true* by default for any network.
   This option allows to change this behaviour for the management network.
+* `management_network_model_type` - Model of the network adapter to use for the management interface. Default is 'virtio'.
 
 You may wonder how vagrant-libvirt knows the IP address a VM received.  Libvirt
 doesn't provide a standard way to find out the IP address of a running domain.

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -70,6 +70,7 @@ module VagrantPlugins
       attr_accessor :management_network_mtu
       attr_accessor :management_network_keep
       attr_accessor :management_network_driver_iommu
+      attr_accessor :management_network_model_type
 
       # System connection information
       attr_accessor :system_uri
@@ -253,6 +254,7 @@ module VagrantPlugins
         @management_network_mtu = UNSET_VALUE
         @management_network_keep = UNSET_VALUE
         @management_network_driver_iommu = UNSET_VALUE
+        @management_network_model_type = UNSET_VALUE
 
         # System connection information
         @system_uri      = UNSET_VALUE
@@ -963,6 +965,7 @@ module VagrantPlugins
         @management_network_mtu = nil if @management_network_mtu == UNSET_VALUE
         @management_network_keep = false if @management_network_keep == UNSET_VALUE
         @management_network_driver_iommu = false if @management_network_driver_iommu == UNSET_VALUE
+        @management_network_model_type = 'virtio' if @management_network_model_type == UNSET_VALUE
 
         # Domain specific settings.
         @title = '' if @title == UNSET_VALUE

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
           management_network_mtu = machine.provider_config.management_network_mtu
           management_network_keep = machine.provider_config.management_network_keep
           management_network_driver_iommu = machine.provider_config.management_network_driver_iommu
+          management_network_model_type = machine.provider_config.management_network_model_type
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
           begin
@@ -54,6 +55,7 @@ module VagrantPlugins
           if qemu_use_session
             management_network_options = {
               iface_type: :public_network,
+              model_type: management_network_model_type,
               dev: management_network_device,
               mode: 'bridge',
               type: 'bridge',
@@ -63,6 +65,7 @@ module VagrantPlugins
           else
             management_network_options = {
               iface_type: :private_network,
+              model_type: management_network_model_type,
               network_name: management_network_name,
               ip: Regexp.last_match(1),
               netmask: Regexp.last_match(2),


### PR DESCRIPTION
Somewhat related to my previous pull request: https://github.com/vagrant-libvirt/vagrant-libvirt/pull/1702 (thanks for merging it)

This PR adds a configuration option for setting the NIC model type for the management interface, which defaults to `virtio` (the current value)

The context for this change is that I was having severe speed issues with `virtio` (which have now disappeared, probably after a QEMU update) and the `e1000e` NIC was doing much better.

So while I don't need this change myself anymore, seeing that there are already many other management NIC settings in the plugin I thought this one could still be useful.