### PR TITLE
Allow non drvfs on wsl environment

### DIFF
--- a/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
+++ b/lib/vagrant-libvirt/cap/synced_folder_virtiofs.rb
@@ -109,6 +109,12 @@ module VagrantPlugins
                 error_message: e.message
         end
       end
+
+      # Enable virtiofs synced folders within WSL when in use
+      # on non-DrvFs file systems
+      def self.wsl_allow_non_drvfs?
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
Hi Preact team!

I have been using vagrant-libvirt on a regular basis!

This time, I want to use this plugin in a wsl environment.

To do so, I need to set the wsl_allow_non_drvfs option to true, so I created this PR based on the official vagrant rsycn shared folder plugin example.

Official Example:

https://github.com/hashicorp/vagrant/blob/5b501a3fb05ed0ab16cf10991b3df9d231edb5cf/plugins/synced_folders/rsync/synced_folder.rb#L52-L56

(As a side note, systemd has recently been supported by wsl, so libvirt can be handled on wsl. Therefore, I would like to develop a combination of wsl and vagrant-libvirt.)

Thank you.