### PR TITLE
Add acceptance tests around halt behaviour

### DIFF
--- a/spec/acceptance/shutdown_halt_spec.rb
+++ b/spec/acceptance/shutdown_halt_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe 'shutdown and halt', acceptance: true do
+  include_context 'libvirt_acceptance'
+
+  before do
+    environment.skeleton('default_settings')
+  end
+
+  after do
+    assert_execute('vagrant', 'destroy', '--force')
+  end
+
+  context 'when system accessible' do
+    it 'graceful shutdown should succeed' do
+      status('Test: machine is created successfully')
+      result = environment.execute('vagrant', 'up')
+      expect(result).to exit_with(0)
+
+      status('Test: Halt')
+      result = environment.execute('vagrant', 'halt')
+      expect(result).to exit_with(0)
+
+      status('Test: validate output')
+      expect(result.stdout).to match(/Attempting graceful shutdown of VM/)
+      expect(result.stdout).to_not match(/Halting domain.../)
+    end
+
+    it 'forced halt should skip graceful and succeed' do
+      status('Test: machine is created successfully')
+      result = environment.execute('vagrant', 'up')
+      expect(result).to exit_with(0)
+
+      status('Test: Halt')
+      result = environment.execute('vagrant', 'halt', '-f')
+      expect(result).to exit_with(0)
+
+      status('Test: validate output')
+      expect(result.stdout).to_not match(/Attempting graceful shutdown of VM/)
+      expect(result.stdout).to match(/Halting domain.../)
+    end
+  end
+
+  context 'when system hung' do
+    it 'should call halt after failed graceful' do
+      status('Test: machine is created successfully')
+      result = environment.execute('vagrant', 'up')
+      expect(result).to exit_with(0)
+
+      status('Test: Trigger crash to prevent graceful halt working')
+      result = environment.execute('vagrant', 'ssh', '-c', 'nohup sudo sh -c \'echo -n c > /proc/sysrq-trigger\' >/dev/null 2>&1 </dev/null', '--', '-f')
+      expect(result).to exit_with(0)
+
+      status('Test: Halt')
+      result = environment.execute('vagrant', 'halt')
+      expect(result).to exit_with(0)
+
+      status('Test: validate output')
+      expect(result.stdout).to match(/Attempting graceful shutdown of VM/)
+      expect(result.stdout).to match(/Guest communication could not be established/)
+      expect(result.stdout).to match(/Halting domain.../)
+    end
+  end
+end

--- a/spec/acceptance/support-skeletons/default_settings/Vagrantfile
+++ b/spec/acceptance/support-skeletons/default_settings/Vagrantfile
@@ -6,5 +6,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "infernix/tinycore"
   config.ssh.shell = "/bin/sh"
+  config.ssh.insert_key = false  # reboots revert box contents
   config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.graceful_halt_timeout = 5
 end


### PR DESCRIPTION
Ensure acceptance tests capture halt behaviour to prevent future
regression around graceful and forced halt.

Related-to: #1765
