### PR TITLE
Prevent error on windows virtiofs mount

### DIFF
--- a/lib/vagrant-libvirt/cap/mount_virtiofs.rb
+++ b/lib/vagrant-libvirt/cap/mount_virtiofs.rb
@@ -34,6 +34,14 @@ module VagrantPlugins
           end
         end
       end
+
+      class MountVirtioFSWin
+        extend Vagrant::Util::Retryable
+
+        def self.mount_virtiofs_shared_folder(machine, folders)
+          # Do nothing
+        end
+      end
     end
   end
 end

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -41,6 +41,8 @@ module VagrantPlugins
       end
       
       guest_capability('windows', 'mount_virtiofs_shared_folder') do
+        require_relative 'cap/mount_virtiofs'
+        Cap::MountVirtioFSWin
       end
 
       provider_capability(:libvirt, :nic_mac_addresses) do

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -39,9 +39,8 @@ module VagrantPlugins
         require_relative 'cap/mount_virtiofs'
         Cap::MountVirtioFS
       end
+      
       guest_capability('windows', 'mount_virtiofs_shared_folder') do
-        require_relative 'cap/mount_virtiofs'
-        Cap::MountVirtioFS
       end
 
       provider_capability(:libvirt, :nic_mac_addresses) do

--- a/lib/vagrant-libvirt/plugin.rb
+++ b/lib/vagrant-libvirt/plugin.rb
@@ -39,6 +39,10 @@ module VagrantPlugins
         require_relative 'cap/mount_virtiofs'
         Cap::MountVirtioFS
       end
+      guest_capability('windows', 'mount_virtiofs_shared_folder') do
+        require_relative 'cap/mount_virtiofs'
+        Cap::MountVirtioFS
+      end
 
       provider_capability(:libvirt, :nic_mac_addresses) do
         require_relative 'cap/nic_mac_addresses'


### PR DESCRIPTION
After installing WinFSP and the virtiofs driver in the provisioning phase, then configuring the service to autostart with `sc config VirtioFsSvc binPath="C:\Program Files\Virtio-Win\VioFS\virtiofs.exe" start=auto depend=VirtioFsDrv` ... the virtiofs share gets mounted as a separate drive in Windows 10.  
Guide: https://github.com/virtio-win/kvm-guest-drivers-windows/wiki/Virtiofs:-Shared-file-system#setup-with-installer

![image](https://github.com/vagrant-libvirt/vagrant-libvirt/assets/3104604/3eff78b1-a3cd-4b62-85d1-bc872eee042a)

I have no experience writing vagrant plugins. In my fork I have just tried to implement a NOOP so that the libvirt plugin doesn't error out because of the missing guest capability. This works for me as `vagrant up` succeeds and the share works properly.

Question for maintainers. Would this be ok to merge into main, to prevent the error? The capability obviously exists, but I do not know what would be acceptable for main.