### PR TITLE
Ignore networks that disappear during discovery

### DIFF
--- a/lib/vagrant-libvirt/util/network_util.rb
+++ b/lib/vagrant-libvirt/util/network_util.rb
@@ -194,40 +194,44 @@ module VagrantPlugins
 
           # Iterate over all (active and inactive) networks.
           driver.list_all_networks.each do |libvirt_network|
-
             # Parse ip address and netmask from the network xml description.
-            xml = Nokogiri::XML(libvirt_network.xml_desc)
-            ip = xml.xpath('/network/ip/@address').first
-            ip = ip.value if ip
-            netmask = xml.xpath('/network/ip/@netmask').first
-            netmask = netmask.value if netmask
+            begin
+              xml = Nokogiri::XML(libvirt_network.xml_desc)
+              end
+              ip = xml.xpath('/network/ip/@address').first
+              ip = ip.value if ip
+              netmask = xml.xpath('/network/ip/@netmask').first
+              netmask = netmask.value if netmask
 
-            dhcp_enabled = if xml.at_xpath('//network/ip/dhcp')
-                             true
-                           else
-                             false
-                           end
+              dhcp_enabled = if xml.at_xpath('//network/ip/dhcp')
+                               true
+                             else
+                               false
+                             end
 
-            domain_name = xml.at_xpath('/network/domain/@name')
-            domain_name = domain_name.value if domain_name
+              domain_name = xml.at_xpath('/network/domain/@name')
+              domain_name = domain_name.value if domain_name
 
-            # Calculate network address of network from ip address and
-            # netmask.
-            network_address = (network_address(ip, netmask) if ip && netmask)
+              # Calculate network address of network from ip address and
+              # netmask.
+              network_address = (network_address(ip, netmask) if ip && netmask)
 
-            libvirt_networks << {
-              name:             libvirt_network.name,
-              ip_address:       ip,
-              netmask:          netmask,
-              network_address:  network_address,
-              dhcp_enabled:     dhcp_enabled,
-              bridge_name:      libvirt_network.bridge_name,
-              domain_name:      domain_name,
-              created:          true,
-              active:           libvirt_network.active?,
-              autostart:        libvirt_network.autostart?,
-              libvirt_network:  libvirt_network
-            }
+              libvirt_networks << {
+                name:             libvirt_network.name,
+                ip_address:       ip,
+                netmask:          netmask,
+                network_address:  network_address,
+                dhcp_enabled:     dhcp_enabled,
+                bridge_name:      libvirt_network.bridge_name,
+                domain_name:      domain_name,
+                created:          true,
+                active:           libvirt_network.active?,
+                autostart:        libvirt_network.autostart?,
+                libvirt_network:  libvirt_network
+              }
+            rescue => e
+              # Network may have been destroyed during loop iteration, continue on
+              next
           end
 
           libvirt_networks


### PR DESCRIPTION
On systems where we have multiple concurrent deployments and teardowns of virtual machines that overlap, there are occasions where setup can fail if teardown of another vagrant deployment is happening in parallel. Generally this is handled well, but the most common place of failure was in the network enumeration where details of all existing networks are collected prior to creating new ones.

Since a number of operations are done after `driver.list_all_networks` and in cases where the number of networks is relatively large, it was common for a network to be destroyed during the iterations of that loop and thus the XML lookup or queries for `bridge_name` etc would fail.

My change here is just to rescue any errors that occur in this loop and continue on. I understand this is a bit of a niche issue for us in the way vagrant-libvirt is used at scale, and this might mask other problems besides networks being cleaned up, but opening this PR anyway for thoughts.