### PR TITLE
Adjust groups to reduce test dependencies

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,19 +27,15 @@ jobs:
           libvirt-dev \
           libz-dev \
         ;
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.6
+        bundler-cache: true
     - name: Run bundler using cached path
       run: |
         bundle config path vendor/bundle
+        bundle config set --local without 'development'
         bundle install --jobs 4 --retry 3
     - name: Generate matrix
       id: generate-matrix
@@ -93,12 +89,6 @@ jobs:
         sudo usermod -a -G libvirt $USER
     - uses: actions/cache@v3
       with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - uses: actions/cache@v3
-      with:
         path: ~/.vagrant.d/boxes
         key: ${{ runner.os }}-${{ env.VAGRANT_VERSION }}
         restore-keys: |
@@ -107,9 +97,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.6
+        bundler-cache: true
     - name: Run bundler using cached path
       run: |
-        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
     - name: Run tests
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,9 @@ jobs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
 
     env:
+      # skip installing development group gems to save time
+      BUNDLE_WITHOUT: 'development'
+      BUNDLE_JOBS: 4
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       VAGRANT_VERSION: v2.2.14
 
@@ -32,11 +35,6 @@ jobs:
       with:
         ruby-version: 2.6.6
         bundler-cache: true
-    - name: Run bundler using cached path
-      run: |
-        bundle config path vendor/bundle
-        bundle config set --local without 'development'
-        bundle install --jobs 4 --retry 3
     - name: Generate matrix
       id: generate-matrix
       run: |
@@ -55,6 +53,9 @@ jobs:
         test_name: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
 
     env:
+      # skip installing development group gems to save time
+      BUNDLE_WITHOUT: 'development'
+      BUNDLE_JOBS: 4
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       VAGRANT_VERSION: v2.2.14
 
@@ -87,20 +88,11 @@ jobs:
 
         # add user to group
         sudo usermod -a -G libvirt $USER
-    - uses: actions/cache@v3
-      with:
-        path: ~/.vagrant.d/boxes
-        key: ${{ runner.os }}-${{ env.VAGRANT_VERSION }}
-        restore-keys: |
-          ${{ runner.os }}-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.6
         bundler-cache: true
-    - name: Run bundler using cached path
-      run: |
-        bundle install --jobs 4 --retry 3
     - name: Run tests
       run: |
         mkdir -p $HOME/.vagrant.d/

--- a/.github/workflows/publish-documentation-preview.yml
+++ b/.github/workflows/publish-documentation-preview.yml
@@ -25,6 +25,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+          bundler-cache: true
+        env:
+          BUNDLE_GEMFILE: ./docs/Gemfile
       - name: Install and Build 🔧
         # don't allow a close to execute anything from the source code
         if: ${{ github.event.action == 'labeled' }}
@@ -41,8 +44,7 @@ jobs:
           plugin_script_base_path: /${REPO_NAME}/pr-preview/pr-${PR_NUMBER}
           EOF
 
-          BUNDLE_GEMFILE=./docs/Gemfile bundle install
-          BUNDLE_GEMFILE=./docs/Gemfile bundle exec jekyll build --source docs/ --baseurl="/${REPO_NAME}/pr-preview/pr-${PR_NUMBER}" --destination build
+          bundle exec jekyll build --source docs/ --baseurl="/${REPO_NAME}/pr-preview/pr-${PR_NUMBER}" --destination build
       - name: Set action
         run: |
           event_type=$(jq -r ".action" "$GITHUB_EVENT_PATH")

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -63,20 +63,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libvirt-dev
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-    - name: Set up rubygems
-      run: |
-        gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
-        gem update bundler --conservative
     - name: Ensure bundle uses https instead of insecure git
       run: |
         git config --global url."https://github.com/".insteadOf git://github.com/
@@ -90,19 +76,24 @@ jobs:
 
         mkdir -p vendor/bundle/ruby/3.0.0/cache/
         cp .deps/libvirt-ruby/pkg/ruby-libvirt-*.gem vendor/bundle/ruby/3.0.0/cache/
+        echo "BUNDLE_DISABLE_CHECKSUM_VALIDATION=true" >> ${GITHUB_ENV}
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+      env:
+        # skip installing development group gems to save time
+        BUNDLE_WITHOUT: 'development'
+        BUNDLE_JOBS: 4
         # need the following to allow the local provided gem to be used instead of the
         # one from rubygems
-        bundle config set --local disable_checksum_validation true
-    - name: Run bundler using cached path
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
-      env:
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - name: Run tests
       run: |
-        bundle exec rspec --color --format documentation
+        bundle exec parallel_test spec --type rspec
       env:
+        BUNDLE_WITHOUT: 'development'
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - name: Coveralls Parallel
       uses: coverallsapp/github-action@master

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -76,6 +76,8 @@ jobs:
 
         mkdir -p vendor/bundle/ruby/3.0.0/cache/
         cp .deps/libvirt-ruby/pkg/ruby-libvirt-*.gem vendor/bundle/ruby/3.0.0/cache/
+        # need the following to allow the local provided gem to be used instead of the
+        # one from rubygems
         echo "BUNDLE_DISABLE_CHECKSUM_VALIDATION=true" >> ${GITHUB_ENV}
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -86,8 +88,6 @@ jobs:
         # skip installing development group gems to save time
         BUNDLE_WITHOUT: 'development'
         BUNDLE_JOBS: 4
-        # need the following to allow the local provided gem to be used instead of the
-        # one from rubygems
         VAGRANT_VERSION: ${{ matrix.vagrant }}
     - name: Run tests
       run: |

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-group :development do
+group :test do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
@@ -46,10 +46,11 @@ group :plugins do
   gemspec
 end
 
-group :test do
+group :development do
   gem "test-prof", require: false
   gem "ruby-prof", ">= 0.17.0", require: false
   gem 'stackprof', '>= 0.2.9', require: false
+  gem 'rubocop', require: false
 end
 
 gem 'parallel_tests', group: [:development, :test], require: false

--- a/lib/vagrant-libvirt/action/handle_storage_pool.rb
+++ b/lib/vagrant-libvirt/action/handle_storage_pool.rb
@@ -2,6 +2,9 @@
 
 require 'log4r'
 
+require 'vagrant-libvirt/util/erb_template'
+require 'vagrant-libvirt/util/storage_util'
+
 module VagrantPlugins
   module ProviderLibvirt
     module Action

--- a/spec/unit/util/network_util_spec.rb
+++ b/spec/unit/util/network_util_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rexml/document'
+
 require_relative '../../spec_helper'
 
 require 'vagrant-libvirt/util/network_util'


### PR DESCRIPTION
Switch around the groups defined in the Gemfile to allow execution
without installing additional tools that are useful for development but
not needed for testing or packaging.
