### PR TITLE
Use jq to parse qemu-img json output

### DIFF
--- a/tools/create_box.sh
+++ b/tools/create_box.sh
@@ -89,12 +89,7 @@ fi
 
 cd "$TMP_DIR"
 
-#Using the awk int function here to truncate the virtual image size to an
-#integer since the fog-libvirt library does not seem to properly handle
-#floating point. Regex in awk function takes in account only "virtual-size"
-#value on the first level of JSON (since QEMU v8 there are multiple
-#"virtual-size"s in disk info).
-IMG_SIZE=$(qemu-img info --output=json "$TMP_IMG" | awk '/^\s{0,4}"virtual-size/{s=int($2)/(1024^3); print (s == int(s)) ? s : int(s)+1 }')
+IMG_SIZE=$(($(qemu-img info --output=json "$TMP_IMG" | jq '."virtual-size"') / 1024 ** 3))
 
 echo "{$IMG_SIZE}"
 


### PR DESCRIPTION
Using awk to parse json is not very resistant to changes in formatting of the json input. Using jq to parse the json output makes the create_box.sh script more stable to change in qemu-img output format.