### PR TITLE
Ensure publish docs runs on workflow changes

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'docs/**'
       - .github/workflows/publish-documentation.yml
+      - .github/workflows/deploy-docs.yml
+      - .github/workflows/build-docs/**
 
 permissions:
   contents: write


### PR DESCRIPTION
Include dependent workflow and github action as part of the path check
for when to trigger the workflow.
