### PR TITLE
Allow video resolution hinting

### DIFF
--- a/docs/configuration.markdown
+++ b/docs/configuration.markdown
@@ -194,6 +194,10 @@ end
   "cirrus", "vmvga", "xen", "vbox", or "qxl".
 * `video_vram` - Used by some graphics card types to vary the amount of RAM
   dedicated to video.  Defaults to 16384.
+* `video_resolution_x` - sets the default EDID/monnitor resolution hinting for the X
+  axis. Defaults to qemu default. (1280x800).
+* `video_resolution_y` - sets the default EDID/monnitor resolution hinting for the Y
+  axis. Defaults to qemu default. (1280x800)
 * `video_accel3d` - Set to `true` to enable 3D acceleration. Defaults to
 `false`.
 * `sound_type` - [Set the virtual sound card](https://libvirt.org/formatdomain.html#sound-devices)

--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -75,6 +75,8 @@ module VagrantPlugins
           @graphics_passwd = config.graphics_passwd
           @graphics_gl = config.graphics_gl
           @video_type = config.video_type
+          @video_resolution_x = config.video_resolution_x
+          @video_resolution_y = config.video_resolution_y
           @sound_type = config.sound_type
           @video_vram = config.video_vram
           @video_accel3d = config.video_accel3d
@@ -293,6 +295,11 @@ module VagrantPlugins
             env[:ui].info(" -- Graphics Password: #{@graphics_passwd.nil? ? 'Not defined' : 'Defined'}")
           end
           env[:ui].info(" -- Video Type:        #{@video_type}")
+          if @video_resolution_x and @video_resolution_y
+            env[:ui].info(" -- Video Resolution:  #{@video_resolution_x}x#{@video_resolution_y}")
+          else
+            env[:ui].info(" -- Video Resolution:  libvirt default")
+          end
           env[:ui].info(" -- Video VRAM:        #{@video_vram}")
           env[:ui].info(" -- Video 3D accel:    #{@video_accel3d}")
           env[:ui].info(" -- Sound Type:        #{@sound_type}") if @sound_type

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -136,6 +136,8 @@ module VagrantPlugins
       attr_accessor :video_type
       attr_accessor :video_vram
       attr_accessor :video_accel3d
+      attr_accessor :video_resolution_x
+      attr_accessor :video_resolution_y
       attr_accessor :keymap
       attr_accessor :kvm_hidden
       attr_accessor :sound_type
@@ -1040,6 +1042,8 @@ module VagrantPlugins
         @graphics_gl = @video_accel3d if @graphics_gl == UNSET_VALUE
         @video_type = @video_accel3d ? 'virtio' : 'cirrus' if @video_type == UNSET_VALUE
         @video_vram = 16384 if @video_vram == UNSET_VALUE
+        @video_resolution_x = nil if @video_resolution_x == UNSET_VALUE
+        @video_resolution_y = nil if @video_resolution_y == UNSET_VALUE
         @sound_type = nil if @sound_type == UNSET_VALUE
         @keymap = 'en-us' if @keymap == UNSET_VALUE
         @kvm_hidden = false if @kvm_hidden == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -285,12 +285,9 @@
       <gl enable='yes'/>
     </graphics><% end -%>
     <video>
-      <model type='<%= @video_type %>'
-             vram='<%= @video_vram %>'
-             heads='1'>
-             <% if @video_accel3d %><acceleration accel3d='yes'/><%- end -%>
-             <% if @video_resolution_x and @video_resolution_y %><resolution x='<%= @video_resolution_x %>' y='<%= @video_resolution_y %>'/><%- end -%>
-      </model>
+      <model type='<%= @video_type %>' vram='<%= @video_vram %>' heads='1'<% if not @video_accel3d and not (@video_resolution_x and @video_resolution_y)%>/><% else %>>
+        <% if @video_accel3d %><acceleration accel3d='yes'/><% end %><% if @video_resolution_x and @video_resolution_y %><resolution x='<%= @video_resolution_x %>' y='<%= @video_resolution_y %>'/><% end %>
+      </model><% end %>
     </video>
     <%#End Video -%>
 <%- end -%>

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -285,9 +285,12 @@
       <gl enable='yes'/>
     </graphics><% end -%>
     <video>
-      <model type='<%= @video_type %>' vram='<%= @video_vram %>' heads='1'<% if not @video_accel3d %>/><% else %>>
-        <acceleration accel3d='yes'/>
-      </model><% end -%>
+      <model type='<%= @video_type %>'
+             vram='<%= @video_vram %>'
+             heads='1'>
+             <% if @video_accel3d %><acceleration accel3d='yes'/><%- end -%>
+             <% if @video_resolution_x and @video_resolution_y %><resolution x='<%= @video_resolution_x %>' y='<%= @video_resolution_y %>'/><%- end -%>
+      </model>
     </video>
     <%#End Video -%>
 <%- end -%>

--- a/spec/unit/templates/domain_all_settings.xml
+++ b/spec/unit/templates/domain_all_settings.xml
@@ -129,7 +129,7 @@
     </graphics>
     <video>
       <model type='virtio' vram='16384' heads='1'>
-        <acceleration accel3d='yes'/>
+        <acceleration accel3d='yes'/><resolution x='1920' y='1080'/>
       </model>
     </video>
     <rng model='virtio'>

--- a/spec/unit/templates/domain_spec.rb
+++ b/spec/unit/templates/domain_spec.rb
@@ -136,6 +136,8 @@ describe 'templates/domain' do
       domain.nodeset = '1-4,^3,6'
 
       domain.video_accel3d = true
+      domain.video_resolution_x = 1920
+      domain.video_resolution_y = 1080
     end
     let(:test_file) { 'domain_all_settings.xml' }
     it 'renders template' do


### PR DESCRIPTION
Add support for custom video resolution

Libvirt supports setting custom video resolution by setting the
resolution subelement in the model tag. This changes the preferred EDID
mode exposed to the vm.

Changing this is usefull when running GUI systems that does not provide
UI elements for changing the resolution. Examples would be cage or other
wayland compositors where initialization uses the preferred EDID mode.