### PR TITLE
Fix duplicate provisioning of running VMs

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -128,9 +128,7 @@ module VagrantPlugins
       private_class_method def self.action_start
         Vagrant::Action::Builder.new.tap do |b|
           b.use Call, IsRunning do |env, b2|
-            # If the VM is running, run the necessary provisioners
             if env[:result]
-              b2.use action_provision
               next
             end
 

--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -58,7 +58,7 @@ describe VagrantPlugins::ProviderLibvirt::Action do
   end
 
   def receive_and_call_next(&block)
-    return receive(:call) { |cls, env| call_next(cls, env, &block) }
+    return receive(:call) { |cls, env| call_next(cls, env, &block) }.exactly(1).times
   end
 
   def call_next(cls, env)
@@ -385,6 +385,35 @@ describe VagrantPlugins::ProviderLibvirt::Action do
 
           expect(runner.run(subject.action_halt)).to match(hash_including({:machine => machine}))
         end
+      end
+    end
+  end
+
+  describe '#action_reload' do
+    context 'when not created' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, false)
+      end
+      
+      it 'should report not created' do
+        expect(ui).to receive(:info).with('Domain is not created. Please run `vagrant up` first.')
+
+        expect(runner.run(subject.action_reload)).to match(hash_including({:machine => machine}))
+      end
+    end
+
+    context 'should call reload' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+      end
+
+      it 'should call reload' do
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+        expect(subject).to receive(:action_halt).and_return(Vagrant::Action::Builder.new)
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+        expect(subject).to receive(:action_start).and_return(Vagrant::Action::Builder.new)
+        
+        expect(runner.run(subject.action_reload)).to match(hash_including({:machine => machine}))
       end
     end
   end

--- a/spec/unit/action_spec.rb
+++ b/spec/unit/action_spec.rb
@@ -332,6 +332,25 @@ describe VagrantPlugins::ProviderLibvirt::Action do
         end
       end
     end
+
+    context 'running' do
+      before do
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, true)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsSuspended, false)
+      end
+
+      it 'should call provision' do
+        expect_any_instance_of(Vagrant::Action::Builtin::BoxCheckOutdated).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
+        # ideally following two actions should not be scheduled if the machine is already running
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::CreateNetworks).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetupComplete).to receive_and_call_next
+
+        expect(runner.run(subject.action_up)).to match(hash_including({:machine => machine}))
+      end
+    end
   end
 
   describe '#action_halt' do
@@ -394,7 +413,7 @@ describe VagrantPlugins::ProviderLibvirt::Action do
       before do
         allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, false)
       end
-      
+
       it 'should report not created' do
         expect(ui).to receive(:info).with('Domain is not created. Please run `vagrant up` first.')
 
@@ -402,17 +421,30 @@ describe VagrantPlugins::ProviderLibvirt::Action do
       end
     end
 
-    context 'should call reload' do
+    context 'when halted' do
       before do
         allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsCreated, true)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsSuspended, false)
+        allow_action_env_result(VagrantPlugins::ProviderLibvirt::Action::IsRunning, false)
       end
 
       it 'should call reload' do
         expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::Provision).to receive_and_call_next
         expect(subject).to receive(:action_halt).and_return(Vagrant::Action::Builder.new)
         expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ResolveDiskSettings).to receive_and_call_next
-        expect(subject).to receive(:action_start).and_return(Vagrant::Action::Builder.new)
-        
+
+        # start action
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::PrepareNFSValidIds).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SyncedFolderCleanup).to receive_and_call_next
+        expect_any_instance_of(Vagrant::Action::Builtin::SyncedFolders).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::PrepareNFSSettings).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ShareFolders).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::SetBootOrder).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::StartDomain).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::WaitTillUp).to receive_and_call_next
+        expect_any_instance_of(Vagrant::Action::Builtin::WaitForCommunicator).to receive_and_call_next
+        expect_any_instance_of(VagrantPlugins::ProviderLibvirt::Action::ForwardPorts).to receive_and_call_next
+
         expect(runner.run(subject.action_reload)).to match(hash_including({:machine => machine}))
       end
     end


### PR DESCRIPTION
Fixes #1710.

I found either deleting the block mentioned in `actions.rb` or removing calls to `Provision` from blocks that also call `action_start` to fix the issue. That said, I went with @electrofelix's recommendation on the former.

I _attempted_ to add behavior to the unit tests that would check that for the actions tested, they would not call other action methods unless explicitly needed to. Though it sounds like actions can call each other _at least_ once. This might not be whats desired so suggestions would be highly appreciated.