### PR TITLE
Implement creating sysinfo fwcfg entries

### DIFF
--- a/lib/vagrant-libvirt/action/create_domain.rb
+++ b/lib/vagrant-libvirt/action/create_domain.rb
@@ -102,6 +102,15 @@ module VagrantPlugins
             'oem strings' => {:ui => "OEM Strings", :xml => "oemStrings"},
           }
 
+          @sysinfo_fwcfgs = config.sysinfo_fwcfgs
+          @sysinfo_fwcfgs.each do |fwcfg_entry|
+            next unless fwcfg_entry[:file]
+
+            if !File.exist?(fwcfg_entry[:file])
+              raise Errors::FwcfgFileNotAccessible, path: fwcfg_entry[:file]
+            end
+          end
+
           # Boot order
           @boot_order = config.boot_order
 
@@ -317,6 +326,17 @@ module VagrantPlugins
                 values.each do |value|
                   env[:ui].info("    -> #{value}")
                 end
+              end
+            end
+          end
+
+          unless @sysinfo_fwcfgs.empty?
+            env[:ui].info(" -- Sysinfo Firmware Configurations:")
+            @sysinfo_fwcfgs.each do |fwcfg_entry|
+              if !fwcfg_entry[:file].nil?
+                env[:ui].info("    -> #{fwcfg_entry[:name]} -> #{fwcfg_entry[:file]}")
+              elsif !fwcfg_entry[:content].nil?
+                env[:ui].info("    -> #{fwcfg_entry[:name]}: '#{fwcfg_entry[:content]}'")
               end
             end
           end

--- a/lib/vagrant-libvirt/config.rb
+++ b/lib/vagrant-libvirt/config.rb
@@ -149,6 +149,8 @@ module VagrantPlugins
 
       # Configure sysinfo values
       attr_accessor :sysinfo
+      # Configure sysinfo fwcfg type values
+      attr_accessor :sysinfo_fwcfgs
 
       # Configure the memballoon
       attr_accessor :memballoon_enabled
@@ -330,6 +332,7 @@ module VagrantPlugins
         @tpm_version       = UNSET_VALUE
 
         @sysinfo           = UNSET_VALUE
+        @sysinfo_fwcfgs    = UNSET_VALUE
 
         @memballoon_enabled = UNSET_VALUE
         @memballoon_model   = UNSET_VALUE
@@ -861,6 +864,28 @@ module VagrantPlugins
         @serials << serial
       end
 
+      def sysinfo_fwcfg(options={})
+        @sysinfo_fwcfgs = [] if @sysinfo_fwcfgs == UNSET_VALUE
+
+        options = {
+          :name => '',
+          :content => nil,
+          :file => nil,
+        }.merge(options)
+
+        if options[:name] == '' || !(options[:content].nil? ^ options[:file].nil?)
+          raise "The name and either a content or a file key must be specified for a sysinfo fwcfg entry"
+        end
+
+        entry = {
+          :name => options[:name],
+          :content => options[:content],
+          :file => options[:file],
+        }
+
+        @sysinfo_fwcfgs << entry
+      end
+
       def _default_uri
         # Determine if any settings except driver provided explicitly, if not
         # and the LIBVIRT_DEFAULT_URI var is set, use that.
@@ -1055,6 +1080,7 @@ module VagrantPlugins
         @emulator_path = nil if @emulator_path == UNSET_VALUE
 
         @sysinfo = {} if @sysinfo == UNSET_VALUE
+        @sysinfo_fwcfgs = [] if @sysinfo_fwcfgs == UNSET_VALUE
 
         # Boot order
         @boot_order = [] if @boot_order == UNSET_VALUE

--- a/lib/vagrant-libvirt/errors.rb
+++ b/lib/vagrant-libvirt/errors.rb
@@ -217,6 +217,10 @@ module VagrantPlugins
       class SerialCannotCreatePathError < VagrantLibvirtError
         error_key(:serial_cannot_create_path_error)
       end
+
+      class FwcfgFileNotAccessible < VagrantLibvirtError
+        error_key(:fwcfg_file_accessibility_error)
+      end
     end
   end
 end

--- a/lib/vagrant-libvirt/templates/domain.xml.erb
+++ b/lib/vagrant-libvirt/templates/domain.xml.erb
@@ -115,6 +115,17 @@
   <% end -%>
   </sysinfo>
 <% end -%>
+<%- unless @sysinfo_fwcfgs.empty? -%>
+  <sysinfo type='fwcfg'>
+  <%- @sysinfo_fwcfgs.each do |entry| -%>
+    <%- if !entry[:file].nil? -%>
+      <entry name='<%= entry[:name] %>' file='<%= entry[:file] %>'/>
+    <%- else -%>
+      <entry name='<%= entry[:name] %>'><%= entry[:content] %></entry>
+    <% end -%>
+  <% end -%>
+  </sysinfo>
+<% end -%>
   <features>
 <%- @features.each do |feature| -%>
     <<%= feature %>/>


### PR DESCRIPTION
With the following configuration this can be used to provide an Ignition configuration to boxes using `ignition.machine.id=qemu`:

```
  config.vm.provider :libvirt do |libvirt|
    libvirt.sysinfo_fwcfg :name => "opt/com.coreos/config", :file => '/tmp/provision.ign'
```