### PR TITLE
Ensure tests block if a single matrix job fails

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -102,6 +102,7 @@ jobs:
     - name: Run tests
       run: |
         bundle exec rspec --color --format documentation
+        exit 1
       env:
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - name: Coveralls Parallel

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,6 +77,9 @@ jobs:
       run: |
         gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
         gem update bundler --conservative
+    - name: exit tests early
+      run: |
+        exit 1
     - name: Ensure bundle uses https instead of insecure git
       run: |
         git config --global url."https://github.com/".insteadOf git://github.com/
@@ -102,7 +105,6 @@ jobs:
     - name: Run tests
       run: |
         bundle exec rspec --color --format documentation
-        exit 1
       env:
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - name: Coveralls Parallel
@@ -113,9 +115,18 @@ jobs:
         path-to-lcov: ./coverage/lcov.info
 
   finish:
-    needs: test
+    needs: [test]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+    - name: Check matrix execution status
+      run: exit 1
+      # see https://stackoverflow.com/a/67532120/4907315
+      if: >-
+        ${{
+             contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled')
+        }}
     - name: Coveralls Finished
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -119,6 +119,7 @@ jobs:
     - name: Check matrix execution status
       run: exit 1
       # see https://stackoverflow.com/a/67532120/4907315
+      # and https://github.com/orgs/community/discussions/26822
       if: >-
         ${{
              contains(needs.*.result, 'failure')

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,9 +77,12 @@ jobs:
       run: |
         gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
         gem update bundler --conservative
-    - name: exit tests early
+    - name: exit 1 test run early
       run: |
-        exit 1
+        if [[ "${{ matrix.ruby }}" == "2.7.2" ]]
+        then
+            exit 1
+        fi
     - name: Ensure bundle uses https instead of insecure git
       run: |
         git config --global url."https://github.com/".insteadOf git://github.com/

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -77,12 +77,6 @@ jobs:
       run: |
         gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
         gem update bundler --conservative
-    - name: exit 1 test run early
-      run: |
-        if [[ "${{ matrix.ruby }}" == "2.7.2" ]]
-        then
-            exit 1
-        fi
     - name: Ensure bundle uses https instead of insecure git
       run: |
         git config --global url."https://github.com/".insteadOf git://github.com/


### PR DESCRIPTION
Github will drop a required check if the job is skipped. This can happen
if a job is placed after a matrix execution with the intent to act as the
required status check as well as complete a coverage report for this
repo.