### PR TITLE
Feature: Allow specifying type for primary disk

### DIFF
--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -93,7 +93,7 @@ end
   may need to override this (e.g. Debian on _virt_ machine may need _virtio-mmio_).
   Possible values are documented in libvirt's [description for
   _address_](https://libvirt.org/formatdomain.html#elementsAddress).
-* `disk_driver_opts` - Extra options for the main disk driver ([see Libvirt documentation](http://libvirt.org/formatdomain.html#elementsDisks)).
+* `disk_driver` - Extra options for the main disk driver ([see Libvirt documentation](http://libvirt.org/formatdomain.html#elementsDisks)).
   NOTE: this option also applies only to disks associated with a box image. In all cases, the value `nil` can be used to force the hypervisor default behaviour (e.g. to override settings defined in top-level Vagrantfiles). Supported options include:
   * `:cache` - Controls the cache mechanism. Possible values are "default", "none", "writethrough", "writeback", "directsync" and "unsafe".
   * `:io` - Controls specific policies on I/O. Possible values are "threads" and "native".

--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -93,7 +93,7 @@ end
   may need to override this (e.g. Debian on _virt_ machine may need _virtio-mmio_).
   Possible values are documented in libvirt's [description for
   _address_](https://libvirt.org/formatdomain.html#elementsAddress).
-* `disk_driver` - Extra options for the main disk driver ([see Libvirt documentation](http://libvirt.org/formatdomain.html#elementsDisks)).
+* `disk_driver_opts` - Extra options for the main disk driver ([see Libvirt documentation](http://libvirt.org/formatdomain.html#elementsDisks)).
   NOTE: this option also applies only to disks associated with a box image. In all cases, the value `nil` can be used to force the hypervisor default behaviour (e.g. to override settings defined in top-level Vagrantfiles). Supported options include:
   * `:cache` - Controls the cache mechanism. Possible values are "default", "none", "writethrough", "writeback", "directsync" and "unsafe".
   * `:io` - Controls specific policies on I/O. Possible values are "threads" and "native".

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -734,7 +734,7 @@ module VagrantPlugins
 
       # Disk driver options for primary disk
       def disk_driver(options = {})
-        supported_opts = [:cache, :io, :copy_on_read, :discard, :detect_zeroes]
+        supported_opts = [:cache, :io, :copy_on_read, :discard, :detect_zeroes, :type]
         @disk_driver_opts = options.select { |k,_| supported_opts.include? k }
       end
 

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -152,12 +152,11 @@
 <%- @domain_volumes.each_with_index do |volume, index| -%>
     <disk type='file' device='disk'>
       <alias name='ua-box-volume-<%= index -%>'/>
-      <driver name='qemu'<%=
-        '%{type}%{cache}%{io}%{copy_on_read}%{discard}%{detect_zeroes}' \
-          % { :type => 'qcow2', :cache => "#{volume[:cache]}", :io => nil, :copy_on_read => nil, :discard => nil, :detect_zeroes => nil }
-            .merge(@disk_driver_opts)
-            .map { |k,v| v.nil? ? [k, ""] : [k, " #{k}='#{v}'"]}.to_h
-      -%>/>
+      <driver name='qemu' <%=
+        {:type => 'qcow2', :cache => "#{volume[:cache]}"}.merge(@disk_driver_opts)
+          .reject { |k,v| v.nil? }
+          .map { |k,v| "#{k}='#{v}'"}
+          .join(' ') -%>/>
       <source file='<%= volume[:absolute_path] %>'/>
       <%# we need to ensure a unique target dev -%>
       <target dev='<%= volume[:device] %>' bus='<%= volume[:bus] %>'/>
@@ -176,13 +175,12 @@
 <%- @disks.each_with_index do |d, index| -%>
     <disk type='file' device='disk'>
       <alias name='ua-disk-volume-<%= index -%>'/>
-      <driver name='qemu'<%=
-        '%{type}%{cache}%{io}%{copy_on_read}%{discard}%{detect_zeroes}' \
-          % { :type => 'qcow2', :cache => nil, :io => nil, :copy_on_read => nil, :discard => nil, :detect_zeroes => nil }
-            .merge(d)
-            .select { |k,_| [:type, :cache, :io, :copy_on_read, :discard, :detect_zeroes].include? k }
-            .map { |k,v| v.nil? ? [k, ""] : [k, " #{k}='#{v}'"]}.to_h
-      -%>/>
+      <driver name='qemu' <%=
+        {:type => 'qcow2'}.merge(d)
+          .select { |k,_| [:type, :cache, :io, :copy_on_read, :discard, :detect_zeroes].include? k }
+          .reject { |k,v| v.nil? }
+          .map { |k,v| "#{k}='#{v}'"}
+          .join(' ') -%>/>
       <source file='<%= d[:absolute_path] %>'/>
       <target dev='<%= d[:device] %>' bus='<%= d[:bus] %>'/>
   <%- if d[:address_type] || @disk_address_type -%>

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -152,11 +152,13 @@
 <%- @domain_volumes.each_with_index do |volume, index| -%>
     <disk type='file' device='disk'>
       <alias name='ua-box-volume-<%= index -%>'/>
-      <driver name='qemu' type='qcow2' <%=
-        @disk_driver_opts.empty? ? "cache='#{volume[:cache]}'" :
-            @disk_driver_opts.reject { |k,v| v.nil? }
-                             .map { |k,v| "#{k}='#{v}'"}
-                             .join(' ') -%>/>
+      <driver name='qemu'<%=
+        '%{type}%{cache}%{io}%{copy_on_read}%{discard}%{detect_zeroes}' \
+          % { :type => 'qcow2', :cache => "#{volume[:cache]}", :io => nil, :copy_on_read => nil, :discard => nil, :detect_zeroes => nil }
+            .merge(@disk_driver_opts)
+            .select { |k,_| [:type, :cache, :io, :copy_on_read, :discard, :detect_zeroes].include? k }
+            .map { |k,v| v.nil? ? [k, ""] : [k, " #{k}='#{v}'"]}.to_h
+      -%>/>
       <source file='<%= volume[:absolute_path] %>'/>
       <%# we need to ensure a unique target dev -%>
       <target dev='<%= volume[:device] %>' bus='<%= volume[:bus] %>'/>
@@ -175,11 +177,12 @@
 <%- @disks.each_with_index do |d, index| -%>
     <disk type='file' device='disk'>
       <alias name='ua-disk-volume-<%= index -%>'/>
-      <driver name='qemu' type='<%= d[:type] %>' <%=
-        d.select { |k,_| [:cache, :io, :copy_on_read, :discard, :detect_zeroes].include? k }
-         .reject { |k,v| v.nil? }
-         .map { |k,v| "#{k}='#{v}'"}
-         .join(' ')
+      <driver name='qemu'<%=
+        '%{type}%{cache}%{io}%{copy_on_read}%{discard}%{detect_zeroes}' \
+          % { :type => 'qcow2', :cache => nil, :io => nil, :copy_on_read => nil, :discard => nil, :detect_zeroes => nil }
+            .merge(d)
+            .select { |k,_| [:type, :cache, :io, :copy_on_read, :discard, :detect_zeroes].include? k }
+            .map { |k,v| v.nil? ? [k, ""] : [k, " #{k}='#{v}'"]}.to_h
       -%>/>
       <source file='<%= d[:absolute_path] %>'/>
       <target dev='<%= d[:device] %>' bus='<%= d[:bus] %>'/>

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -156,7 +156,6 @@
         '%{type}%{cache}%{io}%{copy_on_read}%{discard}%{detect_zeroes}' \
           % { :type => 'qcow2', :cache => "#{volume[:cache]}", :io => nil, :copy_on_read => nil, :discard => nil, :detect_zeroes => nil }
             .merge(@disk_driver_opts)
-            .select { |k,_| [:type, :cache, :io, :copy_on_read, :discard, :detect_zeroes].include? k }
             .map { |k,v| v.nil? ? [k, ""] : [k, " #{k}='#{v}'"]}.to_h
       -%>/>
       <source file='<%= volume[:absolute_path] %>'/>


### PR DESCRIPTION
This PR has changes to allow specifying the `type` for `disk_driver_opts`, rather than hardcoding it to `qcow2`.