### PR TITLE
Add Nvram template option 

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -50,6 +50,7 @@ module VagrantPlugins
           @numa_nodes = config.numa_nodes
           @loader = config.loader
           @nvram = config.nvram
+          @nvram_template = config.nvram_template
           @machine_type = config.machine_type
           @machine_arch = config.machine_arch
           @disk_controller_model = config.disk_controller_model
@@ -271,6 +272,7 @@ module VagrantPlugins
           env[:ui].info(" -- Initrd:            #{@initrd}") if @initrd
           env[:ui].info(" -- Loader:            #{@loader}") if @loader
           env[:ui].info(" -- Nvram:             #{@nvram}") if @nvram
+          env[:ui].info(" -- Nvram Template:             #{@nvram_template}") if @nvram_template
           if env[:machine].config.vm.box
             env[:ui].info(" -- Base box:          #{env[:machine].box.name}")
           end
@@ -456,6 +458,7 @@ module VagrantPlugins
             server = env[:machine].provider.driver.connection.servers.create(
               xml: xml
             )
+            env[:ui].info(server)
           rescue Fog::Errors::Error => e
             raise Errors::FogCreateServerError, error_message: e.message
           end

--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
           domain = env[:machine].provider.driver.connection.servers.get(env[:machine].id.to_s)
 
           undefine_flags = 0
-          undefine_flags |= ProviderLibvirt::Util::DomainFlags::VIR_DOMAIN_UNDEFINE_KEEP_NVRAM if env[:machine].provider_config.nvram
+          undefine_flags |= ProviderLibvirt::Util::DomainFlags::VIR_DOMAIN_UNDEFINE_KEEP_NVRAM if env[:machine].provider_config.nvram || env[:machine].provider_config.nvram_template
 
           if env[:machine].provider_config.disks.empty? &&
              env[:machine].provider_config.cdroms.empty?

--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -524,7 +524,7 @@ module VagrantPlugins
                 loader.text = config.loader
               end
             end
-            loader.attributes['type'] = config.nvram ? 'pflash' : 'rom'
+            loader.attributes['type'] = config.nvram || config.nvram_template ? 'pflash' : 'rom'
           elsif !loader.nil?
             descr_changed = true
             loader.parent.delete_element(loader)
@@ -543,6 +543,14 @@ module VagrantPlugins
                 nvram.text = config.nvram
               end
             end
+          elsif config.nvram_template
+            if nvram.nil?
+              desc_Changed = true
+              nvram = REXML::Element.new('nvram')
+              REXML::XPath.first(xml_descr, '/domain/os').insert_after(loader, nvram)
+              nvram.text = "/var/lib/libvirt/qemu/nvram/#{env[:machine].name}_VARS.fd"
+            end
+            nvram.attributes['template'] = config.nvram_template
           elsif !nvram.nil?
             descr_changed = true
             nvram.parent.delete_element(nvram)

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -109,6 +109,7 @@ module VagrantPlugins
       attr_accessor :numa_nodes
       attr_accessor :loader
       attr_accessor :nvram
+      attr_accessor :nvram_template
       attr_accessor :boot_order
       attr_accessor :machine_type
       attr_accessor :machine_arch
@@ -294,6 +295,7 @@ module VagrantPlugins
         @numa_nodes        = UNSET_VALUE
         @loader            = UNSET_VALUE
         @nvram             = UNSET_VALUE
+        @nvram_template    = UNSET_VALUE
         @machine_type      = UNSET_VALUE
         @machine_arch      = UNSET_VALUE
         @machine_virtual_size = UNSET_VALUE
@@ -1007,7 +1009,8 @@ module VagrantPlugins
         @launchsecurity_data = nil if @launchsecurity_data == UNSET_VALUE
         @numa_nodes = @numa_nodes == UNSET_VALUE ? nil : _generate_numa
         @loader = nil if @loader == UNSET_VALUE
-        @nvram = nil if @nvram == UNSET_VALUE
+        @nvram = nil if @nvram == UNSET_VALUE 
+        @nvram_template = nil if @nvram_template == UNSET_VALUE 
         @machine_virtual_size = nil if @machine_virtual_size == UNSET_VALUE
         @disk_device = @disk_bus == 'scsi' ? 'sda' : 'vda' if @disk_device == UNSET_VALUE
         @disk_bus = @disk_device.start_with?('sd') ? 'scsi' : 'virtio' if @disk_bus == UNSET_VALUE

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -78,15 +78,23 @@
   <%- end -%>
 <%- end -%>
 <%- if @loader -%>
-  <%- if @nvram -%>
+  <%- if @nvram or @nvram_template -%>
     <loader readonly='yes' type='pflash'><%= @loader %></loader>
   <%- else -%>
     <loader readonly='yes' type='rom'><%= @loader %></loader>
   <%- end -%>
 <%- end -%>
+<%- if @nvram_template -%>
+  <%- if @nvram -%>
+    <nvram template='<%= @nvram_template %>'><%= @nvram %></nvram>
+  <%- else -%>
+  <nvram template='<%= @nvram_template %>'>/var/lib/libvirt/qemu/nvram/<%=  @name %>.fd</nvram>
+  <% end -%>
+<%- else -%>
 <%- if @nvram -%>
-    <nvram><%= @nvram %></nvram>
+  <nvram><%= @nvram %></nvram>
 <%- end -%>
+<% end -%>
     <bootmenu enable='<%= @boot_order.count >= 1 ? "yes" : "no" %>'/>
     <kernel><%= @kernel %></kernel>
     <initrd><%= @initrd %></initrd>

--- a/spec/support/environment_helper.rb
+++ b/spec/support/environment_helper.rb
@@ -20,7 +20,7 @@ class EnvironmentHelper
     1024
   end
 
-  %w(cpus cpu_mode loader nvram boot_order machine_type disk_bus disk_device nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_websocket graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms floppies driver).each do |name|
+  %w(cpus cpu_mode loader nvram nvram_template boot_order machine_type disk_bus disk_device nested volume_cache kernel cmd_line initrd graphics_type graphics_autoport graphics_port graphics_websocket graphics_ip graphics_passwd video_type video_vram keymap storage_pool_name disks cdroms floppies driver).each do |name|
     define_method(name.to_sym) do
       nil
     end


### PR DESCRIPTION
Adds an nvram_template option to allow dynamic creation of nvram file in /var/lib/libvirt/qemu/nvram based on OVMF VARS.
Provides a way to launch multiple domain with a same var template.
This may be a solution for https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1725 and https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1723.