### PR TITLE
:tada: Updated container image to vagrant 2.4.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG VAGRANT_VERSION=2.3.0
+ARG VAGRANT_VERSION=2.4.9
 
-
-FROM ubuntu:jammy as base
+FROM ubuntu:noble as base
 
 RUN apt update \
     && apt install -y --no-install-recommends \
@@ -38,10 +37,9 @@ FROM base as build
 
 # allow caching of packages for build
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN sed -i '/deb-src/s/^# //' /etc/apt/sources.list
+RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
 RUN apt update \
     && apt build-dep -y \
-        vagrant \
         ruby-libvirt \
     && apt install -y --no-install-recommends \
         libxslt-dev \
@@ -57,31 +55,12 @@ WORKDIR /build
 COPY . .
 RUN rake build
 
-RUN find /opt/vagrant/embedded/ -type f | grep -v /opt/vagrant/embedded/plugins.json > /files-to-delete.txt
-
-RUN /opt/vagrant/embedded/bin/gem install --install-dir /opt/vagrant/embedded/gems/${VAGRANT_VERSION} ./pkg/vagrant-libvirt*.gem
-
-RUN echo -n '{\n\
-    "version": "1",\n\
-    "installed": {\n\
-        "vagrant-libvirt": {\n\
-            "ruby_version": "'$(/opt/vagrant/embedded/bin/ruby -e 'puts "#{RUBY_VERSION}"')'",\n\
-            "vagrant_version": "'${VAGRANT_VERSION}'",\n\
-            "gem_version":"",\n\
-            "require":"",\n\
-            "sources":[]\n\
-        }\n\
-    }\n\
-}' > /opt/vagrant/embedded/plugins.json
-
-FROM build as pruned
-
-RUN cat /files-to-delete.txt | xargs rm -f
+# Install plugin using vagrant's plugin manager
+RUN vagrant plugin install ./pkg/vagrant-libvirt*.gem
 
 FROM base as slim
 
-COPY --from=pruned /opt/vagrant/embedded/gems /opt/vagrant/embedded/gems
-COPY --from=build /opt/vagrant/embedded/plugins.json /opt/vagrant/embedded/plugins.json
+COPY --from=build /.vagrant.d /.vagrant.d
 
 COPY entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax = docker/dockerfile:1.0-experimental
 ARG VAGRANT_VERSION=2.4.9
 
+
 FROM ubuntu:noble as base
 
 RUN apt update \
@@ -55,12 +56,17 @@ WORKDIR /build
 COPY . .
 RUN rake build
 
-# Install plugin using vagrant's plugin manager
-RUN vagrant plugin install ./pkg/vagrant-libvirt*.gem
+RUN mkdir -p /tmp/vagrant-home \
+    && VAGRANT_HOME=/tmp/vagrant-home vagrant plugin install ./pkg/vagrant-libvirt*.gem \
+    && mkdir -p /vagrant-libvirt-plugin \
+    && mv /tmp/vagrant-home/plugins.json /vagrant-libvirt-plugin/plugins.json \
+    && mv /tmp/vagrant-home/gems /vagrant-libvirt-plugin/gems \
+    && rm -rf /tmp/vagrant-home \
+    && cd / && rm -rf /build
 
 FROM base as slim
 
-COPY --from=build /.vagrant.d /.vagrant.d
+COPY --from=build /vagrant-libvirt-plugin /vagrant-libvirt-plugin
 
 COPY entrypoint.sh /usr/local/bin/
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,6 @@ exec 3>&1
 # redirect stdout to stderr by default
 exec 1>&2
 
-
 vdir="/.vagrant.d"
 
 if [[ ! -d ${vdir} ]]
@@ -15,17 +14,23 @@ then
     echo "Require the user ~/.vagrant.d to be bind mounted at ${vdir}"
     echo
     echo "Typically use '-v ~/.vagrant.d:${vdir}' with the docker run command."
-
     exit 2
