### PR TITLE
Fix memory setting issue when starting domain

### DIFF
--- a/lib/vagrant-libvirt/action/start_domain.rb
+++ b/lib/vagrant-libvirt/action/start_domain.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
           if config.numa_nodes == nil
             if config.memory.to_i * 1024 != libvirt_domain.max_memory
               libvirt_domain.max_memory = config.memory.to_i * 1024
-              libvirt_domain.memory = libvirt_domain.max_memory
+              libvirt_domain.memory = libvirt_domain.max_memory, VagrantPlugins::ProviderLibvirt::Util::ModImpactFlags::VIR_DOMAIN_AFFECT_CONFIG
             end
           end
 

--- a/lib/vagrant-libvirt/util.rb
+++ b/lib/vagrant-libvirt/util.rb
@@ -10,6 +10,7 @@ module VagrantPlugins
       autoload :StorageUtil, 'vagrant-libvirt/util/storage_util'
       autoload :ErrorCodes, 'vagrant-libvirt/util/error_codes'
       autoload :DomainFlags, 'vagrant-libvirt/util/domain_flags'
+      autoload :ModImpactFlags, 'vagrant-libvirt/util/mod_impact_flags'
       autoload :Ui, 'vagrant-libvirt/util/ui'
     end
   end

--- a/lib/vagrant-libvirt/util/mod_impact_flags.rb
+++ b/lib/vagrant-libvirt/util/mod_impact_flags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Ripped from https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainModificationImpact
+module VagrantPlugins
+  module ProviderLibvirt
+    module Util
+      module ModImpactFlags
+        VIR_DOMAIN_AFFECT_CURRENT = 0 # affect current domain state
+        VIR_DOMAIN_AFFECT_LIVE = 1 # affect running domain state
+        VIR_DOMAIN_AFFECT_CONFIG = 2 # affect persistent domain state
+      end
+    end
+  end
+end


### PR DESCRIPTION
By passing a flag to libvirt's API to apply the memory size change to the domain's configuration file, the following issue was solved.

 -  fail to update the domain.memory on existing running vm 'Call to virDomainSetMemory failed' #1812 https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1812

The problem was caused by passing only memory size to #memory= method in start_domain.rb. Specifying a flag in addition to the memory size causes libvirt's API, virDomainSetMemoryFlags, to be called with that flag, explicitly choosing whether to apply the size setting to the running domain or the config file for that domain. The missing flag was causing the above issue by attempting to change the memory size of a running domain that did not exist.

Therefore, a list of possible flags is introduced, and a flag that make changes to the domain's configuration file is selected and used.

Below are links to some related documents.

 -  https://ruby.libvirt.org/api/Libvirt/Domain.html#method-i-memory-3D

 -  https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainSetMemoryFlags