### PR TITLE
Add VIR_DOMAIN_UNDEFINE_CHECKPOINTS_METADATA to undefine flags

### DIFF
--- a/lib/vagrant-libvirt/action/destroy_domain.rb
+++ b/lib/vagrant-libvirt/action/destroy_domain.rb
@@ -49,6 +49,7 @@ module VagrantPlugins
 
           undefine_flags = 0
           undefine_flags |= ProviderLibvirt::Util::DomainFlags::VIR_DOMAIN_UNDEFINE_KEEP_NVRAM if env[:machine].provider_config.nvram
+          undefine_flags |= ProviderLibvirt::Util::DomainFlags::VIR_DOMAIN_UNDEFINE_CHECKPOINTS_METADATA
 
           if env[:machine].provider_config.disks.empty? &&
              env[:machine].provider_config.cdroms.empty?


### PR DESCRIPTION
As described in #1785

Checkpoints are stored within the qcow image files (if supported by libvirt version), so there is no need to remove them like its done for the snapshots.