### PR TITLE
Support for VAGRANT_HOME in Docker/Podman

### DIFF
--- a/docs/installation.markdown
+++ b/docs/installation.markdown
@@ -84,7 +84,7 @@ Running the image:
 docker run -it --rm \
   -e LIBVIRT_DEFAULT_URI \
   -v /var/run/libvirt/:/var/run/libvirt/ \
-  -v ~/.vagrant.d:/.vagrant.d \
+  -v $(realpath ${VAGRANT_HOME:-~/.vagrant.d}):/.vagrant.d \
   -v $(realpath "${PWD}"):${PWD} \
   -w "${PWD}" \
   --network host \
@@ -98,7 +98,7 @@ vagrant(){
   docker run -it --rm \
     -e LIBVIRT_DEFAULT_URI \
     -v /var/run/libvirt/:/var/run/libvirt/ \
-    -v ~/.vagrant.d:/.vagrant.d \
+    -v $(realpath ${VAGRANT_HOME:-~/.vagrant.d}):/.vagrant.d \
     -v $(realpath "${PWD}"):${PWD} \
     -w "${PWD}" \
     --network host \
@@ -124,7 +124,7 @@ vagrant(){
   podman run -it --rm \
     -e LIBVIRT_DEFAULT_URI \
     -v /var/run/libvirt/:/var/run/libvirt/ \
-    -v ~/.vagrant.d:/.vagrant.d \
+    -v $(realpath ${VAGRANT_HOME:-~/.vagrant.d}):/.vagrant.d \
     -v $(realpath "${PWD}"):${PWD} \
     -w "${PWD}" \
     --network host \


### PR DESCRIPTION
If `VAGRANT_HOME` is set, it will be mounted instead of `~/.vagrant.d`

https://developer.hashicorp.com/vagrant/docs/other/environmental-variables#vagrant_home