### PR TITLE
Add support for qemu-img v8 to create_box.sh

### DIFF
--- a/tools/create_box.sh
+++ b/tools/create_box.sh
@@ -91,8 +91,10 @@ cd "$TMP_DIR"
 
 #Using the awk int function here to truncate the virtual image size to an
 #integer since the fog-libvirt library does not seem to properly handle
-#floating point.
-IMG_SIZE=$(qemu-img info --output=json "$TMP_IMG" | awk '/virtual-size/{s=int($2)/(1024^3); print (s == int(s)) ? s : int(s)+1 }')
+#floating point. Regex in awk function takes in account only "virtual-size"
+#value on the first level of JSON (since QEMU v8 there are multiple
+#"virtual-size"s in disk info).
+IMG_SIZE=$(qemu-img info --output=json "$TMP_IMG" | awk '/^\s{0,4}"virtual-size/{s=int($2)/(1024^3); print (s == int(s)) ? s : int(s)+1 }')
 
 echo "{$IMG_SIZE}"
 


### PR DESCRIPTION
#### Details
Since version 8 of qemu-img tool it produces more verbose JSON-output with multiple `virtual-size` keys which leads to incorrect generation of `metadata.json` file (all values of `virtual-size` are placed into file and it becomes non-valid JSON).

This behavious was described in #1746 .

#### Examples of old and new JSON outputs:
<details>
  <summary>qemu5_diskinfo.json</summary>

  ```json
{
    "virtual-size": 34359738368,
    "filename": "vm-100-disk-0.qcow2",
    "cluster-size": 65536,
    "format": "qcow2",
    "actual-size": 2941440,
    "format-specific": {
        "type": "qcow2",
        "data": {
            "compat": "1.1",
            "compression-type": "zlib",
            "lazy-refcounts": false,
            "refcount-bits": 16,
            "corrupt": false,
            "extended-l2": false
        }
    },
    "dirty-flag": false
}
```
</details>
<details>
  <summary>qemu8_diskinfo.json</summary>

  ```json
{
    "children": [
        {
            "name": "file",
            "info": {
                "children": [
                ],
                "virtual-size": 42956488704,
                "filename": "/var/lib/libvirt/images/proxmox_6.4.qcow2",
                "format": "file",
                "actual-size": 1305301504,
                "format-specific": {
                    "type": "file",
                    "data": {
                    }
                },
                "dirty-flag": false
            }
        }
    ],
    "virtual-size": 42949672960,
    "filename": "/var/lib/libvirt/images/proxmox_6.4.qcow2",
    "cluster-size": 65536,
    "format": "qcow2",
    "actual-size": 1305301504,
    "format-specific": {
        "type": "qcow2",
        "data": {
            "compat": "1.1",
            "compression-type": "zlib",
            "lazy-refcounts": true,
            "refcount-bits": 16,
            "corrupt": false,
            "extended-l2": false
        }
    },
    "dirty-flag": false
}
```
</details>

#### Resolution
This PR adds comatibility in a fast-fix-way: awk regex gets in account only `virtual-size` key on the first level of `qemu-img info` JSON-output.

#### Tests
Tested on a local machine (qemu-img version 8.1.2) - Vagrant Box successfully created and imported.