### PR TITLE
Remove config unsupported by fog-libvirt

### DIFF
--- a/lib/vagrant-libvirt/driver.rb
+++ b/lib/vagrant-libvirt/driver.rb
@@ -32,14 +32,9 @@ module VagrantPlugins
         config = @machine.provider_config
         uri = config.uri
 
-        # Setup command for retrieving IP address for newly created machine
-        # with some MAC address. Get it from dnsmasq leases table
-        ip_command = %q( awk "/$mac/ {print \$1}" /proc/net/arp )
-
         conn_attr = {
           provider: 'libvirt',
           libvirt_uri: uri,
-          libvirt_ip_command: ip_command,
         }
         conn_attr[:libvirt_username] = config.username if config.username
         conn_attr[:libvirt_password] = config.password if config.password

--- a/vagrant-libvirt.gemspec
+++ b/vagrant-libvirt.gemspec
@@ -26,8 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'xml-simple'
   s.add_runtime_dependency 'diffy'
 
-  # Make sure to allow use of the same version as Vagrant by being less specific
-  s.add_runtime_dependency 'nokogiri', '~> 1.6'
+  s.add_runtime_dependency 'nokogiri', '< 1.16'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency "rspec-core", ">= 3.5"


### PR DESCRIPTION
fog-libvirt dropped support for libvirt < 1.2.8 in version v0.13.0 This config is no longer supported nor needed

This call generates a warning

Fixes #1831