### PR TITLE
Ensure extra docs config is appended

### DIFF
--- a/.github/workflows/build-docs/action.yml
+++ b/.github/workflows/build-docs/action.yml
@@ -42,7 +42,7 @@ runs:
         EOF
 
         echo "Adding additional config settings:"
-        cat ${TEMP_CONFIG} | tee docs/_config.yml
+        cat ${TEMP_CONFIG} | tee -a docs/_config.yml
 
     - name: Install and Build
       shell: bash


### PR DESCRIPTION
Use of tee requires the argument '-a' to append, as current behaviour
will result in replacing the contents which is not intended. The config
settings should be in addition to the configured values.
