### PR TITLE
specify qcow2 compatibility version to not use very old 0.10 fallback

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain_volume.rb
+++ b/lib/vagrant-libvirt/action/create_domain_volume.rb
@@ -60,6 +60,7 @@ module VagrantPlugins
                       xml.group storage_gid(env)
                       xml.label 'virt_image_t'
                     end
+                    xml.compat '1.1'
                   end
                   xml.backingStore do
                     xml.path(@backing_file)

--- a/spec/unit/action/create_domain_volume_spec/one_disk_in_storage.xml
+++ b/spec/unit/action/create_domain_volume_spec/one_disk_in_storage.xml
@@ -8,6 +8,7 @@
       <group>0</group>
       <label>virt_image_t</label>
     </permissions>
+    <compat>1.1</compat>
   </target>
   <backingStore>
     <path>/test/path_0.img</path>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_0.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_0.xml
@@ -8,6 +8,7 @@
       <group>0</group>
       <label>virt_image_t</label>
     </permissions>
+    <compat>1.1</compat>
   </target>
   <backingStore>
     <path>/test/path_0.img</path>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_1.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_1.xml
@@ -8,6 +8,7 @@
       <group>0</group>
       <label>virt_image_t</label>
     </permissions>
+    <compat>1.1</compat>
   </target>
   <backingStore>
     <path>/test/path_1.img</path>

--- a/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_2.xml
+++ b/spec/unit/action/create_domain_volume_spec/three_disks_in_storage_disk_2.xml
@@ -8,6 +8,7 @@
       <group>0</group>
       <label>virt_image_t</label>
     </permissions>
+    <compat>1.1</compat>
   </target>
   <backingStore>
     <path>/test/path_2.img</path>

--- a/spec/unit/action/handle_box_image_spec.rb
+++ b/spec/unit/action/handle_box_image_spec.rb
@@ -88,6 +88,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
               :virtual_size=>byte_number_5G,
               :format=>"qcow2",
               :device=>'vda',
+              :compat=>"1.1",
             }
           ]
         )
@@ -118,6 +119,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
                 :virtual_size=>byte_number_5G,
                 :format=>"qcow2",
                 :device=>'vda',
+                :compat=>"1.1",
               }
             ]
           )
@@ -156,6 +158,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
                 :virtual_size=>byte_number_5G,
                 :format=>"qcow2",
                 :device=>'vda',
+                :compat=>"1.1",
               }
             ]
           )
@@ -177,6 +180,7 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
                 :virtual_size=>byte_number_20G,
                 :format=>"qcow2",
                 :device=>'vda',
+                :compat=>"1.1",
               }
             ]
           )
@@ -269,18 +273,21 @@ describe VagrantPlugins::ProviderLibvirt::Action::HandleBoxImage do
               :virtual_size=>byte_number_5G,
               :format=>"qcow2",
               :device=>'vda',
+              :compat=>"0.10"
             },
             {
               :path=>"/test/disk.qcow2",
               :name=>"test_vagrant_box_image_1.1.1_disk.img",
               :virtual_size=>byte_number_10G,
-              :format=>"qcow2"
+              :format=>"qcow2",
+              :compat=>"0.10"
             },
             {
               :path=>"/test/box_2.img",
               :name=>"test_vagrant_box_image_1.1.1_box_2.img",
               :virtual_size=>byte_number_20G,
-              :format=>"qcow2"
+              :format=>"qcow2",
+              :compat=>"0.10"
             }
           ]
         )


### PR DESCRIPTION
Libvirt creates qcow2 volumes with very old `compat` version `0.10` if no `compat` version is specified in the xml (see [here](https://libvirt.org/formatstorage.html#id11)). It seems libvirt has backwards compatibility reasons to still use `0.10` if nothing is specified in the xml.

Unfortunately this has the effect that VMs created by vagrant-libvirt are using the 10 year old `0.10` qcow2 version, instead of the `1.1` version that has **better performance and stability fixes**. 
This is even happening when the backing file of the vagrant box is in compat `1.1` format.

This is the `qemu-img info` of the backing file provided by the vagrant box:
```
# qemu-img info /var/lib/libvirt/images/vagrant_box_image_0_box.img
[...]
Format specific information:
    compat: 1.1
    [...]
```
Although the backing file provided by the box is using compat `1.1`, the created volume by vagrant-libvirt has only compat `0.1` as shown here:
```
# qemu-img info /var/lib/libvirt/images/vagrant-01-test_default.img
[...]
backing file: /var/lib/libvirt/images/vagrant_box_image_0_box.img
Format specific information:
    compat: 0.10
    [...]
```

With this MR, the volume of the VM will use the same `compat` version as provided by the backing image of the vagrant box.
If `qemu-img info` does not return a `compat` flag, it falls back to the very old `0.10` version.