### PR TITLE
Support iface_name setting for management network

### DIFF
--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -592,6 +592,7 @@ used by this network are configurable at the provider level.
   the Libvirt default (1500) will be used.
 * `management_network_keep` - Starting from version *0.7.0*, *always_destroy* is set to *true* by default for any network.
   This option allows to change this behaviour for the management network.
+* `management_network_iface_name` - Allow controlling of the network device name that appears on the host for the management network, same as `:libvirt__iface_name` for public and private network definitions. (unreleased).
 * `management_network_model_type` - Model of the network adapter to use for the management interface. Default is 'virtio'.
 
 You may wonder how vagrant-libvirt knows the IP address a VM received.  Libvirt

--- a/lib/vagrant-libvirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-libvirt/action/create_network_interfaces.rb
@@ -81,7 +81,7 @@ module VagrantPlugins
             @driver_name = iface_configuration.fetch(:driver_name, false)
             @driver_iommu = iface_configuration.fetch(:driver_iommu, false )
             @driver_queues = iface_configuration.fetch(:driver_queues, false)
-            @device_name = iface_configuration.fetch(:iface_name, false)
+            @device_name = iface_configuration.fetch(:iface_name, nil)
             @mtu = iface_configuration.fetch(:mtu, nil)
             @pci_bus = iface_configuration.fetch(:bus, nil)
             @pci_slot = iface_configuration.fetch(:slot, nil)

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -70,6 +70,7 @@ module VagrantPlugins
       attr_accessor :management_network_mtu
       attr_accessor :management_network_keep
       attr_accessor :management_network_driver_iommu
+      attr_accessor :management_network_iface_name
       attr_accessor :management_network_model_type
 
       # System connection information
@@ -258,6 +259,7 @@ module VagrantPlugins
         @management_network_mtu = UNSET_VALUE
         @management_network_keep = UNSET_VALUE
         @management_network_driver_iommu = UNSET_VALUE
+        @management_network_iface_name = UNSET_VALUE
         @management_network_model_type = UNSET_VALUE
 
         # System connection information
@@ -973,6 +975,7 @@ module VagrantPlugins
         @management_network_mtu = nil if @management_network_mtu == UNSET_VALUE
         @management_network_keep = false if @management_network_keep == UNSET_VALUE
         @management_network_driver_iommu = false if @management_network_driver_iommu == UNSET_VALUE
+        @management_network_iface_name = nil if @management_network_iface_name == UNSET_VALUE
         @management_network_model_type = 'virtio' if @management_network_model_type == UNSET_VALUE
 
         # Domain specific settings.

--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
           management_network_mtu = machine.provider_config.management_network_mtu
           management_network_keep = machine.provider_config.management_network_keep
           management_network_driver_iommu = machine.provider_config.management_network_driver_iommu
+          management_network_iface_name = machine.provider_config.management_network_iface_name
           management_network_model_type = machine.provider_config.management_network_model_type
           logger.info "Using #{management_network_name} at #{management_network_address} as the management network #{management_network_mode} is the mode"
 
@@ -79,6 +80,7 @@ module VagrantPlugins
           end
 
           management_network_options[:driver_iommu] = management_network_driver_iommu
+          management_network_options[:iface_name] = management_network_iface_name
 
           unless management_network_mac.nil?
             management_network_options[:mac] = management_network_mac


### PR DESCRIPTION
Allow setting the interface name that appears on the host for the
management network interface in the guest. This allows for more complex
networking layouts by allowiing matching against devices for vlan
configurations.

Fixes: #1701