+fi
+
+# Initialize plugin files if they don't exist
+if [[ ! -f ${vdir}/plugins.json ]] && [[ -f /vagrant-libvirt-plugin/plugins.json ]]
+then
+    cp /vagrant-libvirt-plugin/plugins.json ${vdir}/plugins.json
+fi
+
+if [[ ! -d ${vdir}/gems/$(/opt/vagrant/embedded/bin/ruby -e 'puts "#{RUBY_VERSION}"')/gems ]] && [[ -d /vagrant-libvirt-plugin/gems ]]
+then
+    cp -r /vagrant-libvirt-plugin/gems ${vdir}/
 fi
 
 vdir_mnt=$(stat -c %m ${vdir})
 case "${vdir_mnt%%/}" in
     /*)
-        # user mounted vagrant home is not mounted on /, so
-        # presumably it is a mount bind or mounted volume and should
-        # be able to persist boxes and machine index.
-        #
         ;;
     *)
         echo -n "${vdir} is not set to a bind mounted volume, may not be able "
@@ -34,90 +39,96 @@ case "${vdir_mnt%%/}" in
         ;;
 esac
 
-# To determine default user to use search for the Vagrantfile starting with
-# the current working directory. If it can't be found, use the owner/group
-# from the current working directory anyway
-vagrantfile="${VAGRANT_VAGRANTFILE:-Vagrantfile}"
-path="$(pwd)"
-while [[ "$path" != "" && ! -e "$path/$vagrantfile" ]]
-do
-    path=${path%/*}
-done
+# Detect if running in podman rootless mode
+CURRENT_UID=$(id -u)
+CURRENT_GID=$(id -g)
+PODMAN_ROOTLESS=0
 
-if [[ "$path" == "" ]]
+if [[ ${CURRENT_UID} -ne 0 ]] && [[ -n "${USER_UID:-}" ]] && [[ ${USER_UID} -eq ${CURRENT_UID} ]]
 then
-    path="$(pwd)"
+    PODMAN_ROOTLESS=1
 fi
 
-USER_UID=${USER_UID:-$(stat -c %u ${path})} || exit 3
-USER_GID=${USER_GID:-$(stat -c %g ${path})} || exit 3
-if [[ ${USER_UID} -eq 0 ]]
+if [[ ${PODMAN_ROOTLESS} -eq 0 ]]
 then
-    if [[ "${IGNORE_RUN_AS_ROOT:-0}" == "0" ]]
-    then
-        echo "ERROR! Running as root, this usually means there has been a mistake" \
-            "in how the image has been launched."
-        echo "If this is actually intended, please pass '-e IGNORE_RUN_AS_ROOT=1'" \
-            "via the docker run command to allow execution as root."
-        echo
-        echo "Used '${path}' to determine uid/gid, typically starting looking for the" \
-            "file '$(pwd)/Vagrantfile' or if there is a Vagrantfile in the parent directory" \
-            "otherwise fall back to owner/group of'$(pwd)'"
+    vagrantfile="${VAGRANT_VAGRANTFILE:-Vagrantfile}"
+    path="$(pwd)"
+    while [[ "$path" != "" && ! -e "$path/$vagrantfile" ]]
+    do
+        path=${path%/*}
+    done
 
-        exit 2
+    if [[ "$path" == "" ]]
+    then
+        path="$(pwd)"
     fi
-else
-    vdir_uid=$(stat -c %u ${vdir})
-    if [[ "${vdir_uid}" != "${USER_UID}" ]]
-    then
-        if [[ -z "$(ls -A ${vdir})" ]]
-        then
-            # vdir has just been created and is owned by the wrong user
-            # modify the ownership to allow the required directories to
-            # be created
-            chown ${USER_UID}:${USER_GID} ${vdir}
-        else
-            echo -n "ERROR: Attempting to use a directory on ${vdir} that is not "
-            echo -n "owned by the user that owns ${path}/${vagrantfile} is not "
-            echo "supported!"
 
+    USER_UID=${USER_UID:-$(stat -c %u ${path})} || exit 3
+    USER_GID=${USER_GID:-$(stat -c %g ${path})} || exit 3
+
+    if [[ ${USER_UID} -eq 0 ]]
+    then
+        if [[ "${IGNORE_RUN_AS_ROOT:-0}" == "0" ]]
+        then
+            echo "ERROR! Running as root, this usually means there has been a mistake in how the image has been launched."
+            echo "If this is actually intended, please pass '-e IGNORE_RUN_AS_ROOT=1' via the docker run command to allow execution as root."
+            echo
+            echo "Used '${path}' to determine uid/gid, typically starting looking for the file '$(pwd)/Vagrantfile' or if there is a Vagrantfile in the parent directory otherwise fall back to owner/group of'$(pwd)'"
             exit 2
         fi
-    fi
-fi
-
-export USER=vagrant
-export GROUP=users
-export HOME=/home/${USER}
-
-echo "Starting with UID: ${USER_UID}, GID: ${USER_GID}"
-if [[ "${USER_GID}" != "0" ]]
-then
-    if getent group ${GROUP} > /dev/null
-    then
-        GROUPCMD=groupmod
     else
-        GROUPCMD=groupadd
+        vdir_uid=$(stat -c %u ${vdir})
+        if [[ "${vdir_uid}" != "${USER_UID}" ]]
+        then
+            if [[ -z "$(ls -A ${vdir})" ]]
+            then
+                chown ${USER_UID}:${USER_GID} ${vdir}
+            else
+                echo -n "ERROR: Attempting to use a directory on ${vdir} that is not "
+                echo -n "owned by the user that owns ${path}/${vagrantfile} is not "
+                echo "supported!"
+                exit 2
+            fi
+        fi
     fi
-    ${GROUPCMD} -g ${USER_GID} ${GROUP} >/dev/null || exit 3
-fi
 
-if [[ "${USER_UID}" != "0" ]]
-then
-    if getent passwd ${USER} > /dev/null
+    export USER=vagrant
+    export GROUP=users
+    export HOME=/home/${USER}
+
+    echo "Starting with UID: ${USER_UID}, GID: ${USER_GID}"
+    if [[ "${USER_GID}" != "0" ]]
     then
-        USERCMD=usermod
-    else
-        USERCMD=useradd
+        if getent group ${GROUP} > /dev/null
+        then
+            GROUPCMD=groupmod
+        else
+            GROUPCMD=groupadd
+        fi
+        ${GROUPCMD} -g ${USER_GID} ${GROUP} >/dev/null || exit 3
     fi
-    ${USERCMD} --shell /bin/bash -u ${USER_UID} -g ${USER_GID} -o -c "" -m ${USER} >/dev/null 2>&1 || exit 3
-fi
 
-if [[ "${USER_UID}" != "0" ]]
-then
-    # make sure the directories can be written to by vagrant otherwise will
-    # get a start up error
-    find "${VAGRANT_HOME}" -maxdepth 1 ! -exec chown -h ${USER}:${GROUP} {} \+
+    if [[ "${USER_UID}" != "0" ]]
+    then
+        if getent passwd ${USER} > /dev/null
+        then
+            USERCMD=usermod
+        else
+            USERCMD=useradd
+        fi
+        ${USERCMD} --shell /bin/bash -u ${USER_UID} -g ${USER_GID} -o -c "" -m ${USER} >/dev/null 2>&1 || exit 3
+    fi
+
+    if [[ "${USER_UID}" != "0" ]]
+    then
+        find "${VAGRANT_HOME}" -maxdepth 1 ! -exec chown -h ${USER}:${GROUP} {} \+
+    fi
+else
+    USER_UID=${CURRENT_UID}
+    USER_GID=${CURRENT_GID}
+    export USER=${USER:-vagrant}
+    export GROUP=$(id -gn)
+    export HOME=${HOME:-/home/${USER}}
 fi
 
 LIBVIRT_SOCK=/var/run/libvirt/libvirt-sock
@@ -125,15 +136,13 @@ if [[ ! -S ${LIBVIRT_SOCK} ]]
 then
     if [[ -z "${IGNORE_MISSING_LIBVIRT_SOCK:-}" ]]
     then
-        echo "Unless you are using this to connect to a remote libvirtd it is"
-        echo "necessary to mount the libvirt socket in as ${LIBVIRT_SOCK}"
+        echo "Unless you are using this to connect to a remote libvirtd it is necessary to mount the libvirt socket in as ${LIBVIRT_SOCK}"
         echo
         echo "Set IGNORE_MISSING_LIBVIRT_SOCK to silence this warning"
     fi
 else
     LIBVIRT_GID=$(stat -c %g ${LIBVIRT_SOCK})
-    # only do this if the host uses a non-root group for libvirt
-    if [[ "${USER_UID}" != "0" ]] && [[ ${LIBVIRT_GID} -ne 0 ]]
+    if [[ "${USER_UID}" != "0" ]] && [[ ${LIBVIRT_GID} -ne 0 ]] && [[ ${PODMAN_ROOTLESS} -eq 0 ]]
     then
         if getent group libvirt >/dev/null
         then
@@ -142,15 +151,13 @@ else
             GROUPCMD=groupadd
         fi
         ${GROUPCMD} -g ${LIBVIRT_GID} libvirt >/dev/null || exit 3
-
         usermod -a -G libvirt ${USER} || exit 3
     fi
 fi
 
 if [[ $# -eq 0 ]]
 then
-    # if no command provided
-    if [[ "${USER_UID}" != "0" ]]
+    if [[ "${USER_UID}" != "0" ]] && [[ ${PODMAN_ROOTLESS} -eq 0 ]]
     then
         exec gosu ${USER} vagrant help >&3
     else
@@ -158,7 +165,7 @@ then
     fi
 fi
 
-if [[ "${USER_UID}" != "0" ]]
+if [[ "${USER_UID}" != "0" ]] && [[ ${PODMAN_ROOTLESS} -eq 0 ]]
 then
     exec gosu ${USER} "$@" >&3
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,9 @@ fi
 
 if [[ ${PODMAN_ROOTLESS} -eq 0 ]]
 then
+    # To determine default user to use search for the Vagrantfile starting with
+    # the current working directory. If it can't be found, use the owner/group
+    # from the current working directory anyway
     vagrantfile="${VAGRANT_VAGRANTFILE:-Vagrantfile}"
     path="$(pwd)"
     while [[ "$path" != "" && ! -e "$path/$vagrantfile" ]]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,10 @@ fi
 vdir_mnt=$(stat -c %m ${vdir})
 case "${vdir_mnt%%/}" in
     /*)
+        # user mounted vagrant home is not mounted on /, so
+        # presumably it is a mount bind or mounted volume and should
+        # be able to persist boxes and machine index.
+        #
         ;;
     *)
         echo -n "${vdir} is not set to a bind mounted volume, may not be able "
@@ -82,6 +86,9 @@ then
         then
             if [[ -z "$(ls -A ${vdir})" ]]
             then
+                # vdir has just been created and is owned by the wrong user
+                # modify the ownership to allow the required directories to
+                # be created
                 chown ${USER_UID}:${USER_GID} ${vdir}
             else
                 echo -n "ERROR: Attempting to use a directory on ${vdir} that is not "


### PR DESCRIPTION
This PR upgrades the version of vagrant to 2.4.9, version of ruby to 3.3.8, and ubuntu to 24.04 / noble.

### Additional changes
Added podman rootless support in the entrypoint.sh script, so the documentation's recommendation of using `--entrypoint=/bin/bash` should not apply anymore, instead it's best to use: 
```bash
podman run -it --rm \
                  --security-opt label=disable \
                  --user $(id -u):$(id -g) \
                  -e USER=$USER -e USER_UID=$(id -u) -e USER_GID=$(id -g) \
                  --userns=keep-id:uid=$(id -u),gid=$(id -g) \
                  -v /var/run/libvirt:/var/run/libvirt \
                  -v $VAGRANT_HOME:/.vagrant.d \
                  -v $(realpath "$PWD"):$PWD \
                  -w "$PWD" \
                  --network host \
                  vagrantlibvirt/vagrant-libvirt:latest vagrant status
```
This way the plugin's support for qemu's user session won't break.

This might be not the best solution, so I'm open for suggestions.
This should also fix: #1840 