### PR TITLE
Allow a mock object to receive synced_folders in config validation spec.

### DIFF
--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -773,6 +773,8 @@ describe VagrantPlugins::ProviderLibvirt::Config do
       before do
         machine.config.instance_variable_get("@keys")[:vm] = vm
         allow(vm).to receive(:box).and_return(box)
+
+        allow(vm).to receive(:synced_folders).and_return({})
       end
 
       it 'is valid with valid mac' do


### PR DESCRIPTION
When using qemu session, the config is checked
if there are 9p synced folders.
We do not care about synced folders when we want to check if the MAC address is defined correctly.

The result is a failure from the mock object:
`#<Double "vm"> received unexpected message :synced_folders with (no args)`

===

This was found while updating the vagrant-libvirt package to 0.11.2 in Fedora, where we use qemu:///session by default and run the tests with that instead of qemu:///system from config files.

The full failure from spec suite:

```
Failures:

  1) VagrantPlugins::ProviderLibvirt::Config#validate with mac defined is valid with valid mac
     Failure/Error:
       synced_folders(machine).fetch(:"9p", []).each do |_, options|
         unless File.readable?(options[:hostpath])
           errors << "9p synced_folder cannot mount host path #{options[:hostpath]} into guest #{options[:guestpath]} when using qemu session as executing user does not have permissions to read the directory on the user."
         end

       #<Double "vm"> received unexpected message :synced_folders with (no args)
     # /usr/share/vagrant/gems/gems/vagrant-2.2.19/lib/vagrant/action/builtin/mixin_synced_folders.rb:123:in `synced_folders'
     # ./lib/vagrant-libvirt/config.rb:1242:in `validate'
     # ./spec/unit/config_spec.rb:743:in `assert_valid'
     # ./spec/unit/config_spec.rb:777:in `block (4 levels) in <top (required)>'
     # ./spec/support/unit_context.rb:51:in `block (3 levels) in <top (required)>'
     # ./spec/support/unit_context.rb:43:in `block (2 levels) in <top (required)>'
     # /usr/share/gems/gems/bundler-2.4.1/libexec/bundle:45:in `block in <top (required)>'
     # /usr/share/gems/gems/bundler-2.4.1/libexec/bundle:33:in `<top (required)>'

  2) VagrantPlugins::ProviderLibvirt::Config#validate with mac defined is valid with MAC containing no delimiters
     Failure/Error:
       synced_folders(machine).fetch(:"9p", []).each do |_, options|
         unless File.readable?(options[:hostpath])
           errors << "9p synced_folder cannot mount host path #{options[:hostpath]} into guest #{options[:guestpath]} when using qemu session as executing user does not have permissions to read the directory on the user."
         end

       #<Double "vm"> received unexpected message :synced_folders with (no args)
     # /usr/share/vagrant/gems/gems/vagrant-2.2.19/lib/vagrant/action/builtin/mixin_synced_folders.rb:123:in `synced_folders'
     # ./lib/vagrant-libvirt/config.rb:1242:in `validate'
     # ./spec/unit/config_spec.rb:743:in `assert_valid'
     # ./spec/unit/config_spec.rb:783:in `block (4 levels) in <top (required)>'
     # ./spec/support/unit_context.rb:51:in `block (3 levels) in <top (required)>'
     # ./spec/support/unit_context.rb:43:in `block (2 levels) in <top (required)>'
     # /usr/share/gems/gems/bundler-2.4.1/libexec/bundle:45:in `block in <top (required)>'
     # /usr/share/gems/gems/bundler-2.4.1/libexec/bundle:33:in `<top (required)>'

  3) VagrantPlugins::ProviderLibvirt::Config#validate with mac defined should be invalid if MAC not formatted correctly
     Failure/Error:
       synced_folders(machine).fetch(:"9p", []).each do |_, options|
         unless File.readable?(options[:hostpath])
           errors << "9p synced_folder cannot mount host path #{options[:hostpath]} into guest #{options[:guestpath]} when using qemu session as executing user does not have permissions to read the directory on the user."
         end

       #<Double "vm"> received unexpected message :synced_folders with (no args)
     # /usr/share/vagrant/gems/gems/vagrant-2.2.19/lib/vagrant/action/builtin/mixin_synced_folders.rb:123:in `synced_folders'
     # ./lib/vagrant-libvirt/config.rb:1242:in `validate'
     # ./spec/unit/config_spec.rb:736:in `assert_invalid'
     # ./spec/unit/config_spec.rb:789:in `block (4 levels) in <top (required)>'
     # ./spec/support/unit_context.rb:51:in `block (3 levels) in <top (required)>'
     # ./spec/support/unit_context.rb:43:in `block (2 levels) in <top (required)>'
     # /usr/share/gems/gems/bundler-2.4.1/libexec/bundle:45:in `block in <top (required)>'
     # /usr/share/gems/gems/bundler-2.4.1/libexec/bundle:33:in `<top (required)>'

Finished in 2 minutes 3.5 seconds (files took 0.76763 seconds to load)
363 examples, 3 failures

Failed examples:

rspec ./spec/unit/config_spec.rb:775 # VagrantPlugins::ProviderLibvirt::Config#validate with mac defined is valid with valid mac
rspec ./spec/unit/config_spec.rb:780 # VagrantPlugins::ProviderLibvirt::Config#validate with mac defined is valid with MAC containing no delimiters
rspec ./spec/unit/config_spec.rb:787 # VagrantPlugins::ProviderLibvirt::Config#validate with mac defined should be invalid if MAC not formatted correctly
```