### PR TITLE
Poweroff domain on `vagrant halt -f`

### DIFF
--- a/lib/vagrant-libvirt/action.rb
+++ b/lib/vagrant-libvirt/action.rb
@@ -195,6 +195,11 @@ module VagrantPlugins
             b2.use Call, IsRunning do |env2, b3|
               next unless env2[:result]
 
+              if env2[:force_halt]
+                b3.use HaltDomain
+                next
+              end
+
               b3.use StartShutdownTimer
               b3.use Call, GracefulHalt, :shutoff, :running do |env3, b4|
                 if !env3[:result]

--- a/lib/vagrant-libvirt/action/shutdown_domain.rb
+++ b/lib/vagrant-libvirt/action/shutdown_domain.rb
@@ -58,7 +58,10 @@ module VagrantPlugins
           if env[:machine].state.id == @source_state
             env[:ui].info(I18n.t('vagrant_libvirt.shutdown_domain'))
             domain.shutdown
-            domain.wait_for(timeout) { !ready? }
+            begin
+                domain.wait_for(timeout) { !ready? }
+            rescue Fog::Errors::TimeoutError
+            end
           end
 
           env[:result] = env[:machine].state.id == @target_state


### PR DESCRIPTION
`vagrant halt -f` is supposed to poweroff the domain without attempting graceful shutdown. Before, `vagrant halt -f` was attempting to send ACPI and waiting for timeout before actually powering off the domain.

Fix a bug where ACPI timeout code would cause an exception to be thrown, instead of setting :result to false and proceeding to poweroff the domain.

The before behaviour:

`vagrant halt`:
    - attempt graceful shutdown (/sbin/shutdown)
        ERROR: next action
    - attempt sending ACPI (domain.shutdown)
        ERROR: timeout exception

`vagrant halt -f`:
    - attempt sending ACPI (domain.shutdown)
        ERROR: timeout exception

The after behaviour:

`vagrant halt`:
    - attempt graceful shutdown (/sbin/shutdown)
        ERROR: next action
    - attempt sending ACPI (domain.shutdown)
        ERROR: next action
    - poweroff the machine (domain.poweroff)
        ERROR: hopefully never

`vagrant halt -f`:
    - poweroff the machine (domain.poweroff)
        ERROR: hopefully never

Fixes #1765